### PR TITLE
Fix shared instance transport forwarding and R8 keep rules

### DIFF
--- a/python-bridge/conformance/python_shared_instance_session.py
+++ b/python-bridge/conformance/python_shared_instance_session.py
@@ -1,0 +1,223 @@
+"""
+Session where Python is the shared instance server and clients connect via TCP.
+
+This mirrors the Android/Ara topology:
+    Python shared instance (Chaquopy) ← TCP ← Kotlin client (reticulum-kt)
+
+Topology:
+    Hub (Python, link_listen) ──[TCP]──▶  Python Shared Instance  ◀──[TCP]── Client (Python or Kotlin)
+                                          (transport)                         (link_initiate)
+
+The shared instance is always Python to match what Chaquopy provides on Android.
+Clients can be either Python pipe_peer.py or Kotlin PipePeer (via kt_client_cmd).
+"""
+import json
+import os
+import random
+import shlex
+import subprocess
+import threading
+import time
+
+
+class _Subprocess:
+    """A subprocess that reports JSON messages on stderr."""
+
+    def __init__(self, cmd, env):
+        self._cmd = cmd
+        self._env = env
+        self.process = None
+        self._messages = []
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        self._thread = None
+
+    def start(self):
+        self.process = subprocess.Popen(
+            shlex.split(self._cmd),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            env=self._env,
+        )
+        self._thread = threading.Thread(target=self._read_stderr, daemon=True)
+        self._thread.start()
+
+    def _read_stderr(self):
+        try:
+            for line in self.process.stderr:
+                line = line.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                    with self._cond:
+                        self._messages.append(msg)
+                        self._cond.notify_all()
+                except json.JSONDecodeError:
+                    pass
+        except (ValueError, OSError):
+            pass
+
+    def wait_for_message(self, msg_type, timeout=15, predicate=None):
+        deadline = time.time() + timeout
+        with self._cond:
+            while time.time() < deadline:
+                for msg in self._messages:
+                    if msg.get("type") == msg_type:
+                        if predicate is None or predicate(msg):
+                            self._messages.remove(msg)
+                            return msg
+                remaining = deadline - time.time()
+                if remaining > 0:
+                    self._cond.wait(timeout=min(remaining, 0.5))
+        return None
+
+    def get_all_messages(self):
+        with self._lock:
+            return list(self._messages)
+
+    def stop(self):
+        if self.process:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait()
+
+
+class PythonSharedInstanceSession:
+    """
+    Python shared instance with multiple clients connected via TCP.
+
+    The shared instance is always a Python pipe_peer.py subprocess with
+    share_instance=Yes and transport enabled. Clients connect to it via TCP.
+
+    Usage:
+        session = PythonSharedInstanceSession(rns_path)
+        session.start(
+            hub_action="link_listen",
+            client_action="link_initiate",
+            client_cmd=kt_peer_cmd,  # or None for Python
+        )
+        # Read messages from session.hub and session.client
+        session.stop()
+    """
+
+    def __init__(self, rns_path, tcp_port=None):
+        self.rns_path = rns_path
+        self.tcp_port = tcp_port or random.randint(37450, 47450)
+
+        self.server = None   # Python shared instance
+        self.hub = None      # Hub (link_listen)
+        self.client = None   # Client (link_initiate)
+
+    def start(
+        self,
+        hub_action="link_listen",
+        client_action="link_initiate",
+        client_cmd=None,
+        client_env_key="PIPE_PEER_SHARED_PORT",
+        app_name="pipetest",
+        aspects="routing",
+    ):
+        """
+        Start the session.
+
+        Args:
+            hub_action: Action for the hub subprocess (default: link_listen)
+            client_action: Action for the client subprocess (default: link_initiate)
+            client_cmd: Command for the client. None = Python pipe_peer.py.
+                        For Kotlin, pass the kt-pipe-peer.jar command.
+            client_env_key: Env var key for the TCP port on the client side.
+                           Python uses PIPE_PEER_SHARED_PORT (share_instance=Yes in config).
+                           Kotlin uses PIPE_PEER_SHARED_CLIENT_PORT (LocalClientInterface).
+            app_name: RNS app name for destinations
+            aspects: RNS aspects for destinations
+        """
+        project_root = self._find_project_root()
+        py_peer_cmd = f"python3 {os.path.join(project_root, 'python-bridge/pipe_peer.py')}"
+
+        # 1. Start Python shared instance (transport, gets the port)
+        server_env = os.environ.copy()
+        server_env["PIPE_PEER_ACTION"] = "transport"
+        server_env["PIPE_PEER_APP_NAME"] = app_name
+        server_env["PIPE_PEER_ASPECTS"] = aspects
+        server_env["PIPE_PEER_TRANSPORT"] = "true"
+        server_env["PIPE_PEER_SHARED_PORT"] = str(self.tcp_port)
+        if "PYTHON_RNS_PATH" not in server_env:
+            server_env["PYTHON_RNS_PATH"] = self.rns_path
+
+        self.server = _Subprocess(py_peer_cmd, server_env)
+        self.server.start()
+
+        ready = self.server.wait_for_message("ready", timeout=20)
+        if ready is None:
+            raise RuntimeError(
+                "Python shared instance did not emit ready. "
+                f"Messages: {self.server.get_all_messages()}"
+            )
+
+        # Give the TCP server a moment
+        time.sleep(0.5)
+
+        # 2. Start hub (connects as TCP client to shared instance)
+        hub_env = os.environ.copy()
+        hub_env["PIPE_PEER_ACTION"] = hub_action
+        hub_env["PIPE_PEER_APP_NAME"] = app_name
+        hub_env["PIPE_PEER_ASPECTS"] = aspects
+        hub_env["PIPE_PEER_TRANSPORT"] = "false"
+        hub_env["PIPE_PEER_SHARED_PORT"] = str(self.tcp_port)
+        if "PYTHON_RNS_PATH" not in hub_env:
+            hub_env["PYTHON_RNS_PATH"] = self.rns_path
+
+        self.hub = _Subprocess(py_peer_cmd, hub_env)
+        self.hub.start()
+
+        hub_ready = self.hub.wait_for_message("ready", timeout=15)
+        if hub_ready is None:
+            raise RuntimeError(
+                "Hub did not emit ready. "
+                f"Messages: {self.hub.get_all_messages()}"
+            )
+
+        # 3. Start client (Python or Kotlin)
+        if client_cmd is None:
+            client_cmd = py_peer_cmd
+
+        client_env = os.environ.copy()
+        client_env["PIPE_PEER_ACTION"] = client_action
+        client_env["PIPE_PEER_APP_NAME"] = app_name
+        client_env["PIPE_PEER_ASPECTS"] = aspects
+        client_env["PIPE_PEER_TRANSPORT"] = "false"
+        client_env[client_env_key] = str(self.tcp_port)
+        if "PYTHON_RNS_PATH" not in client_env:
+            client_env["PYTHON_RNS_PATH"] = self.rns_path
+
+        self.client = _Subprocess(client_cmd, client_env)
+        self.client.start()
+
+        client_ready = self.client.wait_for_message("ready", timeout=15)
+        if client_ready is None:
+            raise RuntimeError(
+                "Client did not emit ready. "
+                f"Messages: {self.client.get_all_messages()}"
+            )
+
+    def stop(self):
+        if self.client:
+            self.client.stop()
+        if self.hub:
+            self.hub.stop()
+        if self.server:
+            self.server.stop()
+
+    @staticmethod
+    def _find_project_root():
+        d = os.path.dirname(os.path.abspath(__file__))
+        while d != "/":
+            if os.path.exists(os.path.join(d, "settings.gradle.kts")):
+                return d
+            d = os.path.dirname(d)
+        return os.path.dirname(os.path.abspath(__file__))

