### PR TITLE
Fix foreground service type to avoid Android 15 time limit crash

### DIFF
--- a/rns-android/src/main/AndroidManifest.xml
+++ b/rns-android/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
 
     <!-- Service permissions -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <!-- Notification permission (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -46,7 +46,11 @@
         <service
             android:name=".ReticulumService"
             android:exported="false"
-            android:foregroundServiceType="connectedDevice" />
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Runs the Reticulum network stack for mesh networking communication" />
+        </service>
 
         <!-- Boot receiver for auto-start and app update recovery (optional, disabled by default) -->
         <receiver

--- a/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
@@ -207,7 +207,7 @@ class ReticulumService : LifecycleService() {
         sessionStartTime = System.currentTimeMillis()
 
         // Start as foreground service
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             startForeground(
                 NOTIFICATION_ID,
                 createNotification(),

--- a/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
@@ -211,7 +211,7 @@ class ReticulumService : LifecycleService() {
             startForeground(
                 NOTIFICATION_ID,
                 createNotification(),
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
             )
         } else {
             startForeground(NOTIFICATION_ID, createNotification())


### PR DESCRIPTION
## Summary
- Switch foreground service type from `connectedDevice` to `specialUse`
- `connectedDevice` is subject to a time limit on Android 15 when no physical device is connected, which crashes the service with `ForegroundServiceStartNotAllowedException`
- `specialUse` has no time limit and is appropriate for a persistent network stack daemon

## Test plan
- [ ] Verify service starts and stays running on Android 15+ device
- [ ] Verify service survives past the 6-hour dataSync window without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)