### PR TITLE
feat: add Nearby Connections interface (WiFi Direct + BLE mesh)

### DIFF
--- a/rns-android/build.gradle.kts
+++ b/rns-android/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVersion")
 
     // Unit testing
     testImplementation("junit:junit:4.13.2")

--- a/rns-android/build.gradle.kts
+++ b/rns-android/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.work:work-runtime-ktx:2.9.0")
 
+    // Google Nearby Connections (WiFi Direct + BLE mesh)
+    implementation("com.google.android.gms:play-services-nearby:19.3.0")
+
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
 

--- a/rns-android/src/main/AndroidManifest.xml
+++ b/rns-android/src/main/AndroidManifest.xml
@@ -13,10 +13,15 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
-        android:maxSdkVersion="30" />
+        android:maxSdkVersion="32" />
 
     <!-- BLE hardware feature (not required; graceful degradation if unavailable) -->
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
+
+    <!-- Nearby Connections — WiFi transport -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
 
     <!-- Network permissions -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/rns-android/src/main/AndroidManifest.xml
+++ b/rns-android/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
     <!-- Nearby Connections — WiFi transport -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation" />
 
     <!-- Network permissions -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -276,7 +276,7 @@ class AndroidNearbyDriver(
         connectionsClient.stopAllEndpoints()
     }
 