--- a/python-bridge/conformance/test_link_kt_client_via_python_shared.py
+++ b/python-bridge/conformance/test_link_kt_client_via_python_shared.py
@@ -1,0 +1,157 @@
+"""
+Link establishment: Kotlin client → Python shared instance → Python hub.
+
+This reproduces the Ara/Android topology:
+  - Python shared instance (Chaquopy rnsd) acts as transport
+  - Python hub (rrc-nomadnet) announces and accepts links
+  - Kotlin client (reticulum-kt via Ara) connects and establishes a link
+
+Phase 1: All-Python baseline — verifies the test harness itself
+Phase 2: Kotlin as client — tests Kotlin LocalClientInterface through Python shared instance
+
+Topology:
+    Hub (Python, link_listen) ──[TCP]──▶ Python Shared Instance ◀──[TCP]── Client (Python or Kotlin)
+                                         (transport)                        (link_initiate)
+"""
+import os
+import pytest
+from python_shared_instance_session import PythonSharedInstanceSession
+
+
+@pytest.fixture(scope="session")
+def kt_client_cmd(peer_cmd):
+    """Kotlin PipePeer command (reuses the peer_cmd fixture from conftest)."""
+    return peer_cmd
+
+
+# ─── Phase 1: All-Python Baseline ────────────────────────────────────────────
+
+
+class TestAllPythonBaseline:
+    """All-Python: verifies that link establishment works through a Python shared instance.
+
+    This is the baseline that must pass before testing with Kotlin.
+    """
+
+    @pytest.fixture(scope="class")
+    def session(self, rns_path):
+        s = PythonSharedInstanceSession(rns_path)
+        s.start(
+            hub_action="link_listen",
+            client_action="link_initiate",
+            client_cmd=None,  # Python
+            client_env_key="PIPE_PEER_SHARED_PORT",
+        )
+        yield s
+        s.stop()
+
+    def test_hub_announces(self, session):
+        """Hub announces its destination through the shared instance."""
+        msg = session.hub.wait_for_message("announced", timeout=15)
+        assert msg is not None, (
+            "Hub should announce. "
+            f"Hub messages: {session.hub.get_all_messages()}"
+        )
+        assert len(msg.get("destination_hash", "")) > 0
+
+    def test_client_finds_destination(self, session):
+        """Client discovers the hub's destination through the shared instance."""
+        msg = session.client.wait_for_message("destination_found", timeout=20)
+        assert msg is not None, (
+            "Client should discover hub destination. "
+            f"Client messages: {session.client.get_all_messages()}"
+        )
+
+    def test_link_established_on_client(self, session):
+        """Client (initiator) reports link_established."""
+        msg = session.client.wait_for_message("link_established", timeout=25)
+        assert msg is not None, (
+            "Client should establish link to hub. "
+            f"Client messages: {session.client.get_all_messages()}"
+        )
+        assert len(msg.get("link_id", "")) > 0
+
+    def test_link_established_on_hub(self, session):
+        """Hub (listener) reports link_established."""
+        msg = session.hub.wait_for_message("link_established", timeout=25)
+        assert msg is not None, (
+            "Hub should report link_established. "
+            f"Hub messages: {session.hub.get_all_messages()}"
+        )
+
+    def test_data_reaches_hub(self, session):
+        """Data sent by client reaches the hub through the shared instance."""
+        msg = session.hub.wait_for_message("link_data", timeout=15)
+        assert msg is not None, (
+            "Hub should receive data from client. "
+            f"Hub messages: {session.hub.get_all_messages()}"
+        )
+        assert msg["data_hex"] == b"hello-from-initiator".hex()
+
+
+# ─── Phase 2: Kotlin Client ──────────────────────────────────────────────────
+
+
+class TestKotlinClientViaPythonShared:
+    """Kotlin client connecting to Python shared instance → Python hub.
+
+    This is the Ara scenario: Kotlin reticulum-kt connects via
+    LocalClientInterface to a Python shared instance (Chaquopy).
+    """
+
+    @pytest.fixture(scope="class")
+    def session(self, rns_path, kt_client_cmd):
+        s = PythonSharedInstanceSession(rns_path)
+        s.start(
+            hub_action="link_listen",
+            client_action="link_initiate",
+            client_cmd=kt_client_cmd,
+            # Kotlin uses PIPE_PEER_SHARED_CLIENT_PORT to create a
+            # LocalClientInterface (connects as client, not server)
+            client_env_key="PIPE_PEER_SHARED_CLIENT_PORT",
+        )
+        yield s
+        s.stop()
+
+    def test_hub_announces(self, session):
+        """Hub announces its destination through the shared instance."""
+        msg = session.hub.wait_for_message("announced", timeout=15)
+        assert msg is not None, (
+            "Hub should announce. "
+            f"Hub messages: {session.hub.get_all_messages()}"
+        )
+        assert len(msg.get("destination_hash", "")) > 0
+
+    def test_client_finds_destination(self, session):
+        """Kotlin client discovers hub's destination through Python shared instance."""
+        msg = session.client.wait_for_message("destination_found", timeout=20)
+        assert msg is not None, (
+            "Kotlin client should discover hub destination through Python shared instance. "
+            f"Client messages: {session.client.get_all_messages()}"
+        )
+
+    def test_link_established_on_client(self, session):
+        """Kotlin client (initiator) reports link_established."""
+        msg = session.client.wait_for_message("link_established", timeout=25)
+        assert msg is not None, (
+            "Kotlin client should establish link to hub through Python shared instance. "
+            f"Client messages: {session.client.get_all_messages()}"
+        )
+        assert len(msg.get("link_id", "")) > 0
+
+    def test_link_established_on_hub(self, session):
+        """Hub (listener) reports link_established from Kotlin client."""
+        msg = session.hub.wait_for_message("link_established", timeout=25)
+        assert msg is not None, (
+            "Hub should report link_established from Kotlin client. "
+            f"Hub messages: {session.hub.get_all_messages()}"
+        )
+
+    def test_data_reaches_hub(self, session):
+        """Data sent by Kotlin client reaches the Python hub."""
+        msg = session.hub.wait_for_message("link_data", timeout=15)
+        assert msg is not None, (
+            "Hub should receive data from Kotlin client. "
+            f"Hub messages: {session.hub.get_all_messages()}"
+        )
+        assert msg["data_hex"] == b"hello-from-initiator".hex()

