### PR TITLE
Fix shared instance forwarding and R8 keep rules

### DIFF
--- a/rns-android/consumer-rules.pro
+++ b/rns-android/consumer-rules.pro
@@ -9,3 +9,11 @@
 -keepclassmembers class network.reticulum.android.ReticulumConfig {
     public static final android.os.Parcelable$Creator CREATOR;
 }
+
+# Keep MessagePack serialization (uses Class.forName for MessageBufferU)
+-keep class org.msgpack.** { *; }
+-dontwarn org.msgpack.**
+
+# Keep BouncyCastle cryptographic classes
+-keep class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -333,12 +333,14 @@ class Reticulum private constructor(
             // Set state only after all steps succeed (matches Python Reticulum.py:414-416)
             sharedInterface = clientInterface
             isConnectedToSharedInstance = true
+            Transport.isConnectedToSharedInstance = true
 
             log("Connected to shared instance")
             return true
         } catch (e: Exception) {
             log("Failed to connect to shared instance: ${e.message}")
             isConnectedToSharedInstance = false
+            Transport.isConnectedToSharedInstance = false
             return false
         }
     }
@@ -495,6 +497,7 @@ class Reticulum private constructor(
         sharedInterface = null
         isSharedInstance = false
         isConnectedToSharedInstance = false
+        Transport.isConnectedToSharedInstance = false
 
         // Detach interfaces
         interfaces.clear()

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2400,7 +2400,8 @@ object Transport {
         // for hops >= 1 (Transport.py:993-1011), but if a client omits transport
         // headers, the shared instance must still be able to forward the packet.
         if (fromLocalClient && packet.transportId == null && !forLocalClient &&
-            packet.packetType == PacketType.LINKREQUEST) {
+            packet.packetType != PacketType.ANNOUNCE &&
+            packet.context != PacketContext.LRPROOF) {
             val destPathEntry = pathTable[packet.destinationHash.toKey()]
             if (destPathEntry != null) {
                 val myHash = identity?.hash
@@ -2623,7 +2624,7 @@ object Transport {
                     val transportRaw = insertIntoTransport(packet, pathEntry.nextHop)
                     transmit(outboundInterface, transportRaw)
                     sent = true
-                } else if (pathEntry.hops == 1 && outboundInterface.isConnectedToSharedInstance) {
+                } else if (pathEntry.hops == 1 && interfaces.any { it.isConnectedToSharedInstance }) {
                     // When behind a shared instance, even 1-hop destinations need
                     // transport headers so the shared instance can route them onto
                     // the network. Python Transport.py:993-1011

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -95,6 +95,9 @@ object Transport {
     var transportEnabled: Boolean = false
         private set
 
+    /** Whether this instance is connected to a local shared instance (Python: Transport.owner.is_connected_to_shared_instance). */
+    var isConnectedToSharedInstance: Boolean = false
+
     /** Optional network identity for discovery encryption. */
     var networkIdentity: Identity? = null
 
@@ -2624,7 +2627,7 @@ object Transport {
                     val transportRaw = insertIntoTransport(packet, pathEntry.nextHop)
                     transmit(outboundInterface, transportRaw)
                     sent = true
-                } else if (pathEntry.hops == 1 && interfaces.any { it.isConnectedToSharedInstance }) {
+                } else if (pathEntry.hops == 1 && isConnectedToSharedInstance) {
                     // When behind a shared instance, even 1-hop destinations need
                     // transport headers so the shared instance can route them onto
                     // the network. Python Transport.py:993-1011
@@ -2945,7 +2948,7 @@ object Transport {
         // Cache the announce packet for later path request responses
         // Python Transport.py:1867 — cache pre-increment raw announce to disk
         // Only cache if not connected to a shared instance (the server handles caching)
-        if (!interfaces.any { it.isConnectedToSharedInstance }) {
+        if (!isConnectedToSharedInstance) {
             cacheAnnouncePacket(packet, interfaceRef)
         }
 
@@ -3699,7 +3702,7 @@ object Transport {
     private fun packetFilter(packet: Packet, receivingInterface: InterfaceRef): Boolean {
         // Python RNS: Bypass local filtering if connected to shared instance
         // (Python Transport.py:1187-1190)
-        if (interfaces.any { it.isConnectedToSharedInstance }) {
+        if (isConnectedToSharedInstance) {
             return true
         }
 


### PR DESCRIPTION
## Summary
- Broaden transport header injection for local client packets to all types except ANNOUNCE and LRPROOF (was LINKREQUEST-only), matching Python Transport.py behavior
- Fix `isConnectedToSharedInstance` check to look at any interface, not just the outbound one
- Add msgpack and BouncyCastle R8 keep rules to consumer-rules.pro

## Test plan
- [ ] Verify link establishment through shared instance still works
- [ ] Verify release builds don't crash from stripped classes