-    override suspend fun send(
+    override fun send(
         endpointId: String,
         data: ByteArray,
     ) {
@@ -290,7 +290,7 @@ class AndroidNearbyDriver(
             }
     }
 
-    override suspend fun broadcast(data: ByteArray) {
+    override fun broadcast(data: ByteArray) {
         val endpoints = _connectedEndpoints.keys().toList()
         if (endpoints.isEmpty()) return
         connectionsClient.sendPayload(endpoints, Payload.fromBytes(data))
@@ -299,7 +299,7 @@ class AndroidNearbyDriver(
             }
     }
 
-    override suspend fun disconnect(endpointId: String) {
+    override fun disconnect(endpointId: String) {
         connectionsClient.disconnectFromEndpoint(endpointId)
         // onDisconnected callback handles _connectedEndpoints removal and connectionLost emission
     }

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -242,6 +242,7 @@ class AndroidNearbyDriver(
             .addOnFailureListener { e ->
                 Log.e(TAG, "Failed to start advertising", e)
                 isRunning = false
+                connectionsClient.stopDiscovery()
             }
     }
 
@@ -258,14 +259,15 @@ class AndroidNearbyDriver(
             .addOnFailureListener { e ->
                 Log.e(TAG, "Failed to start discovery", e)
                 isRunning = false
+                connectionsClient.stopAdvertising()
             }
     }
 
     override suspend fun stop() {
-        if (!isRunning) return
+        val wasRunning = isRunning
         isRunning = false
 
-        Log.i(TAG, "Stopping Nearby Connections")
+        Log.i(TAG, "Stopping Nearby Connections (wasRunning=$wasRunning)")
         connectionsClient.stopAdvertising()
         connectionsClient.stopDiscovery()
 
@@ -314,12 +316,10 @@ class AndroidNearbyDriver(
     }
 
     override fun shutdown() {
-        if (isRunning) {
-            isRunning = false
-            connectionsClient.stopAdvertising()
-            connectionsClient.stopDiscovery()
-            connectionsClient.stopAllEndpoints()
-        }
+        isRunning = false
+        connectionsClient.stopAdvertising()
+        connectionsClient.stopDiscovery()
+        connectionsClient.stopAllEndpoints()
         _connectedEndpoints.clear()
         _pendingConnections.clear()
         scope.cancel()

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -195,6 +195,10 @@ class AndroidNearbyDriver(
 
             override fun onEndpointLost(endpointId: String) {
                 Log.d(TAG, "Endpoint lost: $endpointId")
+                if (_pendingConnections.remove(endpointId) != null) {
+                    Log.d(TAG, "Cleared pending connection for lost endpoint $endpointId")
+                    _connectionLost.tryEmit(endpointId)
+                }
             }
         }
 

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -1,0 +1,286 @@
+package network.reticulum.android.nearby
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.nearby.Nearby
+import com.google.android.gms.nearby.connection.AdvertisingOptions
+import com.google.android.gms.nearby.connection.ConnectionInfo
+import com.google.android.gms.nearby.connection.ConnectionLifecycleCallback
+import com.google.android.gms.nearby.connection.ConnectionResolution
+import com.google.android.gms.nearby.connection.ConnectionsStatusCodes
+import com.google.android.gms.nearby.connection.DiscoveredEndpointInfo
+import com.google.android.gms.nearby.connection.DiscoveryOptions
+import com.google.android.gms.nearby.connection.EndpointDiscoveryCallback
+import com.google.android.gms.nearby.connection.Payload
+import com.google.android.gms.nearby.connection.PayloadCallback
+import com.google.android.gms.nearby.connection.PayloadTransferUpdate
+import com.google.android.gms.nearby.connection.Strategy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import network.reticulum.interfaces.nearby.ConnectedEndpoint
+import network.reticulum.interfaces.nearby.DiscoveredEndpoint
+import network.reticulum.interfaces.nearby.NearbyDriver
+import network.reticulum.interfaces.nearby.ReceivedData
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Android implementation of [NearbyDriver] wrapping Google Nearby Connections API.
+ *
+ * Uses P2P_CLUSTER strategy for mesh-compatible topology (vs P2P_STAR which forces hub-spoke).
+ * Auto-accepts all connections since Reticulum handles authentication at the protocol level.
+ *
+ * Deterministic tie-breaking on discovery: the NearbyInterface compares endpoint names and
+ * decides which side initiates. This driver exposes discovered endpoints for the interface
+ * to make that decision.
+ *
+ * @param context Android application context
+ * @param scope CoroutineScope for the driver's internal operations
+ */
+class AndroidNearbyDriver(
+    private val context: Context,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+) : NearbyDriver {
+    companion object {
+        private const val TAG = "Carina:Nearby:Driver"
+        const val SERVICE_ID = "network.reticulum.nearby"
+    }
+
+    private val connectionsClient by lazy { Nearby.getConnectionsClient(context) }
+
+    // Connected endpoints: endpointId -> endpointName
+    private val _connectedEndpoints = ConcurrentHashMap<String, String>()
+
+    // Pending connections: endpointId -> endpointName (initiated but not yet resolved)
+    private val _pendingConnections = ConcurrentHashMap<String, String>()
+
+    @Volatile
+    private var localEndpointName: String = ""
+
+    @Volatile
+    private var maxConnections: Int = 10
+
+    @Volatile
+    override var isRunning: Boolean = false
+        private set
+
+    override val connectedCount: Int get() = _connectedEndpoints.size
+
+    // ---- Event Flows ----
+
+    private val _discoveredEndpoints = MutableSharedFlow<DiscoveredEndpoint>(extraBufferCapacity = 64)
+    override val discoveredEndpoints: SharedFlow<DiscoveredEndpoint> = _discoveredEndpoints.asSharedFlow()
+
+    private val _connectedEndpointsFlow = MutableSharedFlow<ConnectedEndpoint>(extraBufferCapacity = 16)
+    override val connectedEndpoints: SharedFlow<ConnectedEndpoint> = _connectedEndpointsFlow.asSharedFlow()
+
+    private val _connectionLost = MutableSharedFlow<String>(extraBufferCapacity = 16)
+    override val connectionLost: SharedFlow<String> = _connectionLost.asSharedFlow()
+
+    private val _dataReceived = MutableSharedFlow<ReceivedData>(extraBufferCapacity = 256)
+    override val dataReceived: SharedFlow<ReceivedData> = _dataReceived.asSharedFlow()
+
+    // ---- Nearby Connections Callbacks ----
+
+    private val connectionLifecycleCallback =
+        object : ConnectionLifecycleCallback() {
+            override fun onConnectionInitiated(
+                endpointId: String,
+                info: ConnectionInfo,
+            ) {
+                Log.i(TAG, "Connection initiated from $endpointId (${info.endpointName})")
+                // Auto-accept: Reticulum handles authentication at the protocol layer
+                _pendingConnections[endpointId] = info.endpointName
+                connectionsClient.acceptConnection(endpointId, payloadCallback)
+            }
+
+            override fun onConnectionResult(
+                endpointId: String,
+                result: ConnectionResolution,
+            ) {
+                val name = _pendingConnections.remove(endpointId) ?: "unknown"
+                when (result.status.statusCode) {
+                    ConnectionsStatusCodes.STATUS_OK -> {
+                        Log.i(TAG, "Connected to $endpointId ($name)")
+                        _connectedEndpoints[endpointId] = name
+                        _connectedEndpointsFlow.tryEmit(ConnectedEndpoint(endpointId, name))
+                    }
+                    ConnectionsStatusCodes.STATUS_CONNECTION_REJECTED -> {
+                        Log.w(TAG, "Connection rejected by $endpointId")
+                    }
+                    ConnectionsStatusCodes.STATUS_ERROR -> {
+                        Log.e(TAG, "Connection error with $endpointId: ${result.status.statusMessage}")
+                        _connectionLost.tryEmit(endpointId)
+                    }
+                    else -> {
+                        Log.w(TAG, "Connection to $endpointId failed: ${result.status}")
+                        _connectionLost.tryEmit(endpointId)
+                    }
+                }
+            }
+
+            override fun onDisconnected(endpointId: String) {
+                Log.i(TAG, "Disconnected from $endpointId")
+                _connectedEndpoints.remove(endpointId)
+                _connectionLost.tryEmit(endpointId)
+            }
+        }
+
+    private val payloadCallback =
+        object : PayloadCallback() {
+            override fun onPayloadReceived(
+                endpointId: String,
+                payload: Payload,
+            ) {
+                if (payload.type == Payload.Type.BYTES) {
+                    payload.asBytes()?.let { data ->
+                        _dataReceived.tryEmit(ReceivedData(endpointId, data))
+                    }
+                }
+            }
+
+            override fun onPayloadTransferUpdate(
+                endpointId: String,
+                update: PayloadTransferUpdate,
+            ) {
+                // Only relevant for STREAM/FILE payloads; BYTES are atomic
+            }
+        }
+
+    private val endpointDiscoveryCallback =
+        object : EndpointDiscoveryCallback() {
+            override fun onEndpointFound(
+                endpointId: String,
+                info: DiscoveredEndpointInfo,
+            ) {
+                Log.i(TAG, "Discovered endpoint $endpointId (${info.endpointName})")
+
+                // Skip if already connected or at limit
+                if (_connectedEndpoints.containsKey(endpointId)) return
+                if (_connectedEndpoints.size >= maxConnections) {
+                    Log.d(TAG, "At max connections ($maxConnections), skipping $endpointId")
+                    return
+                }
+                if (_pendingConnections.containsKey(endpointId)) return
+
+                _discoveredEndpoints.tryEmit(DiscoveredEndpoint(endpointId, info.endpointName))
+
+                // Deterministic tie-breaking: lower name initiates to prevent dual-connect
+                if (localEndpointName < info.endpointName) {
+                    Log.d(TAG, "Initiating connection to $endpointId (our name < theirs)")
+                    _pendingConnections[endpointId] = info.endpointName
+                    connectionsClient
+                        .requestConnection(localEndpointName, endpointId, connectionLifecycleCallback)
+                        .addOnFailureListener { e ->
+                            Log.e(TAG, "Failed to request connection to $endpointId", e)
+                            _pendingConnections.remove(endpointId)
+                            _connectionLost.tryEmit(endpointId)
+                        }
+                } else {
+                    Log.d(TAG, "Waiting for $endpointId to initiate (their name < ours)")
+                }
+            }
+
+            override fun onEndpointLost(endpointId: String) {
+                Log.d(TAG, "Endpoint lost: $endpointId")
+            }
+        }
+
+    // ---- NearbyDriver Implementation ----
+
+    override suspend fun start(
+        endpointName: String,
+        maxConnections: Int,
+    ) {
+        if (isRunning) {
+            Log.w(TAG, "Already running, ignoring start()")
+            return
+        }
+
+        localEndpointName = endpointName
+        this.maxConnections = maxConnections.coerceIn(1, 10)
+        isRunning = true
+
+        Log.i(TAG, "Starting Nearby Connections (name=$localEndpointName, max=${this.maxConnections})")
+
+        startAdvertising()
+        startDiscovery()
+    }
+
+    private fun startAdvertising() {
+        val options =
+            AdvertisingOptions
+                .Builder()
+                .setStrategy(Strategy.P2P_CLUSTER)
+                .build()
+
+        connectionsClient
+            .startAdvertising(localEndpointName, SERVICE_ID, connectionLifecycleCallback, options)
+            .addOnSuccessListener { Log.i(TAG, "Advertising started") }
+            .addOnFailureListener { e -> Log.e(TAG, "Failed to start advertising", e) }
+    }
+
+    private fun startDiscovery() {
+        val options =
+            DiscoveryOptions
+                .Builder()
+                .setStrategy(Strategy.P2P_CLUSTER)
+                .build()
+
+        connectionsClient
+            .startDiscovery(SERVICE_ID, endpointDiscoveryCallback, options)
+            .addOnSuccessListener { Log.i(TAG, "Discovery started") }
+            .addOnFailureListener { e -> Log.e(TAG, "Failed to start discovery", e) }
+    }
+
+    override suspend fun stop() {
+        if (!isRunning) return
+        isRunning = false
+
+        Log.i(TAG, "Stopping Nearby Connections")
+        connectionsClient.stopAdvertising()
+        connectionsClient.stopDiscovery()
+        connectionsClient.stopAllEndpoints()
+        _connectedEndpoints.clear()
+        _pendingConnections.clear()
+    }
+
+    override suspend fun send(
+        endpointId: String,
+        data: ByteArray,
+    ) {
+        if (!_connectedEndpoints.containsKey(endpointId)) {
+            Log.w(TAG, "Cannot send to disconnected endpoint $endpointId")
+            return
+        }
+        connectionsClient.sendPayload(endpointId, Payload.fromBytes(data))
+    }
+
+    override suspend fun broadcast(data: ByteArray) {
+        val endpoints = _connectedEndpoints.keys().toList()
+        if (endpoints.isEmpty()) return
+        connectionsClient.sendPayload(endpoints, Payload.fromBytes(data))
+    }
+
+    override suspend fun disconnect(endpointId: String) {
+        connectionsClient.disconnectFromEndpoint(endpointId)
+        _connectedEndpoints.remove(endpointId)
+    }
+
+    override fun shutdown() {
+        if (isRunning) {
+            isRunning = false
+            connectionsClient.stopAdvertising()
+            connectionsClient.stopDiscovery()
+            connectionsClient.stopAllEndpoints()
+        }
+        _connectedEndpoints.clear()
+        _pendingConnections.clear()
+        scope.cancel()
+        Log.i(TAG, "Nearby driver shut down")
+    }
+}

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -174,8 +174,9 @@ class AndroidNearbyDriver(
                 if (_pendingConnections.containsKey(endpointId)) return
 
                 // Deterministic tie-breaking: lower name initiates to prevent dual-connect.
-                // On equal names, both sides initiate — Nearby Connections deduplicates
-                // the dual requestConnection and one side receives onConnectionInitiated.
+                // On equal names, both sides initiate — Nearby randomly fails one side's
+                // requestConnection (handled by addOnFailureListener), then the surviving
+                // request causes both devices to receive onConnectionInitiated.
                 val weInitiate = localEndpointName <= info.endpointName
                 _discoveredEndpoints.tryEmit(DiscoveredEndpoint(endpointId, info.endpointName, weInitiate))
 
@@ -274,6 +275,12 @@ class AndroidNearbyDriver(
         }
 
         connectionsClient.stopAllEndpoints()
+
+        // Emit connectionLost for pending connections so interface clears stale entries
+        for (endpointId in _pendingConnections.keys()) {
+            _connectionLost.tryEmit(endpointId)
+        }
+
         _connectedEndpoints.clear()
         _pendingConnections.clear()
     }

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -78,7 +78,7 @@ class AndroidNearbyDriver(
     private val _connectedEndpointsFlow = MutableSharedFlow<ConnectedEndpoint>(extraBufferCapacity = 16)
     override val connectedEndpoints: SharedFlow<ConnectedEndpoint> = _connectedEndpointsFlow.asSharedFlow()
 
-    private val _connectionLost = MutableSharedFlow<String>(extraBufferCapacity = 16)
+    private val _connectionLost = MutableSharedFlow<String>(extraBufferCapacity = 64)
     override val connectionLost: SharedFlow<String> = _connectionLost.asSharedFlow()
 
     private val _dataReceived = MutableSharedFlow<ReceivedData>(extraBufferCapacity = 256)
@@ -271,20 +271,15 @@ class AndroidNearbyDriver(
         connectionsClient.stopAdvertising()
         connectionsClient.stopDiscovery()
 
-        // Emit connectionLost for all active peers before clearing state
-        for (endpointId in _connectedEndpoints.keys()) {
-            _connectionLost.tryEmit(endpointId)
-        }
-
-        connectionsClient.stopAllEndpoints()
-
-        // Emit connectionLost for pending connections so interface clears stale entries
+        // Emit connectionLost for pending connections (won't get onDisconnected callbacks)
         for (endpointId in _pendingConnections.keys()) {
             _connectionLost.tryEmit(endpointId)
         }
-
-        _connectedEndpoints.clear()
         _pendingConnections.clear()
+
+        // stopAllEndpoints triggers onDisconnected for each connected endpoint,
+        // which emits connectionLost and clears _connectedEndpoints entries
+        connectionsClient.stopAllEndpoints()
     }
 
     override suspend fun send(

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -176,10 +176,9 @@ class AndroidNearbyDriver(
                 _discoveredEndpoints.tryEmit(DiscoveredEndpoint(endpointId, info.endpointName))
 
                 // Deterministic tie-breaking: lower name initiates to prevent dual-connect.
-                // On equal names, use endpointId as secondary tie-breaker.
-                val weInitiate = localEndpointName < info.endpointName ||
-                    (localEndpointName == info.endpointName && localEndpointName < endpointId)
-                if (weInitiate) {
+                // On equal names, both sides initiate — Nearby Connections deduplicates
+                // the dual requestConnection and one side receives onConnectionInitiated.
+                if (localEndpointName <= info.endpointName) {
                     Log.d(TAG, "Initiating connection to $endpointId (we initiate)")
                     _pendingConnections[endpointId] = info.endpointName
                     connectionsClient

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -202,7 +202,11 @@ class AndroidNearbyDriver(
         }
 
         localEndpointName = endpointName
-        this.maxConnections = maxConnections.coerceIn(1, 10)
+        val clamped = maxConnections.coerceIn(1, 10)
+        if (clamped != maxConnections) {
+            Log.w(TAG, "maxConnections clamped from $maxConnections to $clamped (driver limit: 1..10)")
+        }
+        this.maxConnections = clamped
         isRunning = true
 
         Log.i(TAG, "Starting Nearby Connections (name=$localEndpointName, max=${this.maxConnections})")
@@ -244,6 +248,12 @@ class AndroidNearbyDriver(
         Log.i(TAG, "Stopping Nearby Connections")
         connectionsClient.stopAdvertising()
         connectionsClient.stopDiscovery()
+
+        // Emit connectionLost for all active peers before clearing state
+        for (endpointId in _connectedEndpoints.keys()) {
+            _connectionLost.tryEmit(endpointId)
+        }
+
         connectionsClient.stopAllEndpoints()
         _connectedEndpoints.clear()
         _pendingConnections.clear()

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -116,6 +116,7 @@ class AndroidNearbyDriver(
                     }
                     ConnectionsStatusCodes.STATUS_CONNECTION_REJECTED -> {
                         Log.w(TAG, "Connection rejected by $endpointId")
+                        _connectionLost.tryEmit(endpointId)
                     }
                     ConnectionsStatusCodes.STATUS_ERROR -> {
                         Log.e(TAG, "Connection error with $endpointId: ${result.status.statusMessage}")
@@ -166,7 +167,7 @@ class AndroidNearbyDriver(
 
                 // Skip if already connected or at limit
                 if (_connectedEndpoints.containsKey(endpointId)) return
-                if (_connectedEndpoints.size >= maxConnections) {
+                if (_connectedEndpoints.size + _pendingConnections.size >= maxConnections) {
                     Log.d(TAG, "At max connections ($maxConnections), skipping $endpointId")
                     return
                 }

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -93,6 +93,11 @@ class AndroidNearbyDriver(
                 info: ConnectionInfo,
             ) {
                 Log.i(TAG, "Connection initiated from $endpointId (${info.endpointName})")
+                if (_connectedEndpoints.size + _pendingConnections.size >= maxConnections) {
+                    Log.w(TAG, "At max connections ($maxConnections), rejecting inbound $endpointId")
+                    connectionsClient.rejectConnection(endpointId)
+                    return
+                }
                 // Auto-accept: Reticulum handles authentication at the protocol layer
                 _pendingConnections[endpointId] = info.endpointName
                 connectionsClient.acceptConnection(endpointId, payloadCallback)

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -173,12 +173,13 @@ class AndroidNearbyDriver(
                 }
                 if (_pendingConnections.containsKey(endpointId)) return
 
-                _discoveredEndpoints.tryEmit(DiscoveredEndpoint(endpointId, info.endpointName))
-
                 // Deterministic tie-breaking: lower name initiates to prevent dual-connect.
                 // On equal names, both sides initiate — Nearby Connections deduplicates
                 // the dual requestConnection and one side receives onConnectionInitiated.
-                if (localEndpointName <= info.endpointName) {
+                val weInitiate = localEndpointName <= info.endpointName
+                _discoveredEndpoints.tryEmit(DiscoveredEndpoint(endpointId, info.endpointName, weInitiate))
+
+                if (weInitiate) {
                     Log.d(TAG, "Initiating connection to $endpointId (we initiate)")
                     _pendingConnections[endpointId] = info.endpointName
                     connectionsClient
@@ -237,7 +238,10 @@ class AndroidNearbyDriver(
         connectionsClient
             .startAdvertising(localEndpointName, SERVICE_ID, connectionLifecycleCallback, options)
             .addOnSuccessListener { Log.i(TAG, "Advertising started") }
-            .addOnFailureListener { e -> Log.e(TAG, "Failed to start advertising", e) }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "Failed to start advertising", e)
+                isRunning = false
+            }
     }
 
     private fun startDiscovery() {
@@ -250,7 +254,10 @@ class AndroidNearbyDriver(
         connectionsClient
             .startDiscovery(SERVICE_ID, endpointDiscoveryCallback, options)
             .addOnSuccessListener { Log.i(TAG, "Discovery started") }
-            .addOnFailureListener { e -> Log.e(TAG, "Failed to start discovery", e) }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "Failed to start discovery", e)
+                isRunning = false
+            }
     }
 
     override suspend fun stop() {
@@ -296,7 +303,7 @@ class AndroidNearbyDriver(
 
     override suspend fun disconnect(endpointId: String) {
         connectionsClient.disconnectFromEndpoint(endpointId)
-        _connectedEndpoints.remove(endpointId)
+        // Don't remove from _connectedEndpoints here — onDisconnected will handle it
     }
 
     override fun shutdown() {

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -169,9 +169,12 @@ class AndroidNearbyDriver(
 
                 _discoveredEndpoints.tryEmit(DiscoveredEndpoint(endpointId, info.endpointName))
 
-                // Deterministic tie-breaking: lower name initiates to prevent dual-connect
-                if (localEndpointName < info.endpointName) {
-                    Log.d(TAG, "Initiating connection to $endpointId (our name < theirs)")
+                // Deterministic tie-breaking: lower name initiates to prevent dual-connect.
+                // On equal names, use endpointId as secondary tie-breaker.
+                val weInitiate = localEndpointName < info.endpointName ||
+                    (localEndpointName == info.endpointName && localEndpointName < endpointId)
+                if (weInitiate) {
+                    Log.d(TAG, "Initiating connection to $endpointId (we initiate)")
                     _pendingConnections[endpointId] = info.endpointName
                     connectionsClient
                         .requestConnection(localEndpointName, endpointId, connectionLifecycleCallback)
@@ -268,12 +271,18 @@ class AndroidNearbyDriver(
             return
         }
         connectionsClient.sendPayload(endpointId, Payload.fromBytes(data))
+            .addOnFailureListener { e ->
+                Log.e(TAG, "sendPayload to $endpointId failed: ${e.message}")
+            }
     }
 
     override suspend fun broadcast(data: ByteArray) {
         val endpoints = _connectedEndpoints.keys().toList()
         if (endpoints.isEmpty()) return
         connectionsClient.sendPayload(endpoints, Payload.fromBytes(data))
+            .addOnFailureListener { e ->
+                Log.e(TAG, "broadcast sendPayload failed: ${e.message}")
+            }
     }
 
     override suspend fun disconnect(endpointId: String) {

--- a/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/nearby/AndroidNearbyDriver.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.tasks.await
 import network.reticulum.interfaces.nearby.ConnectedEndpoint
 import network.reticulum.interfaces.nearby.DiscoveredEndpoint
 import network.reticulum.interfaces.nearby.NearbyDriver
@@ -34,9 +35,8 @@ import java.util.concurrent.ConcurrentHashMap
  * Uses P2P_CLUSTER strategy for mesh-compatible topology (vs P2P_STAR which forces hub-spoke).
  * Auto-accepts all connections since Reticulum handles authentication at the protocol level.
  *
- * Deterministic tie-breaking on discovery: the NearbyInterface compares endpoint names and
- * decides which side initiates. This driver exposes discovered endpoints for the interface
- * to make that decision.
+ * The driver is the single source of truth for all connection state — tie-breaking, connection
+ * limits, and pending/connected tracking. The interface layer reacts to driver events only.
  *
  * @param context Android application context
  * @param scope CoroutineScope for the driver's internal operations
@@ -206,6 +206,10 @@ class AndroidNearbyDriver(
 
     // ---- NearbyDriver Implementation ----
 
+    /**
+     * Start advertising and discovery. Suspends until both are confirmed started.
+     * Throws on failure so the caller can set online=false.
+     */
     override suspend fun start(
         endpointName: String,
         maxConnections: Int,
@@ -221,53 +225,43 @@ class AndroidNearbyDriver(
             Log.w(TAG, "maxConnections clamped from $maxConnections to $clamped (driver limit: 1..10)")
         }
         this.maxConnections = clamped
-        isRunning = true
 
         Log.i(TAG, "Starting Nearby Connections (name=$localEndpointName, max=${this.maxConnections})")
 
-        startAdvertising()
-        startDiscovery()
-    }
-
-    private fun startAdvertising() {
-        val options =
-            AdvertisingOptions
-                .Builder()
+        try {
+            val advOptions = AdvertisingOptions.Builder()
                 .setStrategy(Strategy.P2P_CLUSTER)
                 .build()
+            connectionsClient
+                .startAdvertising(localEndpointName, SERVICE_ID, connectionLifecycleCallback, advOptions)
+                .await()
+            Log.i(TAG, "Advertising started")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start advertising", e)
+            throw e
+        }
 
-        connectionsClient
-            .startAdvertising(localEndpointName, SERVICE_ID, connectionLifecycleCallback, options)
-            .addOnSuccessListener { Log.i(TAG, "Advertising started") }
-            .addOnFailureListener { e ->
-                Log.e(TAG, "Failed to start advertising", e)
-                isRunning = false
-                connectionsClient.stopDiscovery()
-            }
-    }
-
-    private fun startDiscovery() {
-        val options =
-            DiscoveryOptions
-                .Builder()
+        try {
+            val discOptions = DiscoveryOptions.Builder()
                 .setStrategy(Strategy.P2P_CLUSTER)
                 .build()
+            connectionsClient
+                .startDiscovery(SERVICE_ID, endpointDiscoveryCallback, discOptions)
+                .await()
+            Log.i(TAG, "Discovery started")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start discovery, stopping advertising", e)
+            connectionsClient.stopAdvertising()
+            throw e
+        }
 
-        connectionsClient
-            .startDiscovery(SERVICE_ID, endpointDiscoveryCallback, options)
-            .addOnSuccessListener { Log.i(TAG, "Discovery started") }
-            .addOnFailureListener { e ->
-                Log.e(TAG, "Failed to start discovery", e)
-                isRunning = false
-                connectionsClient.stopAdvertising()
-            }
+        isRunning = true
     }
 
     override suspend fun stop() {
-        val wasRunning = isRunning
         isRunning = false
 
-        Log.i(TAG, "Stopping Nearby Connections (wasRunning=$wasRunning)")
+        Log.i(TAG, "Stopping Nearby Connections")
         connectionsClient.stopAdvertising()
         connectionsClient.stopDiscovery()
 
@@ -278,7 +272,7 @@ class AndroidNearbyDriver(
         _pendingConnections.clear()
 
         // stopAllEndpoints triggers onDisconnected for each connected endpoint,
-        // which emits connectionLost and clears _connectedEndpoints entries
+        // which emits connectionLost and removes from _connectedEndpoints
         connectionsClient.stopAllEndpoints()
     }
 
@@ -307,7 +301,7 @@ class AndroidNearbyDriver(
 
     override suspend fun disconnect(endpointId: String) {
         connectionsClient.disconnectFromEndpoint(endpointId)
-        // Don't remove from _connectedEndpoints here — onDisconnected will handle it
+        // onDisconnected callback handles _connectedEndpoints removal and connectionLost emission
     }
 
     override fun shutdown() {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyDriver.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyDriver.kt
@@ -103,6 +103,8 @@ interface NearbyDriver {
 data class DiscoveredEndpoint(
     val endpointId: String,
     val endpointName: String,
+    /** Whether the driver initiated a connection to this endpoint. */
+    val weInitiate: Boolean = false,
 )
 
 /** An endpoint that has successfully connected. */

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyDriver.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyDriver.kt
@@ -1,0 +1,130 @@
+package network.reticulum.interfaces.nearby
+
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Abstraction interface for Google Nearby Connections operations.
+ *
+ * This defines the contract between pure-JVM protocol logic (in rns-interfaces)
+ * and platform-specific Nearby Connections implementation (AndroidNearbyDriver in rns-android).
+ *
+ * Unlike [network.reticulum.interfaces.ble.BLEDriver], there is no fragmentation, MTU
+ * negotiation, or identity handshake at the transport level — Nearby Connections handles
+ * transport internally with BYTES payloads (up to 32KB, well above Reticulum's ~16KB max).
+ *
+ * Connection management uses deterministic tie-breaking: the peer with the lexicographically
+ * lower endpoint name initiates the connection to prevent both sides connecting simultaneously.
+ *
+ * Thread safety: Implementations must be safe to call from any coroutine context.
+ */
+interface NearbyDriver {
+    // ---- Lifecycle ----
+
+    /**
+     * Start advertising and discovery simultaneously.
+     *
+     * @param endpointName Local endpoint name for tie-breaking (e.g., RNS identity hash prefix)
+     * @param maxConnections Maximum simultaneous connections to maintain
+     */
+    suspend fun start(
+        endpointName: String,
+        maxConnections: Int,
+    )
+
+    /**
+     * Stop advertising and discovery, disconnect all endpoints.
+     */
+    suspend fun stop()
+
+    /**
+     * Send data to a specific connected endpoint.
+     *
+     * @param endpointId Target endpoint identifier
+     * @param data Bytes to send (max 32KB for BYTES payload)
+     */
+    suspend fun send(
+        endpointId: String,
+        data: ByteArray,
+    )
+
+    /**
+     * Broadcast data to all connected endpoints.
+     *
+     * @param data Bytes to broadcast
+     */
+    suspend fun broadcast(data: ByteArray)
+
+    /**
+     * Disconnect a specific endpoint.
+     */
+    suspend fun disconnect(endpointId: String)
+
+    /**
+     * Full shutdown — stop and release all resources.
+     * After shutdown, the driver cannot be reused.
+     */
+    fun shutdown()
+
+    // ---- Event Flows ----
+
+    /**
+     * Flow of discovered endpoints from Nearby Connections discovery.
+     * Emitted when a new endpoint is found. The NearbyInterface uses the endpoint name
+     * for deterministic tie-breaking to decide which side initiates the connection.
+     */
+    val discoveredEndpoints: SharedFlow<DiscoveredEndpoint>
+
+    /**
+     * Flow of successfully connected endpoints.
+     * Emitted after connection negotiation completes (auto-accepted).
+     */
+    val connectedEndpoints: SharedFlow<ConnectedEndpoint>
+
+    /**
+     * Flow of endpoint IDs for connections that have been lost.
+     */
+    val connectionLost: SharedFlow<String>
+
+    /**
+     * Flow of data received from connected endpoints.
+     */
+    val dataReceived: SharedFlow<ReceivedData>
+
+    // ---- State ----
+
+    /** Whether the driver is currently running (advertising + discovering). */
+    val isRunning: Boolean
+
+    /** Number of currently connected endpoints. */
+    val connectedCount: Int
+}
+
+/** A nearby endpoint discovered via Nearby Connections. */
+data class DiscoveredEndpoint(
+    val endpointId: String,
+    val endpointName: String,
+)
+
+/** An endpoint that has successfully connected. */
+data class ConnectedEndpoint(
+    val endpointId: String,
+    val endpointName: String,
+)
+
+/** Data received from a connected endpoint. */
+data class ReceivedData(
+    val endpointId: String,
+    val data: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ReceivedData) return false
+        return endpointId == other.endpointId && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int {
+        var result = endpointId.hashCode()
+        result = 31 * result + data.contentHashCode()
+        return result
+    }
+}

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyDriver.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyDriver.kt
@@ -42,7 +42,7 @@ interface NearbyDriver {
      * @param endpointId Target endpoint identifier
      * @param data Bytes to send (max 32KB for BYTES payload)
      */
-    suspend fun send(
+    fun send(
         endpointId: String,
         data: ByteArray,
     )
@@ -52,12 +52,12 @@ interface NearbyDriver {
      *
      * @param data Bytes to broadcast
      */
-    suspend fun broadcast(data: ByteArray)
+    fun broadcast(data: ByteArray)
 
     /**
      * Disconnect a specific endpoint.
      */
-    suspend fun disconnect(endpointId: String)
+    fun disconnect(endpointId: String)
 
     /**
      * Full shutdown — stop and release all resources.

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -134,7 +134,7 @@ class NearbyInterface(
                 // Skip if already connected or pending
                 if (peers.containsKey(endpoint.endpointId)) return@collect
                 if (pendingConnections.contains(endpoint.endpointId)) return@collect
-                if (peers.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) return@collect
+                if (peers.size + pendingConnections.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) return@collect
 
                 // Use the driver's tie-breaking decision to track pending state
                 if (endpoint.weInitiate) {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -80,6 +80,8 @@ class NearbyInterface(
                 driver.start(localEndpointName, maxConnections)
                 online.set(true)
                 log("Advertising and discovery started (name=$localEndpointName)")
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 online.set(false)
                 log("Failed to start: ${e.message}")

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -99,11 +99,13 @@ class NearbyInterface(
         online.set(false)
         log("Detaching — shutting down all peers and driver")
 
-        // Detach all peer interfaces
+        // Tear down all peer interfaces directly (don't call peer.detach() which
+        // would re-enter peerDisconnected and double-deregister from Transport)
         for ((_, peer) in peers) {
+            peer.online.set(false)
+            peer.detached.set(true)
             try {
                 Transport.deregisterInterface(peer.toRef())
-                peer.detach()
             } catch (_: Exception) {
             }
         }
@@ -135,10 +137,8 @@ class NearbyInterface(
                 if (peers.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) return@collect
 
                 // Deterministic tie-breaking: lower name initiates.
-                // On equal names, use endpointId as secondary tie-breaker.
-                val weInitiate = localEndpointName < endpoint.endpointName ||
-                    (localEndpointName == endpoint.endpointName && localEndpointName < endpoint.endpointId)
-                if (weInitiate) {
+                // On equal names, both sides initiate — Nearby Connections deduplicates.
+                if (localEndpointName <= endpoint.endpointName) {
                     log(
                         "Initiating connection to ${endpoint.endpointId} " +
                             "(our name=$localEndpointName, theirs=${endpoint.endpointName})",

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -65,14 +65,15 @@ class NearbyInterface(
     // ---- Lifecycle ----
 
     override fun start() {
-        online.set(true)
         log("start() called — launching Nearby Connections coroutines")
 
         scope.launch {
             try {
                 driver.start(localEndpointName, maxConnections)
+                online.set(true)
                 log("Advertising and discovery started (name=$localEndpointName)")
             } catch (e: Exception) {
+                online.set(false)
                 log("Failed to start: ${e.message}")
             }
         }
@@ -131,13 +132,16 @@ class NearbyInterface(
                 // Skip if already connected or pending
                 if (peers.containsKey(endpoint.endpointId)) return@collect
                 if (pendingConnections.contains(endpoint.endpointId)) return@collect
-                if (peers.size >= maxConnections) return@collect
+                if (peers.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) return@collect
 
-                // Deterministic tie-breaking: lower name initiates
-                if (localEndpointName < endpoint.endpointName) {
+                // Deterministic tie-breaking: lower name initiates.
+                // On equal names, use endpointId as secondary tie-breaker.
+                val weInitiate = localEndpointName < endpoint.endpointName ||
+                    (localEndpointName == endpoint.endpointName && localEndpointName < endpoint.endpointId)
+                if (weInitiate) {
                     log(
                         "Initiating connection to ${endpoint.endpointId} " +
-                            "(our name < theirs: $localEndpointName < ${endpoint.endpointName})",
+                            "(our name=$localEndpointName, theirs=${endpoint.endpointName})",
                     )
                     pendingConnections.add(endpoint.endpointId)
                     // Driver handles the actual requestConnection call internally
@@ -145,7 +149,7 @@ class NearbyInterface(
                 } else {
                     log(
                         "Waiting for ${endpoint.endpointId} to initiate " +
-                            "(their name < ours: ${endpoint.endpointName} < $localEndpointName)",
+                            "(our name=$localEndpointName, theirs=${endpoint.endpointName})",
                     )
                 }
             }

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.launch
 import network.reticulum.interfaces.Interface
 import network.reticulum.interfaces.toRef
 import network.reticulum.transport.Transport
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Nearby Connections mesh interface for Reticulum networking.
@@ -59,13 +61,16 @@ class NearbyInterface(
     // endpointId -> NearbyPeerInterface
     private val peers = ConcurrentHashMap<String, NearbyPeerInterface>()
 
+    private val started = AtomicBoolean(false)
+
     init {
-        spawnedInterfaces = mutableListOf()
+        spawnedInterfaces = Collections.synchronizedList(mutableListOf())
     }
 
     // ---- Lifecycle ----
 
     override fun start() {
+        if (started.getAndSet(true)) return
         log("start() called — launching Nearby Connections coroutines")
 
         scope.launch {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -1,0 +1,287 @@
+package network.reticulum.interfaces.nearby
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import network.reticulum.interfaces.Interface
+import network.reticulum.interfaces.toRef
+import network.reticulum.transport.Transport
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Nearby Connections mesh interface for Reticulum networking.
+ *
+ * Server-style parent interface (like [network.reticulum.interfaces.ble.BLEInterface])
+ * that orchestrates discovery, connection, and peer management via Google Nearby
+ * Connections (WiFi Direct + BLE). Spawns [NearbyPeerInterface] children for each
+ * connected endpoint and registers them with Transport.
+ *
+ * Key differences from BLEInterface:
+ * - No fragmentation: Nearby BYTES payloads handle up to 32KB (Reticulum max ~16KB)
+ * - No keepalive: Nearby Connections manages connection health internally
+ * - No identity handshake: endpoint names carry RNS identity hash prefix for tie-breaking
+ * - No RSSI/MTU negotiation: Nearby Connections handles bandwidth upgrades automatically
+ *
+ * Architecture:
+ * - Dual-role: advertises and discovers simultaneously via P2P_CLUSTER strategy
+ * - Deterministic tie-breaking: lower endpoint name initiates connection (prevents dual-connect)
+ * - processOutgoing() is a no-op — Transport calls each NearbyPeerInterface directly
+ *
+ * @param name Human-readable interface name
+ * @param driver NearbyDriver implementation (platform-specific)
+ * @param localEndpointName Local name for tie-breaking (RNS identity hash prefix)
+ * @param maxConnections Maximum simultaneous peer connections (default 10)
+ */
+class NearbyInterface(
+    name: String,
+    private val driver: NearbyDriver,
+    private val localEndpointName: String,
+    private val maxConnections: Int = DEFAULT_MAX_CONNECTIONS,
+) : Interface(name) {
+    companion object {
+        const val DEFAULT_MAX_CONNECTIONS = 10
+        const val BITRATE_ESTIMATE = 2_000_000 // WiFi Direct: ~2 Mbps effective
+    }
+
+    override val bitrate: Int = BITRATE_ESTIMATE
+    override val canReceive: Boolean = true
+    override val canSend: Boolean = true
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // endpointId -> NearbyPeerInterface
+    private val peers = ConcurrentHashMap<String, NearbyPeerInterface>()
+
+    // Endpoints we've already initiated connection to (prevents duplicate requests)
+    private val pendingConnections = ConcurrentHashMap.newKeySet<String>()
+
+    init {
+        spawnedInterfaces = mutableListOf()
+    }
+
+    // ---- Lifecycle ----
+
+    override fun start() {
+        online.set(true)
+        log("start() called — launching Nearby Connections coroutines")
+
+        scope.launch {
+            try {
+                driver.start(localEndpointName, maxConnections)
+                log("Advertising and discovery started (name=$localEndpointName)")
+            } catch (e: Exception) {
+                log("Failed to start: ${e.message}")
+            }
+        }
+
+        // Event collection coroutines
+        scope.launch { collectDiscoveredEndpoints() }
+        scope.launch { collectConnectedEndpoints() }
+        scope.launch { collectConnectionLost() }
+        scope.launch { collectDataReceived() }
+    }
+
+    /**
+     * No-op for server-style parent interface.
+     *
+     * Transport calls each spawned [NearbyPeerInterface]'s processOutgoing() directly.
+     */
+    override fun processOutgoing(data: ByteArray) {
+        // No-op: server-style parent
+    }
+
+    override fun detach() {
+        if (detached.getAndSet(true)) return
+        online.set(false)
+        log("Detaching — shutting down all peers and driver")
+
+        // Detach all peer interfaces
+        for ((_, peer) in peers) {
+            try {
+                Transport.deregisterInterface(peer.toRef())
+                peer.detach()
+            } catch (_: Exception) {
+            }
+        }
+        peers.clear()
+        spawnedInterfaces?.clear()
+        pendingConnections.clear()
+
+        // Shutdown driver and cancel scope
+        driver.shutdown()
+        scope.cancel()
+
+        log("Detached")
+    }
+
+    // ---- Event Collection ----
+
+    /**
+     * Handle discovered endpoints with deterministic tie-breaking.
+     * The peer with the lexicographically lower endpoint name initiates the connection.
+     */
+    private suspend fun collectDiscoveredEndpoints() {
+        try {
+            driver.discoveredEndpoints.collect { endpoint ->
+                if (!online.get() || detached.get()) return@collect
+
+                // Skip if already connected or pending
+                if (peers.containsKey(endpoint.endpointId)) return@collect
+                if (pendingConnections.contains(endpoint.endpointId)) return@collect
+                if (peers.size >= maxConnections) return@collect
+
+                // Deterministic tie-breaking: lower name initiates
+                if (localEndpointName < endpoint.endpointName) {
+                    log(
+                        "Initiating connection to ${endpoint.endpointId} " +
+                            "(our name < theirs: $localEndpointName < ${endpoint.endpointName})",
+                    )
+                    pendingConnections.add(endpoint.endpointId)
+                    // Driver handles the actual requestConnection call internally
+                    // The result comes via connectedEndpoints or connectionLost
+                } else {
+                    log(
+                        "Waiting for ${endpoint.endpointId} to initiate " +
+                            "(their name < ours: ${endpoint.endpointName} < $localEndpointName)",
+                    )
+                }
+            }
+        } catch (_: CancellationException) {
+            // Normal shutdown
+        } catch (e: Exception) {
+            log("Error collecting discovered endpoints: ${e.message}")
+        }
+    }
+
+    /**
+     * Spawn a [NearbyPeerInterface] for each successfully connected endpoint.
+     */
+    private suspend fun collectConnectedEndpoints() {
+        try {
+            driver.connectedEndpoints.collect { endpoint ->
+                if (!online.get() || detached.get()) return@collect
+
+                pendingConnections.remove(endpoint.endpointId)
+
+                // Skip if already have a peer for this endpoint
+                if (peers.containsKey(endpoint.endpointId)) return@collect
+
+                spawnPeerInterface(endpoint.endpointId, endpoint.endpointName)
+            }
+        } catch (_: CancellationException) {
+            // Normal shutdown
+        } catch (e: Exception) {
+            log("Error collecting connected endpoints: ${e.message}")
+        }
+    }
+
+    /**
+     * Tear down peer interface when an endpoint disconnects.
+     */
+    private suspend fun collectConnectionLost() {
+        try {
+            driver.connectionLost.collect { endpointId ->
+                pendingConnections.remove(endpointId)
+                tearDownPeer(endpointId)
+            }
+        } catch (_: CancellationException) {
+            // Normal shutdown
+        } catch (e: Exception) {
+            log("Error collecting connection lost: ${e.message}")
+        }
+    }
+
+    /**
+     * Route incoming data to the correct [NearbyPeerInterface].
+     */
+    private suspend fun collectDataReceived() {
+        try {
+            driver.dataReceived.collect { received ->
+                if (!online.get() || detached.get()) return@collect
+
+                val peer = peers[received.endpointId]
+                if (peer != null) {
+                    peer.deliverIncoming(received.data)
+                } else {
+                    log("Data from unknown endpoint ${received.endpointId}, ignoring")
+                }
+            }
+        } catch (_: CancellationException) {
+            // Normal shutdown
+        } catch (e: Exception) {
+            log("Error collecting received data: ${e.message}")
+        }
+    }
+
+    // ---- Peer Management ----
+
+    private fun spawnPeerInterface(
+        endpointId: String,
+        endpointName: String,
+    ) {
+        val peerName = "Nearby|${endpointId.take(8)}"
+        val peer =
+            NearbyPeerInterface(
+                name = peerName,
+                endpointId = endpointId,
+                parentNearbyInterface = this,
+                driver = driver,
+            )
+
+        peers[endpointId] = peer
+        spawnedInterfaces?.add(peer)
+
+        // Set up packet callback and register with Transport
+        peer.onPacketReceived = { data, fromInterface ->
+            Transport.inbound(data, fromInterface.toRef())
+        }
+        peer.start()
+        Transport.registerInterface(peer.toRef())
+
+        log("Spawned peer interface: $peerName ($endpointName), total=${peers.size}")
+    }
+
+    private fun tearDownPeer(endpointId: String) {
+        val peer = peers.remove(endpointId) ?: return
+        spawnedInterfaces?.remove(peer)
+
+        try {
+            Transport.deregisterInterface(peer.toRef())
+        } catch (_: Exception) {
+        }
+
+        // Only detach if not already detached (avoids recursive peerDisconnected call)
+        if (!peer.detached.get()) {
+            peer.online.set(false)
+            peer.detached.set(true)
+        }
+
+        log("Tore down peer: ${peer.name}, total=${peers.size}")
+    }
+
+    /**
+     * Called by [NearbyPeerInterface.detach] to notify parent of disconnection.
+     */
+    internal fun peerDisconnected(peer: NearbyPeerInterface) {
+        peers.remove(peer.endpointId)
+        spawnedInterfaces?.remove(peer)
+        try {
+            Transport.deregisterInterface(peer.toRef())
+        } catch (_: Exception) {
+        }
+
+        log("Peer disconnected: ${peer.name}, total=${peers.size}")
+    }
+
+    /** Get the number of currently connected peers. */
+    fun getConnectedCount(): Int = peers.size
+
+    private fun log(message: String) {
+        println("[NearbyInterface][$name] $message")
+    }
+
+    override fun toString(): String = "NearbyInterface[$name] (${peers.size} peers)"
+}

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -136,9 +136,8 @@ class NearbyInterface(
                 if (pendingConnections.contains(endpoint.endpointId)) return@collect
                 if (peers.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) return@collect
 
-                // Deterministic tie-breaking: lower name initiates.
-                // On equal names, both sides initiate — Nearby Connections deduplicates.
-                if (localEndpointName <= endpoint.endpointName) {
+                // Use the driver's tie-breaking decision to track pending state
+                if (endpoint.weInitiate) {
                     log(
                         "Initiating connection to ${endpoint.endpointId} " +
                             "(our name=$localEndpointName, theirs=${endpoint.endpointName})",

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -159,7 +159,7 @@ class NearbyInterface(
                 // Enforce cap — disconnect surplus endpoints the driver accepted
                 if (peers.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) {
                     log("At max peers, disconnecting surplus endpoint ${endpoint.endpointId}")
-                    scope.launch { driver.disconnect(endpoint.endpointId) }
+                    driver.disconnect(endpoint.endpointId)
                     return@collect
                 }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -70,8 +70,16 @@ class NearbyInterface(
         scope.launch {
             try {
                 driver.start(localEndpointName, maxConnections)
-                online.set(true)
-                log("Advertising and discovery started (name=$localEndpointName)")
+                // driver.start() returns immediately; async Tasks may still fail.
+                // Brief delay then check driver.isRunning to catch early failures.
+                kotlinx.coroutines.delay(1000)
+                if (driver.isRunning) {
+                    online.set(true)
+                    log("Advertising and discovery started (name=$localEndpointName)")
+                } else {
+                    online.set(false)
+                    log("Driver failed to start (isRunning=false after start)")
+                }
             } catch (e: Exception) {
                 online.set(false)
                 log("Failed to start: ${e.message}")
@@ -171,6 +179,13 @@ class NearbyInterface(
 
                 // Skip if already have a peer for this endpoint
                 if (peers.containsKey(endpoint.endpointId)) return@collect
+
+                // Enforce cap — disconnect surplus endpoints the driver accepted
+                if (peers.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) {
+                    log("At max peers, disconnecting surplus endpoint ${endpoint.endpointId}")
+                    scope.launch { driver.disconnect(endpoint.endpointId) }
+                    return@collect
+                }
 
                 spawnPeerInterface(endpoint.endpointId, endpoint.endpointName)
             }

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -15,9 +15,14 @@ import java.util.concurrent.ConcurrentHashMap
  * Nearby Connections mesh interface for Reticulum networking.
  *
  * Server-style parent interface (like [network.reticulum.interfaces.ble.BLEInterface])
- * that orchestrates discovery, connection, and peer management via Google Nearby
- * Connections (WiFi Direct + BLE). Spawns [NearbyPeerInterface] children for each
- * connected endpoint and registers them with Transport.
+ * that orchestrates peer management via Google Nearby Connections (WiFi Direct + BLE).
+ * Spawns [NearbyPeerInterface] children for each connected endpoint and registers them
+ * with Transport.
+ *
+ * The driver ([NearbyDriver]) is the single source of truth for connection state —
+ * tie-breaking, connection limits, and pending tracking all live in the driver. This
+ * interface only reacts to driver events: spawning peers on [NearbyDriver.connectedEndpoints],
+ * tearing them down on [NearbyDriver.connectionLost], and routing data.
  *
  * Key differences from BLEInterface:
  * - No fragmentation: Nearby BYTES payloads handle up to 32KB (Reticulum max ~16KB)
@@ -27,7 +32,6 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * Architecture:
  * - Dual-role: advertises and discovers simultaneously via P2P_CLUSTER strategy
- * - Deterministic tie-breaking: lower endpoint name initiates connection (prevents dual-connect)
  * - processOutgoing() is a no-op — Transport calls each NearbyPeerInterface directly
  *
  * @param name Human-readable interface name
@@ -55,9 +59,6 @@ class NearbyInterface(
     // endpointId -> NearbyPeerInterface
     private val peers = ConcurrentHashMap<String, NearbyPeerInterface>()
 
-    // Endpoints we've already initiated connection to (prevents duplicate requests)
-    private val pendingConnections = ConcurrentHashMap.newKeySet<String>()
-
     init {
         spawnedInterfaces = mutableListOf()
     }
@@ -69,17 +70,11 @@ class NearbyInterface(
 
         scope.launch {
             try {
+                // driver.start() suspends until advertising + discovery are confirmed.
+                // It throws on failure, so online stays false.
                 driver.start(localEndpointName, maxConnections)
-                // driver.start() returns immediately; async Tasks may still fail.
-                // Brief delay then check driver.isRunning to catch early failures.
-                kotlinx.coroutines.delay(1000)
-                if (driver.isRunning) {
-                    online.set(true)
-                    log("Advertising and discovery started (name=$localEndpointName)")
-                } else {
-                    online.set(false)
-                    log("Driver failed to start (isRunning=false after start)")
-                }
+                online.set(true)
+                log("Advertising and discovery started (name=$localEndpointName)")
             } catch (e: Exception) {
                 online.set(false)
                 log("Failed to start: ${e.message}")
@@ -119,7 +114,6 @@ class NearbyInterface(
         }
         peers.clear()
         spawnedInterfaces?.clear()
-        pendingConnections.clear()
 
         // Shutdown driver and cancel scope
         driver.shutdown()
@@ -131,34 +125,13 @@ class NearbyInterface(
     // ---- Event Collection ----
 
     /**
-     * Handle discovered endpoints with deterministic tie-breaking.
-     * The peer with the lexicographically lower endpoint name initiates the connection.
+     * Log discovered endpoints. Connection decisions are made entirely by the driver.
      */
     private suspend fun collectDiscoveredEndpoints() {
         try {
             driver.discoveredEndpoints.collect { endpoint ->
-                if (!online.get() || detached.get()) return@collect
-
-                // Skip if already connected or pending
-                if (peers.containsKey(endpoint.endpointId)) return@collect
-                if (pendingConnections.contains(endpoint.endpointId)) return@collect
-                if (peers.size + pendingConnections.size >= maxConnections.coerceAtMost(DEFAULT_MAX_CONNECTIONS)) return@collect
-
-                // Use the driver's tie-breaking decision to track pending state
-                if (endpoint.weInitiate) {
-                    log(
-                        "Initiating connection to ${endpoint.endpointId} " +
-                            "(our name=$localEndpointName, theirs=${endpoint.endpointName})",
-                    )
-                    pendingConnections.add(endpoint.endpointId)
-                    // Driver handles the actual requestConnection call internally
-                    // The result comes via connectedEndpoints or connectionLost
-                } else {
-                    log(
-                        "Waiting for ${endpoint.endpointId} to initiate " +
-                            "(our name=$localEndpointName, theirs=${endpoint.endpointName})",
-                    )
-                }
+                val action = if (endpoint.weInitiate) "initiating" else "waiting"
+                log("Discovered ${endpoint.endpointId} (${endpoint.endpointName}), $action")
             }
         } catch (_: CancellationException) {
             // Normal shutdown
@@ -174,8 +147,6 @@ class NearbyInterface(
         try {
             driver.connectedEndpoints.collect { endpoint ->
                 if (!online.get() || detached.get()) return@collect
-
-                pendingConnections.remove(endpoint.endpointId)
 
                 // Skip if already have a peer for this endpoint
                 if (peers.containsKey(endpoint.endpointId)) return@collect
@@ -202,7 +173,6 @@ class NearbyInterface(
     private suspend fun collectConnectionLost() {
         try {
             driver.connectionLost.collect { endpointId ->
-                pendingConnections.remove(endpointId)
                 tearDownPeer(endpointId)
             }
         } catch (_: CancellationException) {
@@ -271,7 +241,6 @@ class NearbyInterface(
         } catch (_: Exception) {
         }
 
-        // Only detach if not already detached (avoids recursive peerDisconnected call)
         if (!peer.detached.get()) {
             peer.online.set(false)
             peer.detached.set(true)

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
@@ -1,7 +1,5 @@
 package network.reticulum.interfaces.nearby
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import network.reticulum.interfaces.Interface
 
 /**
@@ -36,15 +34,12 @@ class NearbyPeerInterface(
 
     /**
      * Send data to this specific endpoint.
-     * Transport calls this synchronously; bridge to suspend with runBlocking.
      */
     override fun processOutgoing(data: ByteArray) {
         if (!online.get() || detached.get()) return
 
         try {
-            runBlocking(Dispatchers.IO) {
-                driver.send(endpointId, data)
-            }
+            driver.send(endpointId, data)
             txBytes.addAndGet(data.size.toLong())
             parentNearbyInterface.txBytes.addAndGet(data.size.toLong())
         } catch (e: Exception) {
@@ -70,7 +65,7 @@ class NearbyPeerInterface(
         online.set(false)
 
         try {
-            runBlocking(Dispatchers.IO) { driver.disconnect(endpointId) }
+            driver.disconnect(endpointId)
         } catch (_: Exception) {
         }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
@@ -1,0 +1,87 @@
+package network.reticulum.interfaces.nearby
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import network.reticulum.interfaces.Interface
+
+/**
+ * Per-endpoint child interface for Nearby Connections.
+ *
+ * Spawned by [NearbyInterface] for each connected endpoint. Much simpler than
+ * [network.reticulum.interfaces.ble.BLEPeerInterface] because Nearby Connections
+ * handles transport internally — no fragmentation, reassembly, or keepalive needed.
+ *
+ * Responsibilities:
+ * - Send outgoing packets via [NearbyDriver.send] (called by Transport)
+ * - Receive incoming packets via [processIncoming] (called by parent's data collection)
+ *
+ * @param name Human-readable name (format: "Nearby|{endpointId.take(8)}")
+ * @param endpointId Nearby Connections endpoint identifier
+ * @param parentNearbyInterface Parent [NearbyInterface] that spawned this
+ * @param driver Driver for sending data
+ */
+class NearbyPeerInterface(
+    name: String,
+    val endpointId: String,
+    private val parentNearbyInterface: NearbyInterface,
+    private val driver: NearbyDriver,
+) : Interface(name) {
+    override val bitrate: Int = 2_000_000 // WiFi Direct: ~2 Mbps effective
+    override val canReceive: Boolean = true
+    override val canSend: Boolean = true
+
+    init {
+        this.parentInterface = parentNearbyInterface
+    }
+
+    /**
+     * Send data to this specific endpoint.
+     * Transport calls this synchronously; bridge to suspend with runBlocking.
+     */
+    override fun processOutgoing(data: ByteArray) {
+        if (!online.get() || detached.get()) return
+
+        try {
+            runBlocking(Dispatchers.IO) {
+                driver.send(endpointId, data)
+            }
+            txBytes.addAndGet(data.size.toLong())
+            parentNearbyInterface.txBytes.addAndGet(data.size.toLong())
+        } catch (e: Exception) {
+            log("Send failed to $endpointId: ${e.message}")
+        }
+    }
+
+    /**
+     * Deliver incoming data to Transport.
+     * Called by [NearbyInterface] when data arrives from this endpoint.
+     */
+    fun deliverIncoming(data: ByteArray) {
+        if (!online.get() || detached.get()) return
+        rxBytes.addAndGet(data.size.toLong())
+        parentNearbyInterface.rxBytes.addAndGet(data.size.toLong())
+        processIncoming(data)
+    }
+
+    override fun start() {
+        online.set(true)
+    }
+
+    override fun detach() {
+        if (detached.getAndSet(true)) return
+        online.set(false)
+
+        try {
+            runBlocking(Dispatchers.IO) { driver.disconnect(endpointId) }
+        } catch (_: Exception) {
+        }
+
+        parentNearbyInterface.peerDisconnected(this)
+    }
+
+    private fun log(message: String) {
+        println("[NearbyPeerInterface][$name] $message")
+    }
+
+    override fun toString(): String = "NearbyPeerInterface[$name]"
+}

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
@@ -58,8 +58,6 @@ class NearbyPeerInterface(
      */
     fun deliverIncoming(data: ByteArray) {
         if (!online.get() || detached.get()) return
-        rxBytes.addAndGet(data.size.toLong())
-        parentNearbyInterface.rxBytes.addAndGet(data.size.toLong())
         processIncoming(data)
     }
 


### PR DESCRIPTION
## Summary

- Adds `NearbyDriver` interface (pure JVM) with SharedFlow event streams for endpoint discovery, connection, disconnection, and data receipt
- Adds `NearbyInterface` server-style parent that orchestrates peer discovery with deterministic tie-breaking (lower endpoint name initiates connection)
- Adds `NearbyPeerInterface` per-endpoint child interface registered directly with Transport for packet send/receive
- Adds `AndroidNearbyDriver` wrapping `Nearby.getConnectionsClient()` with P2P_CLUSTER strategy, auto-accept, and BYTES payloads
- Adds `play-services-nearby:19.3.0` dependency to `rns-android`

Follows the established BLE interface pattern but simpler: no fragmentation (32KB payload limit), no keepalive (managed by Nearby internally), no GATT/MTU negotiation.

## Test plan

- [x] `rns-interfaces` and `rns-android` compile cleanly
- [x] Tested on two physical devices: peer discovery, connection (WiFi Aware transport), and NearbyPeerInterface spawn verified via logcat
- [ ] Unit tests for NearbyInterface (mock NearbyDriver, verify peer spawn/teardown, tie-breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)