--- a/python-bridge/conformance/test_link_local_client_to_external_hub.py
+++ b/python-bridge/conformance/test_link_local_client_to_external_hub.py
@@ -1,0 +1,140 @@
+"""
+Link establishment from a local shared instance client to an external hub.
+
+Tests that a LINKREQUEST from a local client (connected via TCP) to an external
+destination (connected via pipe) is correctly routed through the Kotlin shared
+instance transport node.
+
+Topology:
+    External Hub (Python, link_listen) ──[pipe]──▶ Target (Kotlin transport + shared instance) ◀──[TCP]── Client (Python, link_initiate)
+
+This mirrors the Ara → Carina → remote hub topology:
+    Ara (link initiator) ──TCP──▶ Carina (shared instance) ──▶ rnsd ──▶ rrc-nomadnet (hub)
+
+Bug being guarded against:
+    When a local client sends a LINKREQUEST to a destination beyond the shared
+    instance (hops >= 1 from the shared instance), the client's Transport.outbound
+    must inject transport headers (HEADER_2) so the shared instance can route it.
+    Without this, the LINKREQUEST arrives as HEADER_1 with no transport_id, and
+    the shared instance's processInbound cannot forward it to the backbone interface.
+    Python Transport.py:993-1011 handles this on the client side; the Kotlin
+    implementation was missing this special case.
+"""
+import time
+import pytest
+from hybrid_shared_instance_session import HybridSharedInstanceSession
+
+
+@pytest.fixture(scope="module")
+def session(peer_cmd, rns_path):
+    """Hybrid session: target as transport + shared instance, external hub listens."""
+    s = HybridSharedInstanceSession(peer_cmd, rns_path)
+    s.start(
+        target_transport=True,
+        # The local client will initiate a link to the external hub
+        shared_clients=[{"action": "link_initiate"}],
+    )
+    yield s
+    s.stop()
+
+
+@pytest.fixture(scope="module")
+def hub_dest(session):
+    """Create a destination on the external Python hub and announce it."""
+    RNS = session.RNS
+
+    identity = RNS.Identity()
+    destination = RNS.Destination(
+        identity,
+        RNS.Destination.IN,
+        RNS.Destination.SINGLE,
+        "pipetest",
+        "routing",
+    )
+
+    # Accept incoming links
+    established_links = []
+
+    def link_established(link):
+        established_links.append(link)
+
+    destination.set_link_established_callback(link_established)
+    destination.announce()
+
+    return {
+        "identity": identity,
+        "destination": destination,
+        "dest_hash_hex": destination.hash.hex(),
+        "established_links": established_links,
+    }
+
+
+class TestLocalClientToExternalHub:
+    """Local shared instance client initiates a link to an external hub."""
+
+    def test_hub_destination_announced(self, session, hub_dest):
+        """External hub successfully announces its destination through the pipe."""
+        # The hub's announce should propagate through the target to the local client.
+        # Wait for the local client to discover the destination.
+        msg = session.wait_for_shared_client_message(
+            0, "destination_found", timeout=20
+        )
+        assert msg is not None, (
+            "Local client should discover the external hub destination. "
+            f"Client messages: {session.shared_client(0).get_all_messages()}"
+        )
+
+    def test_link_initiated_by_client(self, session, hub_dest):
+        """Local client initiates a link to the external hub."""
+        msg = session.wait_for_shared_client_message(
+            0, "link_initiated", timeout=10
+        )
+        assert msg is not None, (
+            "Local client should initiate a link to the external hub. "
+            f"Client messages: {session.shared_client(0).get_all_messages()}"
+        )
+
+    def test_link_established_on_client(self, session, hub_dest):
+        """Local client reports link_established to the external hub."""
+        msg = session.wait_for_shared_client_message(
+            0, "link_established", timeout=25
+        )
+        assert msg is not None, (
+            "Local client should establish link to external hub through shared instance. "
+            f"Client messages: {session.shared_client(0).get_all_messages()}"
+        )
+        assert len(msg.get("link_id", "")) > 0
+
+    def test_link_established_on_hub(self, session, hub_dest):
+        """External hub (listener) accepts the link from the local client."""
+        deadline = time.time() + 25
+        while time.time() < deadline:
+            if hub_dest["established_links"]:
+                break
+            time.sleep(0.2)
+
+        assert len(hub_dest["established_links"]) > 0, (
+            "External hub should accept a link from the local client"
+        )
+
+    def test_data_reaches_hub(self, session, hub_dest):
+        """Data sent by the local client reaches the external hub."""
+        # The link_initiate action sends b"hello-from-initiator" after establishment
+        deadline = time.time() + 15
+        received_data = []
+
+        for link in hub_dest["established_links"]:
+            def on_data(message, packet, _received=received_data):
+                data = message if isinstance(message, bytes) else bytes(message)
+                _received.append(data)
+            link.set_packet_callback(on_data)
+
+        while time.time() < deadline:
+            if received_data:
+                break
+            time.sleep(0.2)
+
+        assert len(received_data) > 0, (
+            "External hub should receive data from local client"
+        )
+        assert received_data[0] == b"hello-from-initiator"

--- a/rns-android/consumer-rules.pro
+++ b/rns-android/consumer-rules.pro
@@ -9,3 +9,11 @@
 -keepclassmembers class network.reticulum.android.ReticulumConfig {
     public static final android.os.Parcelable$Creator CREATOR;
 }
+
+# Keep MessagePack serialization (uses Class.forName for MessageBufferU)
+-keep class org.msgpack.** { *; }
+-dontwarn org.msgpack.**
+
+# Keep BouncyCastle cryptographic classes
+-keep class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**

--- a/rns-cli/src/main/kotlin/network/reticulum/cli/PipePeer.kt
+++ b/rns-cli/src/main/kotlin/network/reticulum/cli/PipePeer.kt
@@ -8,6 +8,7 @@ import network.reticulum.common.InterfaceMode
 import network.reticulum.common.toHexString
 import network.reticulum.destination.Destination
 import network.reticulum.identity.Identity
+import network.reticulum.interfaces.local.LocalClientInterface
 import network.reticulum.interfaces.local.LocalServerInterface
 import network.reticulum.interfaces.pipe.PipeInterface
 import network.reticulum.interfaces.toRef
@@ -31,6 +32,7 @@ import java.nio.file.Files
  *   PIPE_PEER_ASPECTS:   comma-separated aspects (default: routing)
  *   PIPE_PEER_TRANSPORT: true | false (default: false)
  *   PIPE_PEER_MODE:      interface mode: full | ap | roaming | boundary | gateway | p2p
+ *   PIPE_PEER_SHARED_CLIENT_PORT: TCP port to connect to as LocalClientInterface client
  *   PIPE_PEER_NUM_IFACES:      number of fd-pair interfaces (0 = use stdin/stdout)
  *   PIPE_PEER_IFACE_{n}_FD_IN:  read fd for interface n
  *   PIPE_PEER_IFACE_{n}_FD_OUT: write fd for interface n
@@ -48,6 +50,7 @@ fun main() {
     val enableTransport = System.getenv("PIPE_PEER_TRANSPORT")?.lowercase() == "true"
     val modeStr = System.getenv("PIPE_PEER_MODE") ?: "full"
     val sharedPort = System.getenv("PIPE_PEER_SHARED_PORT")?.toIntOrNull() ?: 0
+    val sharedClientPort = System.getenv("PIPE_PEER_SHARED_CLIENT_PORT")?.toIntOrNull() ?: 0
 
     val mode = when (modeStr.lowercase()) {
         "ap", "access_point" -> InterfaceMode.ACCESS_POINT
@@ -78,6 +81,16 @@ fun main() {
             server.start()
         }
 
+        // Connect as client to an existing shared instance (e.g., Python rnsd)
+        if (sharedClientPort > 0) {
+            val client = LocalClientInterface(
+                name = "SharedClient",
+                tcpPort = sharedClientPort
+            )
+            Transport.registerInterface(client.toRef())
+            client.start()
+        }
+
         // Pipe interfaces (can coexist with shared instance server)
         val numIfaces = System.getenv("PIPE_PEER_NUM_IFACES")?.toIntOrNull() ?: 0
         if (numIfaces > 0) {
@@ -95,8 +108,8 @@ fun main() {
                 Transport.registerInterface(iface.toRef())
                 iface.start()
             }
-        } else if (sharedPort <= 0) {
-            // Single interface mode: stdin/stdout (only when no shared instance and no fd pairs)
+        } else if (sharedPort <= 0 && sharedClientPort <= 0) {
+            // Single interface mode: stdin/stdout (only when no shared instance/client and no fd pairs)
             val pipeInterface = PipeInterface(
                 name = "StdioPipe",
                 inputStream = System.`in`,

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2394,6 +2394,35 @@ object Transport {
             packet.transportId = identity?.hash
         }
 
+        // Server-side defense: when a local client sends a HEADER_1 packet for a
+        // REMOTE destination (not forLocalClient), inject transport headers so the
+        // existing forwarding logic can handle it. Python clients always send HEADER_2
+        // for hops >= 1 (Transport.py:993-1011), but if a client omits transport
+        // headers, the shared instance must still be able to forward the packet.
+        if (fromLocalClient && packet.transportId == null && !forLocalClient &&
+            packet.packetType != PacketType.ANNOUNCE &&
+            packet.context != PacketContext.LRPROOF) {
+            val destPathEntry = pathTable[packet.destinationHash.toKey()]
+            if (destPathEntry != null) {
+                val myHash = identity?.hash
+                val packetRaw = packet.raw
+                if (myHash != null && packetRaw != null) {
+                    // Convert HEADER_1 raw to HEADER_2 by inserting transport_id
+                    val newFlags = (HeaderType.HEADER_2.value shl 6) or
+                                   (TransportType.TRANSPORT.value shl 4) or
+                                   (packetRaw[0].toInt() and 0x0F)
+                    val newRaw = ByteArray(packetRaw.size + RnsConstants.TRUNCATED_HASH_BYTES)
+                    newRaw[0] = newFlags.toByte()
+                    newRaw[1] = packetRaw[1]
+                    System.arraycopy(myHash, 0, newRaw, 2, RnsConstants.TRUNCATED_HASH_BYTES)
+                    System.arraycopy(packetRaw, 2, newRaw, 2 + RnsConstants.TRUNCATED_HASH_BYTES, packetRaw.size - 2)
+                    packet.raw = newRaw
+                    packet.transportId = myHash
+                    log("Injected transport headers for HEADER_1 packet from local client to remote dest ${packet.destinationHash.toHexString()}")
+                }
+            }
+        }
+
         // General transport handling (Python Transport.py:1404-1510)
         // This runs for ALL packet types (LINKREQUEST, DATA, PROOF) before type-specific handling.
         // It forwards packets where we are the designated next transport hop.
@@ -2592,6 +2621,13 @@ object Transport {
                 log("Sending to $destHex via path (${pathEntry.hops} hops) on ${outboundInterface.name}")
                 if (pathEntry.hops > 1) {
                     // Insert into transport (HEADER_2)
+                    val transportRaw = insertIntoTransport(packet, pathEntry.nextHop)
+                    transmit(outboundInterface, transportRaw)
+                    sent = true
+                } else if (pathEntry.hops == 1 && interfaces.any { it.isConnectedToSharedInstance }) {
+                    // When behind a shared instance, even 1-hop destinations need
+                    // transport headers so the shared instance can route them onto
+                    // the network. Python Transport.py:993-1011
                     val transportRaw = insertIntoTransport(packet, pathEntry.nextHop)
                     transmit(outboundInterface, transportRaw)
                     sent = true


### PR DESCRIPTION
## Summary
- Forward LINKREQUEST packets from local clients through the shared instance by injecting transport headers for remote destinations
- Add msgpack and BouncyCastle keep rules to consumer-rules.pro to prevent R8 from stripping reflection-loaded classes

## Test plan
- [ ] Verify Kotlin client can establish links through a Python shared instance to a remote hub
- [ ] Verify release builds don't crash from stripped msgpack/BouncyCastle classes