### PR TITLE
Columba native Kotlin migration — reticulum-kt changes

### DIFF
--- a/PYTHON_DEVIATIONS.md
+++ b/PYTHON_DEVIATIONS.md
@@ -64,26 +64,47 @@ Sends multicast discovery announcements every 1.6 seconds continuously
 with no adaptation. This interval is hardcoded and never changes.
 
 **Kotlin behavior** (`AutoInterface.kt:startAnnouncementLoop`):
-Starts at Python's 1.6s rate, then linearly ramps to 2 minutes over
-60 seconds after the last peer topology change. Any peer add/remove
-or network change resets to the fast 1.6s rate.
+The announce interval adapts based on peer activity and device state:
+
+| State | Announce Interval | vs Python (1.6s) |
+|-------|------------------|------------------|
+| Startup / peer change | 1.6s (+ immediate reply) | Same |
+| Stable, 30s | ~60s | 37x less |
+| Stable, 60s+ | 2 minutes | 75x less |
+| Doze, stable | 10 minutes | 375x less |
+| New peer during Doze | Immediate reply → 1.6s | Same responsiveness |
+
+The interval linearly ramps from 1.6s to `maxAnnounceIntervalMs *
+throttleMultiplier` over 60 seconds after the last peer topology
+change. Any peer add/remove resets to fast mode AND triggers an
+immediate announce so the new peer discovers us within ~1 second.
+
+Doze awareness: `NativeReticulumProtocol` observes `DozeStateObserver`
+and sets `AutoInterface.throttleMultiplier` to 5.0 during Doze,
+scaling the max interval from 2 minutes to 10 minutes.
 
 **Why**: Continuous 1.6s multicast is the single biggest battery drain
 on the native stack. Receiving other nodes' multicast is free (blocking
-socket.receive), but sending wakes the radio every 1.6s indefinitely.
-Since peer discovery is symmetric, other nodes sending at their rate
-still discover us via receiving — we only need to send often enough
-that they discover us within a reasonable time.
+`socket.receive()`), but sending wakes the WiFi radio every 1.6s
+indefinitely. Since peer discovery is symmetric, other nodes sending
+at their rate still discover us via receiving — we only need to send
+often enough that they discover us within a reasonable time.
+
+**Multicast socket cleanup**: Kotlin explicitly calls `leaveGroup()`
+before closing multicast sockets on detach, preventing OS-level
+multicast group membership from lingering after the interface is
+stopped. Python relies on `socket.close()` for implicit cleanup.
 
 **Risk**: Low. A node running Kotlin at 2-minute intervals next to a
 node running Python at 1.6s will still discover each other: the Python
-node's multicast arrives within 1.6s, and the Kotlin node's arrives
-within 2 minutes. After discovery, unicast data flow is unaffected.
-The fast 1.6s rate on startup and peer changes ensures rapid initial
-discovery.
+node's multicast arrives within 1.6s, and the Kotlin node's immediate
+reply fires within ~1 second. After discovery, unicast data flow is
+unaffected.
 
 **Resolution**: This is an intentional improvement, not a workaround.
-Could be made configurable if exact Python behavior is needed.
+`throttleMultiplier` can be set to 1.0 and `maxAnnounceIntervalMs`
+can be set to `ANNOUNCE_INTERVAL_MS` to match exact Python behavior
+if needed.
 
 ---
 

--- a/PYTHON_DEVIATIONS.md
+++ b/PYTHON_DEVIATIONS.md
@@ -1,0 +1,119 @@
+# Python Reference Implementation Deviations
+
+This document tracks intentional behavioral differences between the
+Kotlin (reticulum-kt) implementation and the Python reference (RNS).
+Each entry explains **what** differs, **why**, and the **risk**.
+
+Python is always the ground truth. Deviations documented here are
+temporary workarounds or conscious trade-offs, not design choices.
+
+---
+
+## Transport: Ingress-Limited Announces Processed Locally
+
+**Python behavior** (`Transport.py:328-331`):
+When `should_ingress_limit()` is true for an unknown destination,
+Python calls `interface.hold_announce(packet)` and returns immediately.
+The announce is not processed locally. Later, `process_held_announces()`
+re-injects held announces when the burst subsides.
+
+**Kotlin behavior** (`Transport.kt:processAnnounce`):
+When ingress-limited, Kotlin processes the announce locally (learns
+the path, stores identity, notifies handlers) but skips retransmission
+to other interfaces. The announce is also held for later re-injection,
+but `processHeldAnnounces()` is a no-op stub.
+
+**Why**: Without a working `processHeldAnnounces`, the Python approach
+causes paths to never be learned for new destinations discovered during
+high-traffic periods. This breaks link establishment, NomadNet browsing,
+and any feature that depends on `Identity.recall()` or `Transport.hasPath()`.
+
+**Risk**: Low. The local processing is strictly additive — we learn
+a path that Python would eventually learn when held announces are
+re-injected. The only difference is timing (immediate vs deferred)
+and that we don't retransmit the announce to other interfaces.
+
+**Resolution**: Implement `processHeldAnnounces()` to match Python,
+then revert to Python's hold-and-return behavior.
+
+---
+
+## Transport: Stale Path Entry Removal on Outbound
+
+**Python behavior** (`Transport.py:load_path_table`):
+When loading persisted paths on startup, Python resolves the stored
+interface hash to a live interface object. If `find_interface_from_hash()`
+returns `None`, the path entry is simply not loaded (line 105:
+"The interface is no longer available").
+
+**Kotlin behavior** (`Transport.kt:processOutbound`):
+Kotlin loads all persisted paths regardless of interface availability.
+During outbound routing, if `findInterfaceByHash()` returns null for
+a path entry, Kotlin removes the stale entry from the path table at
+that point and falls through to broadcast.
+
+**Why**: Kotlin's path persistence loads paths before all interfaces
+are registered (AutoInterface/discovered interfaces register later).
+Filtering at load time would discard valid paths for interfaces that
+haven't connected yet.
+
+**Risk**: Low. The end result is the same — stale paths are eventually
+removed. The timing differs (Python: at load; Kotlin: at first use).
+
+**Resolution**: Add a deferred path validation pass after all interfaces
+are registered, matching Python's load-time filtering.
+
+---
+
+## Transport: processHeldAnnounces Not Implemented
+
+**Python behavior**: `Interface.process_held_announces()` is called
+periodically by the Transport jobs loop. It re-injects held announces
+when the ingress rate drops below the threshold.
+
+**Kotlin behavior**: `processHeldAnnounces()` is a no-op stub.
+Held announces are never re-injected.
+
+**Why**: The ingress-limited-local-processing deviation above mitigates
+the impact for local functionality. Full implementation requires porting
+the interface-level held announce queue and the periodic job timer.
+
+**Risk**: Medium. Announces that should be retransmitted to other
+interfaces after the burst subsides are lost. This affects announce
+propagation across the network but not local path/identity learning.
+
+**Resolution**: Port `Interface.process_held_announces()` from Python.
+
+---
+
+## LXMRouter: Ratchet Self-Storage Removed from generateAnnounceData
+
+**Python behavior** (`Destination.py:announce()`):
+Python does NOT store the ratchet public key under the local
+destination's hash during announce generation. The ratchet public
+key is only stored by REMOTE nodes that receive the announce.
+
+**Kotlin behavior (before fix)**:
+`generateAnnounceData()` called `setRatchetForDestination(hash, ratchetPub)`
+and `Identity.rememberRatchet(hash, ratchetPub)`, storing the ratchet
+public key under the local destination hash. This confused the
+`Destination.encrypt()` path because `Identity.get_ratchet(destHash)`
+would find a public key for a LOCAL destination and use it instead
+of the identity's base key.
+
+**Kotlin behavior (after fix)**: Matches Python — removed self-storage.
+
+**Risk**: None. This was a bug fix, not a deviation.
+
+---
+
+## Conformance Test Status
+
+78 of 79 conformance tests pass (only `bz2_compress` differs due to
+library version producing different but equally valid compressed output).
+
+All 4 ratchet lifecycle tests pass, including:
+- Announce with ratchet pack/unpack
+- Ratchet extraction from announce
+- Full lifecycle encrypt/decrypt
+- Cross-implementation encrypt/decrypt

--- a/PYTHON_DEVIATIONS.md
+++ b/PYTHON_DEVIATIONS.md
@@ -9,35 +9,6 @@ temporary workarounds or conscious trade-offs, not design choices.
 
 ---
 
-## Transport: Ingress-Limited Announces Processed Locally
-
-**Python behavior** (`Transport.py:328-331`):
-When `should_ingress_limit()` is true for an unknown destination,
-Python calls `interface.hold_announce(packet)` and returns immediately.
-The announce is not processed locally. Later, `process_held_announces()`
-re-injects held announces when the burst subsides.
-
-**Kotlin behavior** (`Transport.kt:processAnnounce`):
-When ingress-limited, Kotlin processes the announce locally (learns
-the path, stores identity, notifies handlers) but skips retransmission
-to other interfaces. The announce is also held for later re-injection,
-but `processHeldAnnounces()` is a no-op stub.
-
-**Why**: Without a working `processHeldAnnounces`, the Python approach
-causes paths to never be learned for new destinations discovered during
-high-traffic periods. This breaks link establishment, NomadNet browsing,
-and any feature that depends on `Identity.recall()` or `Transport.hasPath()`.
-
-**Risk**: Low. The local processing is strictly additive — we learn
-a path that Python would eventually learn when held announces are
-re-injected. The only difference is timing (immediate vs deferred)
-and that we don't retransmit the announce to other interfaces.
-
-**Resolution**: Implement `processHeldAnnounces()` to match Python,
-then revert to Python's hold-and-return behavior.
-
----
-
 ## Transport: Stale Path Entry Removal on Outbound
 
 **Python behavior** (`Transport.py:load_path_table`):
@@ -62,27 +33,6 @@ removed. The timing differs (Python: at load; Kotlin: at first use).
 
 **Resolution**: Add a deferred path validation pass after all interfaces
 are registered, matching Python's load-time filtering.
-
----
-
-## Transport: processHeldAnnounces Not Implemented
-
-**Python behavior**: `Interface.process_held_announces()` is called
-periodically by the Transport jobs loop. It re-injects held announces
-when the ingress rate drops below the threshold.
-
-**Kotlin behavior**: `processHeldAnnounces()` is a no-op stub.
-Held announces are never re-injected.
-
-**Why**: The ingress-limited-local-processing deviation above mitigates
-the impact for local functionality. Full implementation requires porting
-the interface-level held announce queue and the periodic job timer.
-
-**Risk**: Medium. Announces that should be retransmitted to other
-interfaces after the burst subsides are lost. This affects announce
-propagation across the network but not local path/identity learning.
-
-**Resolution**: Port `Interface.process_held_announces()` from Python.
 
 ---
 

--- a/PYTHON_DEVIATIONS.md
+++ b/PYTHON_DEVIATIONS.md
@@ -57,6 +57,36 @@ of the identity's base key.
 
 ---
 
+## AutoInterface: Adaptive Announce Interval
+
+**Python behavior** (`AutoInterface.py:announce_handler`):
+Sends multicast discovery announcements every 1.6 seconds continuously
+with no adaptation. This interval is hardcoded and never changes.
+
+**Kotlin behavior** (`AutoInterface.kt:startAnnouncementLoop`):
+Starts at Python's 1.6s rate, then linearly ramps to 2 minutes over
+60 seconds after the last peer topology change. Any peer add/remove
+or network change resets to the fast 1.6s rate.
+
+**Why**: Continuous 1.6s multicast is the single biggest battery drain
+on the native stack. Receiving other nodes' multicast is free (blocking
+socket.receive), but sending wakes the radio every 1.6s indefinitely.
+Since peer discovery is symmetric, other nodes sending at their rate
+still discover us via receiving — we only need to send often enough
+that they discover us within a reasonable time.
+
+**Risk**: Low. A node running Kotlin at 2-minute intervals next to a
+node running Python at 1.6s will still discover each other: the Python
+node's multicast arrives within 1.6s, and the Kotlin node's arrives
+within 2 minutes. After discovery, unicast data flow is unaffected.
+The fast 1.6s rate on startup and peer changes ensures rapid initial
+discovery.
+
+**Resolution**: This is an intentional improvement, not a workaround.
+Could be made configurable if exact Python behavior is needed.
+
+---
+
 ## Conformance Test Status
 
 78 of 79 conformance tests pass (only `bz2_compress` differs due to

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-    kotlin("jvm") version "1.9.22" apply false
-    kotlin("android") version "1.9.22" apply false
-    kotlin("plugin.serialization") version "1.9.22" apply false
-    id("com.android.library") version "8.13.0" apply false
-    id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
+    kotlin("jvm") version "2.3.0" apply false
+    kotlin("plugin.serialization") version "2.3.0" apply false
+    id("com.android.library") version "9.1.0" apply false
+    id("com.google.devtools.ksp") version "2.3.6" apply false
     id("org.jetbrains.kotlinx.kover") version "0.7.6"
 }
 
@@ -23,9 +22,9 @@ subprojects {
     afterEvaluate {
         if (!plugins.hasPlugin("com.android.library") && !plugins.hasPlugin("com.android.application")) {
             tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-                kotlinOptions {
-                    jvmTarget = "21"
-                    freeCompilerArgs = listOf("-Xjsr305=strict")
+                compilerOptions {
+                    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+                    freeCompilerArgs.add("-Xjsr305=strict")
                 }
             }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm") version "1.9.22" apply false
     kotlin("android") version "1.9.22" apply false
     kotlin("plugin.serialization") version "1.9.22" apply false
-    id("com.android.library") version "8.2.2" apply false
+    id("com.android.library") version "8.13.0" apply false
     id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
     id("org.jetbrains.kotlinx.kover") version "0.7.6"
 }

--- a/conformance-bridge/build.gradle.kts
+++ b/conformance-bridge/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "1.9.22"
+    kotlin("jvm") version "2.3.0"
     application
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "9.0.0-beta12"
 }
 
 application {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/python-bridge/bridge_server.py
+++ b/python-bridge/bridge_server.py
@@ -4448,6 +4448,38 @@ def cmd_packet_parse_header(params):
     }
 
 
+
+def cmd_propagation_encrypt_for_recipient(params):
+    """
+    Encrypt data using Destination.encrypt() - the exact propagation path.
+    Creates an Identity from public key, creates an OUT destination,
+    and encrypts using Destination.encrypt().
+    """
+    RNS = _get_full_rns()
+    public_key = hex_to_bytes(params['recipient_public_key'])
+    plaintext = hex_to_bytes(params['plaintext'])
+
+    # Create a recipient identity from public key (like Identity.recall)
+    identity = RNS.Identity(create_keys=False)
+    identity.load_public_key(public_key)
+
+    # Create OUT destination (as sender would)
+    dest = RNS.Destination(identity, RNS.Destination.OUT, RNS.Destination.SINGLE, "lxmf", "delivery")
+
+    # Check for ratchets (there shouldn't be any in test)
+    selected_ratchet = RNS.Identity.get_ratchet(dest.hash)
+    used_ratchet = selected_ratchet is not None
+
+    # Encrypt using Destination.encrypt - the exact propagation code path
+    encrypted = dest.encrypt(plaintext)
+
+    return {
+        'dest_hash': bytes_to_hex(dest.hash),
+        'encrypted_data': bytes_to_hex(encrypted),
+        'identity_hash': identity.hash.hex(),
+        'used_ratchet': used_ratchet,
+    }
+
 # Command dispatcher
 COMMANDS = {
     'x25519_generate': cmd_x25519_generate,
@@ -4567,6 +4599,7 @@ COMMANDS = {
     'propagation_node_get_messages': cmd_propagation_node_get_messages,
     'propagation_node_submit_for_recipient': cmd_propagation_node_submit_for_recipient,
     'propagation_node_announce': cmd_propagation_node_announce,
+    'propagation_encrypt_for_recipient': cmd_propagation_encrypt_for_recipient,
     # Live RNS protocol operations (link, resource, ratchet)
     'rns_create_destination': cmd_rns_create_destination,
     'rns_get_established_link': cmd_rns_get_established_link,

--- a/rns-android/build.gradle.kts
+++ b/rns-android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    kotlin("android")
     id("kotlin-parcelize")
     id("com.google.devtools.ksp")
 }
@@ -9,12 +8,10 @@ val coroutinesVersion: String by project
 
 android {
     namespace = "network.reticulum.android"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26  // Android 8.0
-        targetSdk = 34
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
@@ -34,8 +31,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
     }
 
     ksp {

--- a/rns-android/schemas/network.reticulum.android.db.ReticulumDatabase/2.json
+++ b/rns-android/schemas/network.reticulum.android.db.ReticulumDatabase/2.json
@@ -1,0 +1,538 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "55cccd8e307b829ae745c581ab955fa4",
+    "entities": [
+      {
+        "tableName": "paths",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dest_hash` BLOB NOT NULL, `next_hop` BLOB NOT NULL, `hops` INTEGER NOT NULL, `expires` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `interface_hash` BLOB NOT NULL, `announce_hash` BLOB NOT NULL, `state` INTEGER NOT NULL, `failure_count` INTEGER NOT NULL, `random_blobs` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`dest_hash`))",
+        "fields": [
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextHop",
+            "columnName": "next_hop",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expires",
+            "columnName": "expires",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interfaceHash",
+            "columnName": "interface_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announceHash",
+            "columnName": "announce_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failure_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "randomBlobs",
+            "columnName": "random_blobs",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dest_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_paths_expires",
+            "unique": false,
+            "columnNames": [
+              "expires"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_paths_expires` ON `${TABLE_NAME}` (`expires`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "packet_hashes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hash` BLOB NOT NULL, `generation` INTEGER NOT NULL, PRIMARY KEY(`hash`))",
+        "fields": [
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_packet_hashes_generation",
+            "unique": false,
+            "columnNames": [
+              "generation"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_hashes_generation` ON `${TABLE_NAME}` (`generation`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "known_destinations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dest_hash` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, `packet_hash` BLOB NOT NULL, `public_key` BLOB NOT NULL, `app_data` BLOB, PRIMARY KEY(`dest_hash`))",
+        "fields": [
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetHash",
+            "columnName": "packet_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appData",
+            "columnName": "app_data",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dest_hash"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tunnels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tunnel_id` BLOB NOT NULL, `interface_hash` BLOB, `expires` INTEGER NOT NULL, PRIMARY KEY(`tunnel_id`))",
+        "fields": [
+          {
+            "fieldPath": "tunnelId",
+            "columnName": "tunnel_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interfaceHash",
+            "columnName": "interface_hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "expires",
+            "columnName": "expires",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tunnel_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tunnel_paths",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tunnel_id` BLOB NOT NULL, `dest_hash` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, `received_from` BLOB NOT NULL, `hops` INTEGER NOT NULL, `expires` INTEGER NOT NULL, `packet_hash` BLOB NOT NULL, PRIMARY KEY(`tunnel_id`, `dest_hash`), FOREIGN KEY(`tunnel_id`) REFERENCES `tunnels`(`tunnel_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "tunnelId",
+            "columnName": "tunnel_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedFrom",
+            "columnName": "received_from",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expires",
+            "columnName": "expires",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetHash",
+            "columnName": "packet_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tunnel_id",
+            "dest_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tunnel_paths_tunnel_id",
+            "unique": false,
+            "columnNames": [
+              "tunnel_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tunnel_paths_tunnel_id` ON `${TABLE_NAME}` (`tunnel_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tunnels",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tunnel_id"
+            ],
+            "referencedColumns": [
+              "tunnel_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "announce_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packet_hash` BLOB NOT NULL, `raw` BLOB NOT NULL, `interface_name` TEXT NOT NULL, PRIMARY KEY(`packet_hash`))",
+        "fields": [
+          {
+            "fieldPath": "packetHash",
+            "columnName": "packet_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raw",
+            "columnName": "raw",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interfaceName",
+            "columnName": "interface_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packet_hash"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "identity_ratchets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dest_hash` BLOB NOT NULL, `ratchet` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`dest_hash`))",
+        "fields": [
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratchet",
+            "columnName": "ratchet",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dest_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_identity_ratchets_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_identity_ratchets_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "discovered_interfaces",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`discovery_hash` BLOB NOT NULL, `type` TEXT NOT NULL, `transport` INTEGER NOT NULL, `name` TEXT NOT NULL, `received` INTEGER NOT NULL, `stamp_value` INTEGER NOT NULL, `transport_id` TEXT NOT NULL, `network_id` TEXT NOT NULL, `hops` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `height` REAL, `reachable_on` TEXT, `port` INTEGER, `frequency` INTEGER, `bandwidth` INTEGER, `spreading_factor` INTEGER, `coding_rate` INTEGER, `modulation` TEXT, `channel` INTEGER, `ifac_netname` TEXT, `ifac_netkey` TEXT, `discovered` INTEGER NOT NULL, `last_heard` INTEGER NOT NULL, `heard_count` INTEGER NOT NULL, PRIMARY KEY(`discovery_hash`))",
+        "fields": [
+          {
+            "fieldPath": "discoveryHash",
+            "columnName": "discovery_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transport",
+            "columnName": "transport",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received",
+            "columnName": "received",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stampValue",
+            "columnName": "stamp_value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "network_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reachableOn",
+            "columnName": "reachable_on",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "frequency",
+            "columnName": "frequency",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bandwidth",
+            "columnName": "bandwidth",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spreadingFactor",
+            "columnName": "spreading_factor",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "codingRate",
+            "columnName": "coding_rate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modulation",
+            "columnName": "modulation",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ifacNetname",
+            "columnName": "ifac_netname",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ifacNetkey",
+            "columnName": "ifac_netkey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "discovered",
+            "columnName": "discovered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeard",
+            "columnName": "last_heard",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "heardCount",
+            "columnName": "heard_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "discovery_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovered_interfaces_last_heard",
+            "unique": false,
+            "columnNames": [
+              "last_heard"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_interfaces_last_heard` ON `${TABLE_NAME}` (`last_heard`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '55cccd8e307b829ae745c581ab955fa4')"
+    ]
+  }
+}

--- a/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
@@ -310,6 +310,8 @@ class ReticulumService : LifecycleService() {
                 applicationContext,
                 network.reticulum.android.db.ReticulumDatabase::class.java,
                 "reticulum.db"
+            ).addMigrations(
+                network.reticulum.android.db.ReticulumDatabase.MIGRATION_1_2
             ).build()
             database = db
 

--- a/rns-android/src/main/kotlin/network/reticulum/android/ble/AndroidBLEDriver.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ble/AndroidBLEDriver.kt
@@ -164,6 +164,15 @@ class AndroidBLEDriver(
         _isRunning = true
     }
 
+    override suspend fun setScanLowPower(lowPower: Boolean) {
+        val mode = if (lowPower) BleScanner.ScanMode.LOW_POWER else BleScanner.ScanMode.BALANCED
+        Log.d(TAG, "Switching BLE scan mode to $mode")
+        if (scanner.isScanning.value) {
+            scanner.stopScanning()
+            scanner.startScanning(mode)
+        }
+    }
+
     override suspend fun stopScanning() {
         scanner.stopScanning()
     }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/ReticulumDatabase.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/ReticulumDatabase.kt
@@ -2,6 +2,8 @@ package network.reticulum.android.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import network.reticulum.android.db.dao.AnnounceCacheDao
 import network.reticulum.android.db.dao.DiscoveredInterfaceDao
 import network.reticulum.android.db.dao.IdentityRatchetDao
@@ -30,7 +32,7 @@ import network.reticulum.android.db.entity.TunnelPathEntity
         IdentityRatchetEntity::class,
         DiscoveredInterfaceEntity::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 abstract class ReticulumDatabase : RoomDatabase() {
@@ -42,4 +44,13 @@ abstract class ReticulumDatabase : RoomDatabase() {
     abstract fun announceCacheDao(): AnnounceCacheDao
     abstract fun identityRatchetDao(): IdentityRatchetDao
     abstract fun discoveredInterfaceDao(): DiscoveredInterfaceDao
+
+    companion object {
+        /** Migration 1→2: Add random_blobs column to paths table. */
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE paths ADD COLUMN random_blobs TEXT NOT NULL DEFAULT ''")
+            }
+        }
+    }
 }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/entity/PathEntity.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/entity/PathEntity.kt
@@ -30,7 +30,11 @@ data class PathEntity(
     val state: Int,
 
     @ColumnInfo(name = "failure_count")
-    val failureCount: Int
+    val failureCount: Int,
+
+    /** Serialized random blobs: hex strings joined by commas. */
+    @ColumnInfo(name = "random_blobs", defaultValue = "")
+    val randomBlobs: String = ""
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomPathStore.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomPathStore.kt
@@ -3,10 +3,12 @@ package network.reticulum.android.db.store
 import network.reticulum.android.db.dao.PathDao
 import network.reticulum.android.db.entity.PathEntity
 import network.reticulum.common.ByteArrayKey
+import network.reticulum.common.toHexString
 import network.reticulum.common.toKey
 import network.reticulum.storage.PathStore
 import network.reticulum.transport.PathEntry
 import network.reticulum.transport.PathState
+import network.reticulum.transport.TransportConstants
 import java.util.concurrent.ExecutorService
 
 class RoomPathStore(
@@ -15,6 +17,10 @@ class RoomPathStore(
 ) : PathStore {
 
     override fun upsertPath(destHash: ByteArray, entry: PathEntry) {
+        // Serialize up to PERSIST_RANDOM_BLOBS most recent blobs as hex CSV
+        val blobsCsv = entry.randomBlobs
+            .takeLast(TransportConstants.PERSIST_RANDOM_BLOBS)
+            .joinToString(",") { it.toHexString() }
         val entity = PathEntity(
             destHash = destHash.copyOf(),
             nextHop = entry.nextHop.copyOf(),
@@ -24,7 +30,8 @@ class RoomPathStore(
             interfaceHash = entry.receivingInterfaceHash.copyOf(),
             announceHash = entry.announcePacketHash.copyOf(),
             state = entry.state.ordinal,
-            failureCount = entry.failureCount
+            failureCount = entry.failureCount,
+            randomBlobs = blobsCsv
         )
         writeExecutor.execute { dao.upsert(entity) }
     }
@@ -36,18 +43,38 @@ class RoomPathStore(
 
     override fun loadAllPaths(): Map<ByteArrayKey, PathEntry> {
         return dao.getAll().associate { e ->
+            val blobs = if (e.randomBlobs.isNotBlank()) {
+                e.randomBlobs.split(",")
+                    .filter { it.isNotBlank() }
+                    .map { hex -> hexToBytes(hex) }
+                    .toMutableList()
+            } else {
+                mutableListOf()
+            }
             e.destHash.toKey() to PathEntry(
                 timestamp = e.timestamp,
                 nextHop = e.nextHop,
                 hops = e.hops,
                 expires = e.expires,
-                randomBlobs = mutableListOf(),
+                randomBlobs = blobs,
                 receivingInterfaceHash = e.interfaceHash,
                 announcePacketHash = e.announceHash,
                 state = PathState.entries.getOrElse(e.state) { PathState.ACTIVE },
                 failureCount = e.failureCount
             )
         }
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        val len = hex.length
+        val data = ByteArray(len / 2)
+        var i = 0
+        while (i < len) {
+            data[i / 2] = ((Character.digit(hex[i], 16) shl 4) +
+                Character.digit(hex[i + 1], 16)).toByte()
+            i += 2
+        }
+        return data
     }
 
     override fun removeExpiredBefore(timestampMs: Long) {

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -477,6 +477,13 @@ class Reticulum private constructor(
     private fun shutdown() {
         log("Shutting down Reticulum...")
 
+        // Persist known destinations before shutdown so identities survive restart
+        try {
+            Identity.saveKnownDestinations()
+        } catch (e: Exception) {
+            log("Error saving known destinations: ${e.message}")
+        }
+
         // Run shutdown hooks
         shutdownHooks.forEach { hook ->
             try {

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -275,6 +275,7 @@ class Reticulum private constructor(
         Transport.setCachePath(cachePath)
         Transport.setStoragePath(storagePath)
         Identity.setStoragePath(storagePath)
+        Identity.loadKnownDestinations()
 
         // Check if we should connect to an existing shared instance
         if (connectToSharedInstance) {

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -51,7 +51,7 @@ class Reticulum private constructor(
     val enableTransport: Boolean,
     val shareInstance: Boolean,
     val sharedInstancePort: Int,
-    val connectToSharedInstance: Boolean
+    val connectToSharedInstance: Boolean,
 ) {
     companion object {
         /**
@@ -132,9 +132,7 @@ class Reticulum private constructor(
          * Get the current Reticulum instance.
          * @throws IllegalStateException if not started
          */
-        fun getInstance(): Reticulum {
-            return instance ?: throw IllegalStateException("Reticulum not started")
-        }
+        fun getInstance(): Reticulum = instance ?: throw IllegalStateException("Reticulum not started")
 
         /**
          * Check if Reticulum is currently running.
@@ -156,7 +154,7 @@ class Reticulum private constructor(
             enableTransport: Boolean = false,
             shareInstance: Boolean = false,
             sharedInstancePort: Int = DEFAULT_SHARED_INSTANCE_PORT,
-            connectToSharedInstance: Boolean = false
+            connectToSharedInstance: Boolean = false,
         ): Reticulum {
             if (started.compareAndSet(false, true)) {
                 val dir = configDir ?: getDefaultConfigDir()
@@ -183,9 +181,9 @@ class Reticulum private constructor(
          */
         fun isSharedInstanceRunning(
             port: Int = DEFAULT_SHARED_INSTANCE_PORT,
-            host: String = "127.0.0.1"
-        ): Boolean {
-            return try {
+            host: String = "127.0.0.1",
+        ): Boolean =
+            try {
                 Socket().use { socket ->
                     socket.connect(InetSocketAddress(host, port), 1000)
                     true
@@ -193,7 +191,6 @@ class Reticulum private constructor(
             } catch (e: Exception) {
                 false
             }
-        }
 
         /**
          * Stop Reticulum and clean up resources.
@@ -224,9 +221,11 @@ class Reticulum private constructor(
         fun linkMtuDiscovery(): Boolean = LINK_MTU_DISCOVERY
 
         private fun log(message: String) {
-            val timestamp = java.time.LocalDateTime.now().format(
-                java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-            )
+            val timestamp =
+                java.time.LocalDateTime.now().format(
+                    java.time.format.DateTimeFormatter
+                        .ofPattern("yyyy-MM-dd HH:mm:ss.SSS"),
+                )
             println("[$timestamp] [Reticulum] $message")
         }
     }
@@ -272,9 +271,10 @@ class Reticulum private constructor(
         // Load or create transport identity
         val transportIdentity = loadOrCreateTransportIdentity()
 
-        // Configure Transport paths
+        // Configure Transport and Identity storage paths
         Transport.setCachePath(cachePath)
         Transport.setStoragePath(storagePath)
+        Identity.setStoragePath(storagePath)
 
         // Check if we should connect to an existing shared instance
         if (connectToSharedInstance) {
@@ -443,10 +443,10 @@ class Reticulum private constructor(
     /**
      * Get the path table as a map of destination hash (hex) to hop count.
      */
-    fun getPathTable(): Map<String, Int> {
-        return Transport.pathTable.mapKeys { it.key.toString() }
+    fun getPathTable(): Map<String, Int> =
+        Transport.pathTable
+            .mapKeys { it.key.toString() }
             .mapValues { it.value.hops }
-    }
 
     /**
      * Register a destination with Transport.

--- a/rns-core/src/main/kotlin/network/reticulum/destination/Destination.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/destination/Destination.kt
@@ -1436,9 +1436,10 @@ class Destination private constructor(
             ratchet = ratchetPub
             hasRatchet = true
 
-            // Store ratchet for this destination
-            setRatchetForDestination(hash, ratchet)
-            Identity.rememberRatchet(hash, ratchet)
+            // NOTE: Do not store the ratchet public key under our own hash!
+            // The ratchet public key should only be stored by REMOTE parties who receive our announce.
+            // We keep the private keys in our ratchets list for decryption.
+            // Storing the public key under our own hash would confuse the encryption logic.
         } else {
             ratchet = byteArrayOf()
             hasRatchet = false

--- a/rns-core/src/main/kotlin/network/reticulum/discovery/DiscoveryConstants.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/discovery/DiscoveryConstants.kt
@@ -10,26 +10,26 @@ object DiscoveryConstants {
     const val APP_NAME = "rnstransport"
 
     // Msgpack field keys (Discovery.py lines 8-24)
-    const val NAME            = 0xFF
-    const val TRANSPORT_ID    = 0xFE
-    const val INTERFACE_TYPE  = 0x00
-    const val TRANSPORT       = 0x01
-    const val REACHABLE_ON    = 0x02
-    const val LATITUDE        = 0x03
-    const val LONGITUDE       = 0x04
-    const val HEIGHT          = 0x05
-    const val PORT            = 0x06
-    const val IFAC_NETNAME    = 0x07
-    const val IFAC_NETKEY     = 0x08
-    const val FREQUENCY       = 0x09
-    const val BANDWIDTH       = 0x0A
+    const val NAME = 0xFF
+    const val TRANSPORT_ID = 0xFE
+    const val INTERFACE_TYPE = 0x00
+    const val TRANSPORT = 0x01
+    const val REACHABLE_ON = 0x02
+    const val LATITUDE = 0x03
+    const val LONGITUDE = 0x04
+    const val HEIGHT = 0x05
+    const val PORT = 0x06
+    const val IFAC_NETNAME = 0x07
+    const val IFAC_NETKEY = 0x08
+    const val FREQUENCY = 0x09
+    const val BANDWIDTH = 0x0A
     const val SPREADING_FACTOR = 0x0B
-    const val CODING_RATE     = 0x0C
-    const val MODULATION      = 0x0D
-    const val CHANNEL         = 0x0E
+    const val CODING_RATE = 0x0C
+    const val MODULATION = 0x0D
+    const val CHANNEL = 0x0E
 
     // Flags byte
-    const val FLAG_SIGNED: Byte    = 0x01
+    const val FLAG_SIGNED: Byte = 0x01
     const val FLAG_ENCRYPTED: Byte = 0x02
 
     // PoW parameters
@@ -37,30 +37,34 @@ object DiscoveryConstants {
     const val WORKBLOCK_EXPAND_ROUNDS = 20
 
     // Status thresholds (seconds, matching Python)
-    const val THRESHOLD_UNKNOWN = 24 * 60 * 60L        // 1 day
-    const val THRESHOLD_STALE   = 3 * 24 * 60 * 60L    // 3 days
-    const val THRESHOLD_REMOVE  = 7 * 24 * 60 * 60L    // 7 days
+    const val THRESHOLD_UNKNOWN = 24 * 60 * 60L // 1 day
+    const val THRESHOLD_STALE = 3 * 24 * 60 * 60L // 3 days
+    const val THRESHOLD_REMOVE = 7 * 24 * 60 * 60L // 7 days
 
     // Status codes (matching Python)
-    const val STATUS_STALE     = 0
-    const val STATUS_UNKNOWN   = 100
+    const val STATUS_STALE = 0
+    const val STATUS_UNKNOWN = 100
     const val STATUS_AVAILABLE = 1000
 
     // Announce timing (seconds)
     const val JOB_INTERVAL = 60L
-    const val DEFAULT_ANNOUNCE_INTERVAL = 6 * 60 * 60L  // 6 hours
-    const val MIN_ANNOUNCE_INTERVAL = 5 * 60L            // 5 minutes
+    const val DEFAULT_ANNOUNCE_INTERVAL = 6 * 60 * 60L // 6 hours
+    const val MIN_ANNOUNCE_INTERVAL = 5 * 60L // 5 minutes
 
     // Auto-connect monitoring (seconds)
     const val MONITOR_INTERVAL = 5L
     const val DETACH_THRESHOLD = 12L
 
     // Interface types that support discovery
-    val DISCOVERABLE_INTERFACE_TYPES = setOf(
-        "TCPServerInterface", "TCPClientInterface",
-        "RNodeInterface", "I2PInterface"
-    )
+    val DISCOVERABLE_INTERFACE_TYPES =
+        setOf(
+            "TCPServerInterface",
+            "TCPClientInterface",
+            "BackboneInterface",
+            "RNodeInterface",
+            "I2PInterface",
+        )
 
-    // Interface types that support auto-connect
-    val AUTOCONNECT_TYPES = setOf("TCPServerInterface")
+    // Interface types that support auto-connect (Python: BackboneInterface + TCPServerInterface)
+    val AUTOCONNECT_TYPES = setOf("BackboneInterface", "TCPServerInterface")
 }

--- a/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
@@ -6,15 +6,15 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlin.coroutines.coroutineContext
+import network.reticulum.common.ByteArrayKey
 import network.reticulum.common.toHexString
 import network.reticulum.crypto.Hashes
-import network.reticulum.common.ByteArrayKey
 import network.reticulum.transport.InterfaceRef
 import network.reticulum.transport.Transport
 import org.msgpack.core.MessagePack
 import java.io.ByteArrayOutputStream
 import java.io.File
+import kotlin.coroutines.coroutineContext
 
 /**
  * High-level interface discovery manager.
@@ -49,20 +49,24 @@ class InterfaceDiscovery(
     private data class MonitoredInterface(
         val ref: InterfaceRef,
         val endpointHash: ByteArray,
+        val endpoint: String? = null,
         var downSince: Long? = null,
     )
 
     fun start() {
-        handler = InterfaceAnnounceHandler(
-            requiredValue = requiredValue,
-            callback = ::onInterfaceDiscovered,
-            discoverySources = discoverySources,
-        )
+        handler =
+            InterfaceAnnounceHandler(
+                requiredValue = requiredValue,
+                callback = ::onInterfaceDiscovered,
+                discoverySources = discoverySources,
+            )
         Transport.registerAnnounceHandler(handler!!)
-        log("Started discovery listener (requiredValue=$requiredValue, " +
-            "sources=${discoverySources?.size ?: "any"}, " +
-            "autoConnect=${if (autoConnectFactory != null) "max $maxAutoConnected" else "disabled"}, " +
-            "storagePath=$storagePath)")
+        log(
+            "Started discovery listener (requiredValue=$requiredValue, " +
+                "sources=${discoverySources?.size ?: "any"}, " +
+                "autoConnect=${if (autoConnectFactory != null) "max $maxAutoConnected" else "disabled"}, " +
+                "storagePath=$storagePath)",
+        )
 
         // Reconnect previously discovered interfaces
         if (autoConnectFactory != null && maxAutoConnected > 0) {
@@ -79,6 +83,11 @@ class InterfaceDiscovery(
     }
 
     /**
+     * Get the set of currently auto-connected endpoint strings ("host:port").
+     */
+    fun getAutoconnectedEndpoints(): Set<String> = monitoredInterfaces.mapNotNull { it.endpoint }.toSet()
+
+    /**
      * List all discovered interfaces from disk, applying status thresholds and pruning stale entries.
      * Returns sorted by (status_code desc, stamp_value desc, last_heard desc).
      */
@@ -87,25 +96,35 @@ class InterfaceDiscovery(
         val results = mutableListOf<Pair<DiscoveredInterface, String>>()
 
         // Load from store or file system
-        val allDiscovered: List<DiscoveredInterface> = discoveryStore?.let { store ->
-            store.removeOlderThan(now - DiscoveryConstants.THRESHOLD_REMOVE)
-            store.loadAllDiscovered()
-        } ?: run {
-            val dir = discoveryDir
-            if (!dir.exists()) return results
-            dir.listFiles()?.mapNotNull { file ->
-                try { loadDiscoveredInterface(file) } catch (_: Exception) { null }
-            } ?: emptyList()
-        }
+        val allDiscovered: List<DiscoveredInterface> =
+            discoveryStore?.let { store ->
+                store.removeOlderThan(now - DiscoveryConstants.THRESHOLD_REMOVE)
+                store.loadAllDiscovered()
+            } ?: run {
+                val dir = discoveryDir
+                if (!dir.exists()) return results
+                dir.listFiles()?.mapNotNull { file ->
+                    try {
+                        loadDiscoveredInterface(file)
+                    } catch (_: Exception) {
+                        null
+                    }
+                } ?: emptyList()
+            }
 
         for (info in allDiscovered) {
             try {
                 val heardDelta = now - info.lastHeard
 
                 // Check removal thresholds
-                val shouldRemove = heardDelta > DiscoveryConstants.THRESHOLD_REMOVE
-                    || (discoverySources != null && !discoverySources.contains(
-                        ByteArrayKey(hexToBytes(info.networkId))))
+                val shouldRemove =
+                    heardDelta > DiscoveryConstants.THRESHOLD_REMOVE ||
+                        (
+                            discoverySources != null &&
+                                !discoverySources.contains(
+                                    ByteArrayKey(hexToBytes(info.networkId)),
+                                )
+                        )
 
                 if (shouldRemove) {
                     if (discoveryStore != null) {
@@ -116,11 +135,12 @@ class InterfaceDiscovery(
                     continue
                 }
 
-                val status = when {
-                    heardDelta > DiscoveryConstants.THRESHOLD_STALE -> "stale"
-                    heardDelta > DiscoveryConstants.THRESHOLD_UNKNOWN -> "unknown"
-                    else -> "available"
-                }
+                val status =
+                    when {
+                        heardDelta > DiscoveryConstants.THRESHOLD_STALE -> "stale"
+                        heardDelta > DiscoveryConstants.THRESHOLD_UNKNOWN -> "unknown"
+                        else -> "available"
+                    }
 
                 results.add(info to status)
             } catch (e: Exception) {
@@ -128,14 +148,17 @@ class InterfaceDiscovery(
             }
         }
 
-        val statusOrder = mapOf(
-            "available" to DiscoveryConstants.STATUS_AVAILABLE,
-            "unknown" to DiscoveryConstants.STATUS_UNKNOWN,
-            "stale" to DiscoveryConstants.STATUS_STALE,
+        val statusOrder =
+            mapOf(
+                "available" to DiscoveryConstants.STATUS_AVAILABLE,
+                "unknown" to DiscoveryConstants.STATUS_UNKNOWN,
+                "stale" to DiscoveryConstants.STATUS_STALE,
+            )
+        results.sortWith(
+            compareByDescending<Pair<DiscoveredInterface, String>> {
+                statusOrder[it.second] ?: 0
+            }.thenByDescending { it.first.stampValue }.thenByDescending { it.first.lastHeard },
         )
-        results.sortWith(compareByDescending<Pair<DiscoveredInterface, String>> {
-            statusOrder[it.second] ?: 0
-        }.thenByDescending { it.first.stampValue }.thenByDescending { it.first.lastHeard })
 
         val available = results.count { it.second == "available" }
         val unknown = results.count { it.second == "unknown" }
@@ -162,8 +185,10 @@ class InterfaceDiscovery(
                 }
                 val isNew = existing == null
                 discoveryStore.upsertDiscovered(info)
-                log("${if (isNew) "New" else "Updated"} discovered interface: " +
-                    "${info.type} \"${info.name}\" (heard=${info.heardCount})")
+                log(
+                    "${if (isNew) "New" else "Updated"} discovered interface: " +
+                        "${info.type} \"${info.name}\" (heard=${info.heardCount})",
+                )
             } else {
                 val file = File(discoveryDir, filename)
                 val isNew = !file.exists()
@@ -178,8 +203,10 @@ class InterfaceDiscovery(
                     info.lastHeard = info.received
                 }
                 saveDiscoveredInterface(file, info)
-                log("${if (isNew) "New" else "Updated"} discovered interface: " +
-                    "${info.type} \"${info.name}\" (heard=${info.heardCount}, file=$filename)")
+                log(
+                    "${if (isNew) "New" else "Updated"} discovered interface: " +
+                        "${info.type} \"${info.name}\" (heard=${info.heardCount}, file=$filename)",
+                )
             }
         } catch (e: Exception) {
             log("Error persisting discovered interface: ${e.message}")
@@ -209,15 +236,17 @@ class InterfaceDiscovery(
         }
 
         // Check for duplicate endpoint
-        val endpointSpecifier = buildString {
-            info.reachableOn?.let { append(it) }
-            info.port?.let { append(":$it") }
-        }
+        val endpointSpecifier =
+            buildString {
+                info.reachableOn?.let { append(it) }
+                info.port?.let { append(":$it") }
+            }
         val endpointHash = Hashes.fullHash(endpointSpecifier.toByteArray(Charsets.UTF_8))
 
-        val alreadyExists = monitoredInterfaces.any {
-            it.endpointHash.contentEquals(endpointHash)
-        }
+        val alreadyExists =
+            monitoredInterfaces.any {
+                it.endpointHash.contentEquals(endpointHash)
+            }
         if (alreadyExists) {
             log("Skipping auto-connect for ${info.name}: endpoint $endpointSpecifier already connected")
             return
@@ -225,11 +254,12 @@ class InterfaceDiscovery(
 
         try {
             log("Auto-connecting discovered interface: ${info.type} \"${info.name}\" at $endpointSpecifier")
-            val iface = autoConnectFactory.invoke(info) ?: run {
-                log("Auto-connect factory returned null for ${info.name}")
-                return
-            }
-            val monitored = MonitoredInterface(iface, endpointHash)
+            val iface =
+                autoConnectFactory.invoke(info) ?: run {
+                    log("Auto-connect factory returned null for ${info.name}")
+                    return
+                }
+            val monitored = MonitoredInterface(iface, endpointHash, endpoint = endpointSpecifier)
             monitoredInterfaces.add(monitored)
             log("Auto-connected ${info.name} (${monitoredInterfaces.size}/$maxAutoConnected)")
             startMonitorIfNeeded()
@@ -294,7 +324,10 @@ class InterfaceDiscovery(
 
     // ==================== Persistence ====================
 
-    private fun saveDiscoveredInterface(file: File, info: DiscoveredInterface) {
+    private fun saveDiscoveredInterface(
+        file: File,
+        info: DiscoveredInterface,
+    ) {
         val out = ByteArrayOutputStream()
         val packer = MessagePack.newDefaultPacker(out)
 
@@ -349,10 +382,11 @@ class InterfaceDiscovery(
         }
 
         val discoveryHash = fields["discovery_hash"]
-        val hashBytes = when (discoveryHash) {
-            is ByteArray -> discoveryHash
-            else -> return null
-        }
+        val hashBytes =
+            when (discoveryHash) {
+                is ByteArray -> discoveryHash
+                else -> return null
+            }
 
         return DiscoveredInterface(
             type = fields["type"] as? String ?: return null,
@@ -383,7 +417,10 @@ class InterfaceDiscovery(
         )
     }
 
-    private fun packValue(packer: org.msgpack.core.MessagePacker, value: Any?) {
+    private fun packValue(
+        packer: org.msgpack.core.MessagePacker,
+        value: Any?,
+    ) {
         when (value) {
             null -> packer.packNil()
             is Boolean -> packer.packBoolean(value)
@@ -403,11 +440,17 @@ class InterfaceDiscovery(
     private fun unpackValue(unpacker: org.msgpack.core.MessageUnpacker): Any? {
         val format = unpacker.nextFormat
         return when (format.valueType) {
-            org.msgpack.value.ValueType.NIL -> { unpacker.unpackNil(); null }
+            org.msgpack.value.ValueType.NIL -> {
+                unpacker.unpackNil()
+                null
+            }
             org.msgpack.value.ValueType.BOOLEAN -> unpacker.unpackBoolean()
             org.msgpack.value.ValueType.INTEGER -> {
-                try { unpacker.unpackInt() }
-                catch (_: Exception) { unpacker.unpackLong() }
+                try {
+                    unpacker.unpackInt()
+                } catch (_: Exception) {
+                    unpacker.unpackLong()
+                }
             }
             org.msgpack.value.ValueType.FLOAT -> unpacker.unpackDouble()
             org.msgpack.value.ValueType.STRING -> unpacker.unpackString()
@@ -415,7 +458,10 @@ class InterfaceDiscovery(
                 val len = unpacker.unpackBinaryHeader()
                 unpacker.readPayload(len)
             }
-            else -> { unpacker.skipValue(); null }
+            else -> {
+                unpacker.skipValue()
+                null
+            }
         }
     }
 
@@ -423,8 +469,11 @@ class InterfaceDiscovery(
         val len = hex.length
         val data = ByteArray(len / 2)
         for (i in 0 until len step 2) {
-            data[i / 2] = ((Character.digit(hex[i], 16) shl 4)
-                + Character.digit(hex[i + 1], 16)).toByte()
+            data[i / 2] =
+                (
+                    (Character.digit(hex[i], 16) shl 4) +
+                        Character.digit(hex[i + 1], 16)
+                ).toByte()
         }
         return data
     }

--- a/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
@@ -79,6 +79,19 @@ class InterfaceDiscovery(
         handler = null
         monitorJob?.cancel()
         monitorJob = null
+
+        // Disconnect all auto-connected interfaces
+        for (m in monitoredInterfaces.toList()) {
+            try {
+                Transport.deregisterInterface(m.ref)
+                m.ref.detach()
+                log("Detached auto-connected interface on stop: ${m.ref.name}")
+            } catch (e: Exception) {
+                log("Error detaching ${m.ref.name}: ${e.message}")
+            }
+        }
+        monitoredInterfaces.clear()
+
         log("Stopped discovery listener")
     }
 
@@ -102,6 +115,7 @@ class InterfaceDiscovery(
                 monitoredInterfaces.remove(m)
                 try {
                     Transport.deregisterInterface(m.ref)
+                    m.ref.detach()
                     log("Detached auto-connected interface: ${m.ref.name}")
                 } catch (e: Exception) {
                     log("Error detaching interface ${m.ref.name}: ${e.message}")

--- a/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
@@ -39,7 +39,7 @@ class InterfaceDiscovery(
     private val discoveryStore: network.reticulum.storage.DiscoveryStore? = null,
 ) {
     private var handler: InterfaceAnnounceHandler? = null
-    private val monitoredInterfaces = mutableListOf<MonitoredInterface>()
+    private val monitoredInterfaces = java.util.concurrent.CopyOnWriteArrayList<MonitoredInterface>()
     private var monitorJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 

--- a/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
@@ -84,14 +84,31 @@ class InterfaceDiscovery(
 
     /**
      * Update the auto-connect limit at runtime (no restart needed).
-     * If the new limit is higher than the current count, triggers reconnect
-     * of available discovered interfaces to fill the new slots.
+     * - If increased: connects more discovered interfaces to fill new slots.
+     * - If reduced: detaches excess auto-connected interfaces (LIFO order).
+     * - If set to 0: detaches all auto-connected interfaces.
      */
     fun setMaxAutoConnected(count: Int) {
         val old = maxAutoConnected
         maxAutoConnected = count
         log("Auto-connect limit updated: $old → $count")
-        if (count > old && autoConnectFactory != null) {
+
+        // Detach excess interfaces when limit is reduced
+        val excess = monitoredInterfaces.size - count
+        if (excess > 0) {
+            // Remove from the end (most recently added first)
+            val toDetach = monitoredInterfaces.takeLast(excess)
+            for (m in toDetach) {
+                monitoredInterfaces.remove(m)
+                try {
+                    Transport.deregisterInterface(m.ref)
+                    log("Detached auto-connected interface: ${m.ref.name}")
+                } catch (e: Exception) {
+                    log("Error detaching interface ${m.ref.name}: ${e.message}")
+                }
+            }
+        } else if (count > old && autoConnectFactory != null) {
+            // Fill new slots from known discovered interfaces
             scope.launch { connectDiscovered() }
         }
     }

--- a/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/discovery/InterfaceDiscovery.kt
@@ -33,7 +33,7 @@ class InterfaceDiscovery(
     private val requiredValue: Int = DiscoveryConstants.DEFAULT_STAMP_VALUE,
     private val discoverySources: Set<ByteArrayKey>? = null,
     private val autoConnectFactory: ((DiscoveredInterface) -> InterfaceRef?)? = null,
-    private val maxAutoConnected: Int = 0,
+    private var maxAutoConnected: Int = 0,
     private val discoveryCallback: ((DiscoveredInterface) -> Unit)? = null,
     /** Pluggable persistent storage. When null, falls back to file-based persistence. */
     private val discoveryStore: network.reticulum.storage.DiscoveryStore? = null,
@@ -80,6 +80,20 @@ class InterfaceDiscovery(
         monitorJob?.cancel()
         monitorJob = null
         log("Stopped discovery listener")
+    }
+
+    /**
+     * Update the auto-connect limit at runtime (no restart needed).
+     * If the new limit is higher than the current count, triggers reconnect
+     * of available discovered interfaces to fill the new slots.
+     */
+    fun setMaxAutoConnected(count: Int) {
+        val old = maxAutoConnected
+        maxAutoConnected = count
+        log("Auto-connect limit updated: $old → $count")
+        if (count > old && autoConnectFactory != null) {
+            scope.launch { connectDiscovered() }
+        }
     }
 
     /**

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -306,6 +306,10 @@ class Link private constructor(
     var establishmentTimeout: Long = 0
         private set
 
+    /** Expected hop count for LRPROOF validation (Python: self.expected_hops). */
+    var expectedHops: Int = 0
+        private set
+
     // Callbacks
     val callbacks = LinkCallbacks()
 
@@ -405,8 +409,9 @@ class Link private constructor(
         sigPrv = ed25519KeyPair.privateKey
         sigPub = ed25519KeyPair.publicKey
 
-        // Calculate establishment timeout
+        // Calculate establishment timeout and expected hops (Python Link.py:295-296)
         val hops = Transport.hopsTo(destination!!.hash) ?: 1
+        expectedHops = hops
         establishmentTimeout = LinkConstants.ESTABLISHMENT_TIMEOUT_PER_HOP * maxOf(1, hops) +
             LinkConstants.KEEPALIVE
 
@@ -1759,10 +1764,10 @@ class Link private constructor(
      */
     private fun processResponse(packet: Packet) {
         try {
-            System.err.println("[Link] processResponse: decrypting ${packet.data.size} bytes")
+            println("[Link] processResponse: decrypting ${packet.data.size} bytes")
             val packedResponse = decrypt(packet.data)
             if (packedResponse == null) {
-                System.err.println("[Link] processResponse: decrypt returned null!")
+                println("[Link] processResponse: decrypt returned null!")
                 return
             }
 
@@ -1809,10 +1814,10 @@ class Link private constructor(
             val transferSize = responseDataSize
 
             // Pass to handleResponse
-            System.err.println("[Link] processResponse: requestId=${requestId.joinToString("") { "%02x".format(it) }}, dataSize=$responseDataSize")
+            println("[Link] processResponse: requestId=${requestId.joinToString("") { "%02x".format(it) }}, dataSize=$responseDataSize")
             handleResponse(requestId, responseData, responseDataSize, transferSize)
         } catch (e: Exception) {
-            System.err.println("[Link] processResponse EXCEPTION: ${e.message}")
+            println("[Link] processResponse EXCEPTION: ${e.message}")
             e.printStackTrace()
         }
     }

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -1,5 +1,16 @@
 package network.reticulum.link
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import network.reticulum.Reticulum
+import network.reticulum.channel.Channel
+import network.reticulum.channel.ChannelOutlet
+import network.reticulum.channel.MessageState
 import network.reticulum.common.DestinationType
 import network.reticulum.common.PacketContext
 import network.reticulum.common.PacketType
@@ -14,20 +25,7 @@ import network.reticulum.destination.Destination
 import network.reticulum.identity.Identity
 import network.reticulum.packet.Packet
 import network.reticulum.packet.PacketReceipt
-import network.reticulum.Reticulum
 import network.reticulum.transport.Transport
-import network.reticulum.channel.Channel
-import network.reticulum.channel.ChannelOutlet
-import network.reticulum.channel.MessageState
-import network.reticulum.common.ByteArrayKey
-import network.reticulum.common.toKey
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import org.msgpack.core.MessagePack
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.ConcurrentHashMap
@@ -79,7 +77,7 @@ class Link private constructor(
     /** The owner destination for incoming links. */
     private val owner: Destination?,
     /** Encryption mode for this link. */
-    val mode: Int = LinkConstants.MODE_DEFAULT
+    val mode: Int = LinkConstants.MODE_DEFAULT,
 ) {
     companion object {
         private val linkCounter = AtomicInteger(0)
@@ -114,19 +112,20 @@ class Link private constructor(
             destination: Destination,
             establishedCallback: ((Link) -> Unit)? = null,
             closedCallback: ((Link) -> Unit)? = null,
-            mode: Int = LinkConstants.MODE_DEFAULT
+            mode: Int = LinkConstants.MODE_DEFAULT,
         ): Link {
             require(destination.type == DestinationType.SINGLE) {
                 "Links can only be established to SINGLE destination type"
             }
 
-            val link = Link(
-                crypto = defaultCryptoProvider(),
-                destination = destination,
-                initiator = true,
-                owner = null,
-                mode = mode
-            )
+            val link =
+                Link(
+                    crypto = defaultCryptoProvider(),
+                    destination = destination,
+                    initiator = true,
+                    owner = null,
+                    mode = mode,
+                )
 
             establishedCallback?.let { link.callbacks.linkEstablished = it }
             closedCallback?.let { link.callbacks.linkClosed = it }
@@ -143,9 +142,14 @@ class Link private constructor(
          * @param packet The link request packet
          * @return The new Link if valid, null otherwise
          */
-        fun validateRequest(owner: Destination, data: ByteArray, packet: Packet): Link? {
+        fun validateRequest(
+            owner: Destination,
+            data: ByteArray,
+            packet: Packet,
+        ): Link? {
             if (data.size != LinkConstants.ECPUBSIZE &&
-                data.size != LinkConstants.ECPUBSIZE + LinkConstants.LINK_MTU_SIZE) {
+                data.size != LinkConstants.ECPUBSIZE + LinkConstants.LINK_MTU_SIZE
+            ) {
                 log("Invalid link request payload size: ${data.size}")
                 return null
             }
@@ -154,13 +158,14 @@ class Link private constructor(
                 val peerPubBytes = data.copyOfRange(0, LinkConstants.KEYSIZE)
                 val peerSigPubBytes = data.copyOfRange(LinkConstants.KEYSIZE, LinkConstants.ECPUBSIZE)
 
-                val link = Link(
-                    crypto = defaultCryptoProvider(),
-                    destination = null,
-                    initiator = false,
-                    owner = owner,
-                    mode = modeFromLrPacket(packet)
-                )
+                val link =
+                    Link(
+                        crypto = defaultCryptoProvider(),
+                        destination = null,
+                        initiator = false,
+                        owner = owner,
+                        mode = modeFromLrPacket(packet),
+                    )
 
                 link.loadPeer(peerPubBytes, peerSigPubBytes)
                 link.initializeAsReceiver()
@@ -202,7 +207,6 @@ class Link private constructor(
 
                 log("Link request ${link.linkId.toHexString()} accepted")
                 link
-
             } catch (e: Exception) {
                 log("Validating link request failed: ${e.message}")
                 null
@@ -230,8 +234,8 @@ class Link private constructor(
             }
             val offset = LinkConstants.ECPUBSIZE
             return ((packet.data[offset].toInt() and 0xFF) shl 16) or
-                   ((packet.data[offset + 1].toInt() and 0xFF) shl 8) or
-                   (packet.data[offset + 2].toInt() and 0xFF) and LinkConstants.MTU_BYTEMASK
+                ((packet.data[offset + 1].toInt() and 0xFF) shl 8) or
+                (packet.data[offset + 2].toInt() and 0xFF) and LinkConstants.MTU_BYTEMASK
         }
 
         /**
@@ -247,23 +251,29 @@ class Link private constructor(
         /**
          * Create signalling bytes for MTU and mode.
          */
-        fun signallingBytes(mtu: Int, mode: Int): ByteArray {
+        fun signallingBytes(
+            mtu: Int,
+            mode: Int,
+        ): ByteArray {
             require(mode in LinkConstants.ENABLED_MODES) {
                 "Requested link mode ${LinkConstants.modeDescription(mode)} not enabled"
             }
-            val value = (mtu and LinkConstants.MTU_BYTEMASK) +
-                        (((mode shl 5) and LinkConstants.MODE_BYTEMASK) shl 16)
+            val value =
+                (mtu and LinkConstants.MTU_BYTEMASK) +
+                    (((mode shl 5) and LinkConstants.MODE_BYTEMASK) shl 16)
             return byteArrayOf(
                 ((value shr 16) and 0xFF).toByte(),
                 ((value shr 8) and 0xFF).toByte(),
-                (value and 0xFF).toByte()
+                (value and 0xFF).toByte(),
             )
         }
 
         private fun log(message: String) {
-            val timestamp = java.time.LocalDateTime.now().format(
-                java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-            )
+            val timestamp =
+                java.time.LocalDateTime.now().format(
+                    java.time.format.DateTimeFormatter
+                        .ofPattern("yyyy-MM-dd HH:mm:ss.SSS"),
+                )
             println("[$timestamp] [Link] $message")
         }
     }
@@ -345,17 +355,18 @@ class Link private constructor(
     // Attached interface/destination (public to allow initiator links to attach a destination
     // for request handling — matches Python's Link.attached_interface which is also public)
     var attachedDestination: Destination? = null
+
     // Hash of the interface this link is attached to (Python: link.attached_interface)
     var attachedInterfaceHash: ByteArray? = null
     private var remoteIdentity: Identity? = null
 
     // Cryptographic state
-    private var prv: ByteArray? = null  // X25519 private key
-    private var pub: ByteArray? = null  // X25519 public key
-    private var sigPrv: ByteArray? = null  // Ed25519 private key
-    private var sigPub: ByteArray? = null  // Ed25519 public key
-    private var peerPub: ByteArray? = null  // Peer's X25519 public key
-    private var peerSigPub: ByteArray? = null  // Peer's Ed25519 public key
+    private var prv: ByteArray? = null // X25519 private key
+    private var pub: ByteArray? = null // X25519 public key
+    private var sigPrv: ByteArray? = null // Ed25519 private key
+    private var sigPub: ByteArray? = null // Ed25519 public key
+    private var peerPub: ByteArray? = null // Peer's X25519 public key
+    private var peerSigPub: ByteArray? = null // Peer's Ed25519 public key
     private var sharedKey: ByteArray? = null
     private var derivedKey: ByteArray? = null
     private var token: Token? = null
@@ -401,23 +412,25 @@ class Link private constructor(
 
         // Query next-hop interface MTU for link MTU discovery (Python Link.py:308-314)
         val nhHwMtu = Transport.nextHopInterfaceHwMtu(destination!!.hash)
-        val signalledMtu = if (Reticulum.LINK_MTU_DISCOVERY && nhHwMtu != null) {
-            log("Signalling link MTU of $nhHwMtu for link")
-            nhHwMtu
-        } else {
-            mtu  // default RnsConstants.MTU (500)
-        }
+        val signalledMtu =
+            if (Reticulum.LINK_MTU_DISCOVERY && nhHwMtu != null) {
+                log("Signalling link MTU of $nhHwMtu for link")
+                nhHwMtu
+            } else {
+                mtu // default RnsConstants.MTU (500)
+            }
         val signallingBytes = signallingBytes(signalledMtu, mode)
         val requestData = pub!! + sigPub!! + signallingBytes
 
         // Create and send link request
-        val packet = Packet.createRaw(
-            destinationHash = destination.hash,
-            data = requestData,
-            packetType = PacketType.LINKREQUEST,
-            destinationType = destination.type,
-            transportType = TransportType.BROADCAST
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = destination.hash,
+                data = requestData,
+                packetType = PacketType.LINKREQUEST,
+                destinationType = destination.type,
+                transportType = TransportType.BROADCAST,
+            )
         packet.pack()
 
         establishmentCost += packet.raw?.size ?: 0
@@ -436,7 +449,10 @@ class Link private constructor(
     /**
      * Load peer public keys.
      */
-    private fun loadPeer(peerPubBytes: ByteArray, peerSigPubBytes: ByteArray) {
+    private fun loadPeer(
+        peerPubBytes: ByteArray,
+        peerSigPubBytes: ByteArray,
+    ) {
         this.peerPub = peerPubBytes.copyOf()
         this.peerSigPub = peerSigPubBytes.copyOf()
     }
@@ -452,8 +468,9 @@ class Link private constructor(
         pub = x25519KeyPair.publicKey
 
         // Use owner's Ed25519 signing key
-        val ownerIdentity = owner?.identity
-            ?: throw IllegalStateException("Cannot initialize receiver link: owner has no identity")
+        val ownerIdentity =
+            owner?.identity
+                ?: throw IllegalStateException("Cannot initialize receiver link: owner has no identity")
         sigPrv = ownerIdentity.sigPrv
         sigPub = ownerIdentity.sigPub
     }
@@ -481,12 +498,13 @@ class Link private constructor(
 
         // Derive encryption keys using HKDF
         val derivedKeyLength = LinkConstants.derivedKeyLength(mode)
-        derivedKey = crypto.hkdf(
-            length = derivedKeyLength,
-            ikm = sharedKey!!,
-            salt = getSalt(),
-            info = getContext()
-        )
+        derivedKey =
+            crypto.hkdf(
+                length = derivedKeyLength,
+                ikm = sharedKey!!,
+                salt = getSalt(),
+                info = getContext(),
+            )
     }
 
     /**
@@ -497,18 +515,20 @@ class Link private constructor(
         val signedData = linkId + pub!! + sigPub!! + signallingBytes
 
         // Sign with owner's identity
-        val signature = owner!!.identity!!.sign(signedData)
-            ?: throw IllegalStateException("Cannot sign link proof")
+        val signature =
+            owner!!.identity!!.sign(signedData)
+                ?: throw IllegalStateException("Cannot sign link proof")
 
         val proofData = signature + pub!! + signallingBytes
 
-        val proof = Packet.createRaw(
-            destinationHash = linkId,
-            data = proofData,
-            packetType = PacketType.PROOF,
-            context = PacketContext.LRPROOF,
-            destinationType = DestinationType.LINK
-        )
+        val proof =
+            Packet.createRaw(
+                destinationHash = linkId,
+                data = proofData,
+                packetType = PacketType.PROOF,
+                context = PacketContext.LRPROOF,
+                destinationType = DestinationType.LINK,
+            )
         proof.link = this
 
         Transport.outbound(proof)
@@ -546,8 +566,11 @@ class Link private constructor(
             val peerPubBytes = packet.data.copyOfRange(sigLength, sigLength + pubSize)
 
             // Get peer's Ed25519 public key from destination's identity
-            val peerSigPubBytes = destination!!.identity!!.getPublicKey()
-                .copyOfRange(LinkConstants.KEYSIZE, LinkConstants.ECPUBSIZE)
+            val peerSigPubBytes =
+                destination!!
+                    .identity!!
+                    .getPublicKey()
+                    .copyOfRange(LinkConstants.KEYSIZE, LinkConstants.ECPUBSIZE)
 
             loadPeer(peerPubBytes, peerSigPubBytes)
             handshake()
@@ -615,7 +638,6 @@ class Link private constructor(
             }
 
             return true
-
         } catch (e: Exception) {
             log("Error validating proof: ${e.message}")
             status = LinkConstants.CLOSED
@@ -638,8 +660,8 @@ class Link private constructor(
         val mtuOffset = sigLength + pubSize
         if (packet.data.size >= mtuOffset + LinkConstants.LINK_MTU_SIZE) {
             return ((packet.data[mtuOffset].toInt() and 0xFF) shl 16) or
-                   ((packet.data[mtuOffset + 1].toInt() and 0xFF) shl 8) or
-                   (packet.data[mtuOffset + 2].toInt() and 0xFF) and LinkConstants.MTU_BYTEMASK
+                ((packet.data[mtuOffset + 1].toInt() and 0xFF) shl 8) or
+                (packet.data[mtuOffset + 2].toInt() and 0xFF) and LinkConstants.MTU_BYTEMASK
         }
         return null
     }
@@ -677,21 +699,21 @@ class Link private constructor(
     /**
      * Sign a message using this link's signing key.
      */
-    fun sign(message: ByteArray): ByteArray {
-        return crypto.ed25519Sign(sigPrv!!, message)
-    }
+    fun sign(message: ByteArray): ByteArray = crypto.ed25519Sign(sigPrv!!, message)
 
     /**
      * Validate a signature from the peer.
      */
-    fun validate(signature: ByteArray, message: ByteArray): Boolean {
-        return try {
+    fun validate(
+        signature: ByteArray,
+        message: ByteArray,
+    ): Boolean =
+        try {
             crypto.ed25519Verify(peerSigPub!!, message, signature)
             true
         } catch (e: Exception) {
             false
         }
-    }
 
     /**
      * Generate and send a proof for a packet over this link.
@@ -706,12 +728,13 @@ class Link private constructor(
         val proofData = packet.packetHash + signature
 
         // Create proof packet addressed to this link
-        val proof = Packet.createRaw(
-            destinationHash = linkId,
-            data = proofData,
-            packetType = PacketType.PROOF,
-            destinationType = DestinationType.LINK
-        )
+        val proof =
+            Packet.createRaw(
+                destinationHash = linkId,
+                data = proofData,
+                packetType = PacketType.PROOF,
+                destinationType = DestinationType.LINK,
+            )
 
         proof.send()
         hadOutbound(isData = false)
@@ -720,9 +743,7 @@ class Link private constructor(
     /**
      * Send data over the link.
      */
-    fun send(data: ByteArray): Boolean {
-        return sendWithReceipt(data) != null
-    }
+    fun send(data: ByteArray): Boolean = sendWithReceipt(data) != null
 
     /**
      * Send data over the link and return a receipt for delivery tracking.
@@ -736,14 +757,15 @@ class Link private constructor(
         }
 
         val encrypted = encrypt(data)
-        val packet = Packet.createRaw(
-            destinationHash = linkId,
-            data = encrypted,
-            packetType = PacketType.DATA,
-            destinationType = DestinationType.LINK,
-            createReceipt = true,
-            mtu = mtu
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = linkId,
+                data = encrypted,
+                packetType = PacketType.DATA,
+                destinationType = DestinationType.LINK,
+                createReceipt = true,
+                mtu = mtu,
+            )
         packet.link = this
 
         val receipt = packet.send()
@@ -765,14 +787,15 @@ class Link private constructor(
         }
 
         log("sendResourceData: sending ${data.size} bytes (already resource-encrypted, no link encryption)")
-        val packet = Packet.createRaw(
-            destinationHash = linkId,
-            data = data,  // Send directly - already resource-level encrypted
-            packetType = PacketType.DATA,
-            destinationType = DestinationType.LINK,
-            context = PacketContext.RESOURCE,
-            mtu = mtu
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = linkId,
+                data = data, // Send directly - already resource-level encrypted
+                packetType = PacketType.DATA,
+                destinationType = DestinationType.LINK,
+                context = PacketContext.RESOURCE,
+                mtu = mtu,
+            )
         packet.link = this
 
         packet.send()
@@ -796,7 +819,9 @@ class Link private constructor(
      * ChannelOutlet implementation that wraps a Link.
      * Provides the transport layer for Channel message delivery.
      */
-    private class LinkChannelOutlet(private val link: Link) : ChannelOutlet {
+    private class LinkChannelOutlet(
+        private val link: Link,
+    ) : ChannelOutlet {
         override val mdu: Int
             get() = link.mdu
 
@@ -807,21 +832,23 @@ class Link private constructor(
             get() = link.status == LinkConstants.ACTIVE
 
         override val timedOut: Boolean
-            get() = link.status == LinkConstants.CLOSED &&
+            get() =
+                link.status == LinkConstants.CLOSED &&
                     link.teardownReason == LinkConstants.TEARDOWN_REASON_TIMEOUT
 
         override fun send(raw: ByteArray): Any? {
             if (!isUsable) return null
 
             val encrypted = link.encrypt(raw)
-            val packet = Packet.createRaw(
-                destinationHash = link.linkId,
-                data = encrypted,
-                packetType = PacketType.DATA,
-                context = PacketContext.CHANNEL,
-                destinationType = DestinationType.LINK,
-                mtu = link.mtu
-            )
+            val packet =
+                Packet.createRaw(
+                    destinationHash = link.linkId,
+                    data = encrypted,
+                    packetType = PacketType.DATA,
+                    context = PacketContext.CHANNEL,
+                    destinationType = DestinationType.LINK,
+                    mtu = link.mtu,
+                )
 
             // Use packet.send() so a PacketReceipt is created, enabling
             // delivery confirmation and timeout callbacks for Channel retry logic
@@ -852,12 +879,16 @@ class Link private constructor(
             }
         }
 
-        override fun setPacketTimeoutCallback(packet: Any, callback: ((Any) -> Unit)?, timeout: Long?) {
+        override fun setPacketTimeoutCallback(
+            packet: Any,
+            callback: ((Any) -> Unit)?,
+            timeout: Long?,
+        ) {
             if (packet !is Packet) return
             val receipt = packet.receipt ?: return
 
             if (timeout != null) {
-                receipt.setTimeout(timeout / 1000.0)  // Convert ms to seconds
+                receipt.setTimeout(timeout / 1000.0) // Convert ms to seconds
             }
 
             if (callback != null) {
@@ -867,7 +898,10 @@ class Link private constructor(
             }
         }
 
-        override fun setPacketDeliveredCallback(packet: Any, callback: ((Any) -> Unit)?) {
+        override fun setPacketDeliveredCallback(
+            packet: Any,
+            callback: ((Any) -> Unit)?,
+        ) {
             if (packet !is Packet) return
             val receipt = packet.receipt ?: return
 
@@ -878,9 +912,7 @@ class Link private constructor(
             }
         }
 
-        override fun getPacketId(packet: Any): Any {
-            return if (packet is Packet) packet.packetHash else packet
-        }
+        override fun getPacketId(packet: Any): Any = if (packet is Packet) packet.packetHash else packet
     }
 
     /**
@@ -906,7 +938,7 @@ class Link private constructor(
         responseCallback: ((RequestReceipt) -> Unit)? = null,
         failedCallback: ((RequestReceipt) -> Unit)? = null,
         progressCallback: ((RequestReceipt) -> Unit)? = null,
-        timeout: Long? = null
+        timeout: Long? = null,
     ): RequestReceipt? {
         if (status != LinkConstants.ACTIVE) {
             log("Cannot send request: link not active")
@@ -918,12 +950,13 @@ class Link private constructor(
 
         // Pack the request: [timestamp, path_hash, data]
         val timestamp = System.currentTimeMillis()
-        val packedRequest = try {
-            packRequest(timestamp, pathHash, data)
-        } catch (e: Exception) {
-            log("Error packing request: ${e.message}")
-            return null
-        }
+        val packedRequest =
+            try {
+                packRequest(timestamp, pathHash, data)
+            } catch (e: Exception) {
+                log("Error packing request: ${e.message}")
+                return null
+            }
 
         // Calculate timeout if not provided
         val actualTimeout = timeout ?: calculateRequestTimeout()
@@ -932,14 +965,15 @@ class Link private constructor(
         if (packedRequest.size <= mdu) {
             // Send as packet
             val encrypted = encrypt(packedRequest)
-            val packet = Packet.createRaw(
-                destinationHash = linkId,
-                data = encrypted,
-                packetType = PacketType.DATA,
-                context = PacketContext.REQUEST,
-                destinationType = DestinationType.LINK,
-                mtu = mtu
-            )
+            val packet =
+                Packet.createRaw(
+                    destinationHash = linkId,
+                    data = encrypted,
+                    packetType = PacketType.DATA,
+                    context = PacketContext.REQUEST,
+                    destinationType = DestinationType.LINK,
+                    mtu = mtu,
+                )
 
             packet.link = this
 
@@ -948,15 +982,16 @@ class Link private constructor(
             val requestId = packet.truncatedHash
 
             // Create the RequestReceipt
-            val receipt = RequestReceipt(
-                link = this,
-                requestId = requestId,
-                requestSize = packedRequest.size,
-                responseCallback = responseCallback,
-                failedCallback = failedCallback,
-                progressCallback = progressCallback,
-                timeout = actualTimeout
-            )
+            val receipt =
+                RequestReceipt(
+                    link = this,
+                    requestId = requestId,
+                    requestSize = packedRequest.size,
+                    responseCallback = responseCallback,
+                    failedCallback = failedCallback,
+                    progressCallback = progressCallback,
+                    timeout = actualTimeout,
+                )
 
             // Add to pending requests
             synchronized(pendingRequests) {
@@ -976,29 +1011,30 @@ class Link private constructor(
 
             // Timeout monitoring handled by watchdog checkRequestTimeouts()
             return receipt
-
         } else {
             // Send as resource (Python: Link.py:514-527)
             val requestId = Hashes.truncatedHash(packedRequest)
             log("Sending request ${requestId.toHexString()} as resource")
 
-            val requestResource = network.reticulum.resource.Resource.create(
-                data = packedRequest,
-                link = this,
-                requestId = requestId,
-                isResponse = false,
-                timeout = actualTimeout
-            )
+            val requestResource =
+                network.reticulum.resource.Resource.create(
+                    data = packedRequest,
+                    link = this,
+                    requestId = requestId,
+                    isResponse = false,
+                    timeout = actualTimeout,
+                )
 
-            val receipt = RequestReceipt(
-                link = this,
-                requestId = requestId,
-                requestSize = packedRequest.size,
-                responseCallback = responseCallback,
-                failedCallback = failedCallback,
-                progressCallback = progressCallback,
-                timeout = actualTimeout
-            )
+            val receipt =
+                RequestReceipt(
+                    link = this,
+                    requestId = requestId,
+                    requestSize = packedRequest.size,
+                    responseCallback = responseCallback,
+                    failedCallback = failedCallback,
+                    progressCallback = progressCallback,
+                    timeout = actualTimeout,
+                )
 
             synchronized(pendingRequests) {
                 pendingRequests.add(receipt)
@@ -1038,21 +1074,23 @@ class Link private constructor(
         val signedData = linkId + publicKey
 
         // Sign the data
-        val signature = identity.sign(signedData)
-            ?: return false.also { log("Failed to sign identity data") }
+        val signature =
+            identity.sign(signedData)
+                ?: return false.also { log("Failed to sign identity data") }
 
         // Build proof data: public_key + signature
         val proofData = publicKey + signature
 
         // Encrypt and send
         val encrypted = encrypt(proofData)
-        val packet = Packet.createRaw(
-            destinationHash = linkId,
-            data = encrypted,
-            packetType = PacketType.DATA,
-            context = PacketContext.LINKIDENTIFY,
-            destinationType = DestinationType.LINK
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = linkId,
+                data = encrypted,
+                packetType = PacketType.DATA,
+                context = PacketContext.LINKIDENTIFY,
+                destinationType = DestinationType.LINK,
+            )
         packet.link = this
 
         return Transport.outbound(packet).also { sent ->
@@ -1069,8 +1107,8 @@ class Link private constructor(
      * @param strategy One of ACCEPT_NONE, ACCEPT_ALL, or ACCEPT_APP
      * @return true if strategy was set successfully, false otherwise
      */
-    fun setResourceStrategy(strategy: Int): Boolean {
-        return when (strategy) {
+    fun setResourceStrategy(strategy: Int): Boolean =
+        when (strategy) {
             ACCEPT_NONE, ACCEPT_ALL, ACCEPT_APP -> {
                 resourceStrategy = strategy
                 true
@@ -1080,7 +1118,6 @@ class Link private constructor(
                 false
             }
         }
-    }
 
     /**
      * Get the current resource strategy for this link.
@@ -1103,7 +1140,11 @@ class Link private constructor(
      *
      * Format: [timestamp, path_hash, data]
      */
-    private fun packRequest(timestamp: Long, pathHash: ByteArray, data: Any?): ByteArray {
+    private fun packRequest(
+        timestamp: Long,
+        pathHash: ByteArray,
+        data: Any?,
+    ): ByteArray {
         val output = ByteArrayOutputStream()
         val packer = MessagePack.newDefaultPacker(output)
 
@@ -1122,7 +1163,10 @@ class Link private constructor(
     /**
      * Pack a generic value using msgpack.
      */
-    private fun packValue(packer: org.msgpack.core.MessagePacker, value: Any?) {
+    private fun packValue(
+        packer: org.msgpack.core.MessagePacker,
+        value: Any?,
+    ) {
         when (value) {
             null -> packer.packNil()
             is ByteArray -> {
@@ -1147,7 +1191,10 @@ class Link private constructor(
     /**
      * Pack a map using msgpack.
      */
-    private fun packMap(packer: org.msgpack.core.MessagePacker, map: Map<*, *>) {
+    private fun packMap(
+        packer: org.msgpack.core.MessagePacker,
+        map: Map<*, *>,
+    ) {
         packer.packMapHeader(map.size)
         for ((key, value) in map) {
             // Pack key
@@ -1160,7 +1207,10 @@ class Link private constructor(
     /**
      * Pack a list using msgpack.
      */
-    private fun packList(packer: org.msgpack.core.MessagePacker, list: List<*>) {
+    private fun packList(
+        packer: org.msgpack.core.MessagePacker,
+        list: List<*>,
+    ) {
         packer.packArrayHeader(list.size)
         for (item in list) {
             packValue(packer, item)
@@ -1189,12 +1239,16 @@ class Link private constructor(
         status = LinkConstants.CLOSED
 
         // Set teardown reason
-        teardownReason = if (reason == LinkConstants.TEARDOWN_REASON_UNKNOWN) {
-            if (initiator) LinkConstants.TEARDOWN_REASON_INITIATOR_CLOSED
-            else LinkConstants.TEARDOWN_REASON_DESTINATION_CLOSED
-        } else {
-            reason
-        }
+        teardownReason =
+            if (reason == LinkConstants.TEARDOWN_REASON_UNKNOWN) {
+                if (initiator) {
+                    LinkConstants.TEARDOWN_REASON_INITIATOR_CLOSED
+                } else {
+                    LinkConstants.TEARDOWN_REASON_DESTINATION_CLOSED
+                }
+            } else {
+                reason
+            }
 
         stopWatchdog()
 
@@ -1220,7 +1274,10 @@ class Link private constructor(
     /**
      * Record outbound activity.
      */
-    fun hadOutbound(isKeepalive: Boolean = false, isData: Boolean = false) {
+    fun hadOutbound(
+        isKeepalive: Boolean = false,
+        isData: Boolean = false,
+    ) {
         lastOutbound = System.currentTimeMillis()
         if (isKeepalive) {
             lastKeepalive = lastOutbound
@@ -1243,11 +1300,12 @@ class Link private constructor(
     /**
      * Get link age in milliseconds.
      */
-    fun getAge(): Long? {
-        return if (activatedAt > 0) {
+    fun getAge(): Long? =
+        if (activatedAt > 0) {
             System.currentTimeMillis() - activatedAt
-        } else null
-    }
+        } else {
+            null
+        }
 
     /**
      * Time since last inbound packet.
@@ -1261,23 +1319,17 @@ class Link private constructor(
     /**
      * Time since last outbound packet.
      */
-    fun noOutboundFor(): Long {
-        return System.currentTimeMillis() - lastOutbound
-    }
+    fun noOutboundFor(): Long = System.currentTimeMillis() - lastOutbound
 
     /**
      * Time since last data packet (excludes keepalives).
      */
-    fun noDataFor(): Long {
-        return System.currentTimeMillis() - lastData
-    }
+    fun noDataFor(): Long = System.currentTimeMillis() - lastData
 
     /**
      * Time since any activity.
      */
-    fun inactiveFor(): Long {
-        return minOf(noInboundFor(), noOutboundFor())
-    }
+    fun inactiveFor(): Long = minOf(noInboundFor(), noOutboundFor())
 
     /**
      * Get the remote peer's identity if known.
@@ -1306,19 +1358,20 @@ class Link private constructor(
         activeWatchdogs[instanceId]?.cancel()
 
         // Start new watchdog coroutine in shared scope
-        val job = watchdogScope.launch {
-            while (isActive && status != LinkConstants.CLOSED) {
-                try {
-                    delay(minOf(keepalive / 4, LinkConstants.WATCHDOG_MAX_SLEEP))
-                    checkTimeout()
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    // Normal cancellation, exit loop
-                    break
-                } catch (e: Exception) {
-                    log("Watchdog error: ${e.message}")
+        val job =
+            watchdogScope.launch {
+                while (isActive && status != LinkConstants.CLOSED) {
+                    try {
+                        delay(minOf(keepalive / 4, LinkConstants.WATCHDOG_MAX_SLEEP))
+                        checkTimeout()
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        // Normal cancellation, exit loop
+                        break
+                    } catch (e: Exception) {
+                        log("Watchdog error: ${e.message}")
+                    }
                 }
             }
-        }
 
         activeWatchdogs[instanceId] = job
     }
@@ -1416,14 +1469,15 @@ class Link private constructor(
      */
     private fun sendTeardownPacket() {
         try {
-            val teardownData = linkId  // Send link ID as teardown data
-            val packet = Packet.createRaw(
-                destinationHash = linkId,
-                data = encrypt(teardownData),
-                packetType = PacketType.DATA,
-                context = PacketContext.LINKCLOSE,
-                destinationType = DestinationType.LINK
-            )
+            val teardownData = linkId // Send link ID as teardown data
+            val packet =
+                Packet.createRaw(
+                    destinationHash = linkId,
+                    data = encrypt(teardownData),
+                    packetType = PacketType.DATA,
+                    context = PacketContext.LINKCLOSE,
+                    destinationType = DestinationType.LINK,
+                )
             packet.link = this
             Transport.outbound(packet)
         } catch (e: Exception) {
@@ -1448,13 +1502,14 @@ class Link private constructor(
 
         // Encrypt and send
         val encrypted = encrypt(rttData)
-        val packet = Packet.createRaw(
-            destinationHash = linkId,
-            data = encrypted,
-            packetType = PacketType.DATA,
-            context = PacketContext.LRRTT,
-            destinationType = DestinationType.LINK
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = linkId,
+                data = encrypted,
+                packetType = PacketType.DATA,
+                context = PacketContext.LRRTT,
+                destinationType = DestinationType.LINK,
+            )
         packet.link = this
 
         Transport.outbound(packet)
@@ -1468,13 +1523,14 @@ class Link private constructor(
     private fun sendKeepalive() {
         if (status != LinkConstants.ACTIVE && status != LinkConstants.STALE) return
 
-        val packet = Packet.createRaw(
-            destinationHash = linkId,
-            data = byteArrayOf(0xFF.toByte()),
-            packetType = PacketType.DATA,
-            context = PacketContext.KEEPALIVE,
-            destinationType = DestinationType.LINK
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = linkId,
+                data = byteArrayOf(0xFF.toByte()),
+                packetType = PacketType.DATA,
+                context = PacketContext.KEEPALIVE,
+                destinationType = DestinationType.LINK,
+            )
         packet.link = this
 
         Transport.outbound(packet)
@@ -1499,16 +1555,20 @@ class Link private constructor(
     fun receive(packet: Packet) {
         // Skip closed links, and skip initiator keepalive responses
         if (status == LinkConstants.CLOSED) return
-        if (initiator && packet.context == PacketContext.KEEPALIVE &&
-            packet.data.contentEquals(byteArrayOf(0xFF.toByte()))) {
+        if (initiator &&
+            packet.context == PacketContext.KEEPALIVE &&
+            packet.data.contentEquals(byteArrayOf(0xFF.toByte()))
+        ) {
             return
         }
 
         // Verify packet arrived on expected interface (Python: Link.py:982-983)
         val expectedIface = attachedInterfaceHash
         val receivedIface = packet.receivingInterfaceHash
-        if (expectedIface != null && receivedIface != null &&
-            !expectedIface.contentEquals(receivedIface)) {
+        if (expectedIface != null &&
+            receivedIface != null &&
+            !expectedIface.contentEquals(receivedIface)
+        ) {
             log("Link packet received on unexpected interface, ignoring")
             return
         }
@@ -1611,10 +1671,11 @@ class Link private constructor(
             try {
                 val publicKey = plaintext.copyOfRange(0, RnsConstants.IDENTITY_PUBLIC_KEY_SIZE)
                 val signedData = linkId + publicKey
-                val signature = plaintext.copyOfRange(
-                    RnsConstants.IDENTITY_PUBLIC_KEY_SIZE,
-                    RnsConstants.IDENTITY_PUBLIC_KEY_SIZE + RnsConstants.SIGNATURE_SIZE
-                )
+                val signature =
+                    plaintext.copyOfRange(
+                        RnsConstants.IDENTITY_PUBLIC_KEY_SIZE,
+                        RnsConstants.IDENTITY_PUBLIC_KEY_SIZE + RnsConstants.SIGNATURE_SIZE,
+                    )
 
                 // Load and validate the identity
                 val identity = Identity.fromPublicKey(publicKey)
@@ -1652,7 +1713,9 @@ class Link private constructor(
             val packedRequest = decrypt(packet.data) ?: return
 
             // Unpack msgpack request: [timestamp, pathHash, data]
-            val unpacker = org.msgpack.core.MessagePack.newDefaultUnpacker(packedRequest)
+            val unpacker =
+                org.msgpack.core.MessagePack
+                    .newDefaultUnpacker(packedRequest)
             val arraySize = unpacker.unpackArrayHeader()
             if (arraySize != 3) {
                 log("Invalid request format: expected 3 elements, got $arraySize")
@@ -1662,29 +1725,30 @@ class Link private constructor(
             // Python sends time.time() which is a float; Kotlin uses millis (Long).
             // Accept both integer and float timestamps from msgpack.
             val nextFormat = unpacker.nextFormat
-            val timestamp = if (nextFormat.valueType == org.msgpack.value.ValueType.FLOAT) {
-                unpacker.unpackDouble().toLong()
-            } else {
-                unpacker.unpackLong()
-            }
+            val timestamp =
+                if (nextFormat.valueType == org.msgpack.value.ValueType.FLOAT) {
+                    unpacker.unpackDouble().toLong()
+                } else {
+                    unpacker.unpackLong()
+                }
             val pathHashSize = unpacker.unpackBinaryHeader()
             val pathHash = ByteArray(pathHashSize)
             unpacker.readPayload(pathHash)
 
-            val requestData = if (unpacker.tryUnpackNil()) {
-                null
-            } else {
-                val dataSize = unpacker.unpackBinaryHeader()
-                val data = ByteArray(dataSize)
-                unpacker.readPayload(data)
-                data
-            }
+            val requestData =
+                if (unpacker.tryUnpackNil()) {
+                    null
+                } else {
+                    val dataSize = unpacker.unpackBinaryHeader()
+                    val data = ByteArray(dataSize)
+                    unpacker.readPayload(data)
+                    data
+                }
             unpacker.close()
 
             // Pass to handleRequest
             val unpackedRequest = listOf(timestamp, pathHash, requestData)
             handleRequest(requestId, unpackedRequest)
-
         } catch (e: Exception) {
             log("Error processing request: ${e.message}")
         }
@@ -1695,11 +1759,18 @@ class Link private constructor(
      */
     private fun processResponse(packet: Packet) {
         try {
-            val packedResponse = decrypt(packet.data) ?: return
+            System.err.println("[Link] processResponse: decrypting ${packet.data.size} bytes")
+            val packedResponse = decrypt(packet.data)
+            if (packedResponse == null) {
+                System.err.println("[Link] processResponse: decrypt returned null!")
+                return
+            }
 
             // Unpack msgpack response: [requestId, responseData]
             // The responseData can be any msgpack type (binary, array, map, etc.)
-            val unpacker = org.msgpack.core.MessagePack.newDefaultUnpacker(packedResponse)
+            val unpacker =
+                org.msgpack.core.MessagePack
+                    .newDefaultUnpacker(packedResponse)
             val arraySize = unpacker.unpackArrayHeader()
             if (arraySize != 2) {
                 log("Invalid response format: expected 2 elements, got $arraySize")
@@ -1716,29 +1787,33 @@ class Link private constructor(
             val responseValue = unpacker.unpackValue()
             unpacker.close()
 
-            val responseData: ByteArray? = when {
-                responseValue.isNilValue -> null
-                responseValue.isBinaryValue -> responseValue.asBinaryValue().asByteArray()
-                responseValue.isStringValue -> responseValue.asStringValue().asByteArray()
-                else -> {
-                    // For complex types (arrays, maps), re-serialize to msgpack bytes
-                    val responseBuffer = ByteArrayOutputStream()
-                    val responsePacker = org.msgpack.core.MessagePack.newDefaultPacker(responseBuffer)
-                    responseValue.writeTo(responsePacker)
-                    responsePacker.close()
-                    responseBuffer.toByteArray()
+            val responseData: ByteArray? =
+                when {
+                    responseValue.isNilValue -> null
+                    responseValue.isBinaryValue -> responseValue.asBinaryValue().asByteArray()
+                    responseValue.isStringValue -> responseValue.asStringValue().asByteArray()
+                    else -> {
+                        // For complex types (arrays, maps), re-serialize to msgpack bytes
+                        val responseBuffer = ByteArrayOutputStream()
+                        val responsePacker =
+                            org.msgpack.core.MessagePack
+                                .newDefaultPacker(responseBuffer)
+                        responseValue.writeTo(responsePacker)
+                        responsePacker.close()
+                        responseBuffer.toByteArray()
+                    }
                 }
-            }
 
             // Calculate transfer size
             val responseDataSize = responseData?.size ?: 0
             val transferSize = responseDataSize
 
             // Pass to handleResponse
+            System.err.println("[Link] processResponse: requestId=${requestId.joinToString("") { "%02x".format(it) }}, dataSize=$responseDataSize")
             handleResponse(requestId, responseData, responseDataSize, transferSize)
-
         } catch (e: Exception) {
-            log("Error processing response: ${e.message}")
+            System.err.println("[Link] processResponse EXCEPTION: ${e.message}")
+            e.printStackTrace()
         }
     }
 
@@ -1762,22 +1837,23 @@ class Link private constructor(
 
             // Unpack msgpack RTT value from plaintext
             // Python sends RTT as a float in seconds
-            val remoteRtt = try {
-                val unpacker = MessagePack.newDefaultUnpacker(plaintext)
-                val rttSeconds = unpacker.unpackDouble()
-                unpacker.close()
-                (rttSeconds * 1000).toLong()  // Convert seconds to ms
-            } catch (e: Exception) {
-                // Fallback: try as float
+            val remoteRtt =
                 try {
                     val unpacker = MessagePack.newDefaultUnpacker(plaintext)
-                    val rttSeconds = unpacker.unpackFloat()
+                    val rttSeconds = unpacker.unpackDouble()
                     unpacker.close()
-                    (rttSeconds * 1000).toLong()
-                } catch (e2: Exception) {
-                    measuredRtt  // Use measured if unpacking fails
+                    (rttSeconds * 1000).toLong() // Convert seconds to ms
+                } catch (e: Exception) {
+                    // Fallback: try as float
+                    try {
+                        val unpacker = MessagePack.newDefaultUnpacker(plaintext)
+                        val rttSeconds = unpacker.unpackFloat()
+                        unpacker.close()
+                        (rttSeconds * 1000).toLong()
+                    } catch (e2: Exception) {
+                        measuredRtt // Use measured if unpacking fails
+                    }
                 }
-            }
 
             // Use max of measured and remote RTT
             rtt = maxOf(measuredRtt, remoteRtt)
@@ -1819,11 +1895,12 @@ class Link private constructor(
             // Verify the close is for this link
             if (plaintext.contentEquals(linkId)) {
                 log("Received link close packet")
-                val closeReason = if (initiator) {
-                    LinkConstants.TEARDOWN_REASON_DESTINATION_CLOSED
-                } else {
-                    LinkConstants.TEARDOWN_REASON_INITIATOR_CLOSED
-                }
+                val closeReason =
+                    if (initiator) {
+                        LinkConstants.TEARDOWN_REASON_DESTINATION_CLOSED
+                    } else {
+                        LinkConstants.TEARDOWN_REASON_INITIATOR_CLOSED
+                    }
                 teardown(closeReason)
             }
         } catch (e: Exception) {
@@ -1840,20 +1917,25 @@ class Link private constructor(
             val plaintext = decrypt(packet.data) ?: return
 
             // Parse the advertisement
-            val advertisement = network.reticulum.resource.ResourceAdvertisement.unpack(plaintext)
+            val advertisement =
+                network.reticulum.resource.ResourceAdvertisement
+                    .unpack(plaintext)
             if (advertisement == null) {
                 log("Failed to unpack resource advertisement")
                 return
             }
 
             // Check if this is a request response
-            if (network.reticulum.resource.ResourceAdvertisement.isRequest(plaintext)) {
+            if (network.reticulum.resource.ResourceAdvertisement
+                    .isRequest(plaintext)
+            ) {
                 // This is a request being sent as a resource
-                val resource = network.reticulum.resource.Resource.accept(
-                    advertisement = advertisement,
-                    link = this,
-                    callback = { res -> requestResourceConcluded(res) }
-                )
+                val resource =
+                    network.reticulum.resource.Resource.accept(
+                        advertisement = advertisement,
+                        link = this,
+                        callback = { res -> requestResourceConcluded(res) },
+                    )
                 if (resource != null) {
                     registerIncomingResource(resource)
                 }
@@ -1861,24 +1943,34 @@ class Link private constructor(
             }
 
             // Check if this is a response to a pending request
-            if (network.reticulum.resource.ResourceAdvertisement.isResponse(plaintext)) {
-                val requestId = network.reticulum.resource.ResourceAdvertisement.readRequestId(plaintext)
+            if (network.reticulum.resource.ResourceAdvertisement
+                    .isResponse(plaintext)
+            ) {
+                val requestId =
+                    network.reticulum.resource.ResourceAdvertisement
+                        .readRequestId(plaintext)
                 if (requestId != null) {
                     // Find matching pending request
-                    val pendingRequest = synchronized(pendingRequests) {
-                        pendingRequests.find { it.requestId.contentEquals(requestId) }
-                    }
+                    val pendingRequest =
+                        synchronized(pendingRequests) {
+                            pendingRequests.find { it.requestId.contentEquals(requestId) }
+                        }
 
                     if (pendingRequest != null) {
-                        val resource = network.reticulum.resource.Resource.accept(
-                            advertisement = advertisement,
-                            link = this,
-                            callback = { res -> responseResourceConcluded(res) },
-                            progressCallback = { res -> pendingRequest.updateProgress(res.progress) }
-                        )
+                        val resource =
+                            network.reticulum.resource.Resource.accept(
+                                advertisement = advertisement,
+                                link = this,
+                                callback = { res -> responseResourceConcluded(res) },
+                                progressCallback = { res -> pendingRequest.updateProgress(res.progress) },
+                            )
                         if (resource != null) {
-                            val responseSize = network.reticulum.resource.ResourceAdvertisement.readSize(plaintext)
-                            val transferSize = network.reticulum.resource.ResourceAdvertisement.readTransferSize(plaintext)
+                            val responseSize =
+                                network.reticulum.resource.ResourceAdvertisement
+                                    .readSize(plaintext)
+                            val transferSize =
+                                network.reticulum.resource.ResourceAdvertisement
+                                    .readTransferSize(plaintext)
                             if (responseSize != null) {
                                 pendingRequest.responseSize = responseSize
                             }
@@ -1902,15 +1994,17 @@ class Link private constructor(
             when (resourceStrategy) {
                 ACCEPT_NONE -> {
                     log("Rejecting resource ${advertisement.hash.toHexString()} (strategy: ACCEPT_NONE)")
-                    network.reticulum.resource.Resource.reject(advertisement, this)
+                    network.reticulum.resource.Resource
+                        .reject(advertisement, this)
                 }
                 ACCEPT_ALL -> {
                     log("Accepting resource ${advertisement.hash.toHexString()} (strategy: ACCEPT_ALL)")
-                    val resource = network.reticulum.resource.Resource.accept(
-                        advertisement = advertisement,
-                        link = this,
-                        callback = { res -> resourceConcluded(res) }
-                    )
+                    val resource =
+                        network.reticulum.resource.Resource.accept(
+                            advertisement = advertisement,
+                            link = this,
+                            callback = { res -> resourceConcluded(res) },
+                        )
                     if (resource != null) {
                         registerIncomingResource(resource)
                         callbacks.resourceStarted?.let { callback ->
@@ -1930,11 +2024,12 @@ class Link private constructor(
                         try {
                             if (callback(advertisement)) {
                                 log("Accepting resource ${advertisement.hash.toHexString()} (strategy: ACCEPT_APP, callback returned true)")
-                                val resource = network.reticulum.resource.Resource.accept(
-                                    advertisement = advertisement,
-                                    link = this,
-                                    callback = { res -> resourceConcluded(res) }
-                                )
+                                val resource =
+                                    network.reticulum.resource.Resource.accept(
+                                        advertisement = advertisement,
+                                        link = this,
+                                        callback = { res -> resourceConcluded(res) },
+                                    )
                                 if (resource != null) {
                                     registerIncomingResource(resource)
                                     callbacks.resourceStarted?.let { startCallback ->
@@ -1949,19 +2044,21 @@ class Link private constructor(
                                 }
                             } else {
                                 log("Rejecting resource ${advertisement.hash.toHexString()} (strategy: ACCEPT_APP, callback returned false)")
-                                network.reticulum.resource.Resource.reject(advertisement, this)
+                                network.reticulum.resource.Resource
+                                    .reject(advertisement, this)
                             }
                         } catch (e: Exception) {
                             log("Error in resource callback: ${e.message}")
-                            network.reticulum.resource.Resource.reject(advertisement, this)
+                            network.reticulum.resource.Resource
+                                .reject(advertisement, this)
                         }
                     } else {
                         log("Rejecting resource ${advertisement.hash.toHexString()} (strategy: ACCEPT_APP, no callback set)")
-                        network.reticulum.resource.Resource.reject(advertisement, this)
+                        network.reticulum.resource.Resource
+                            .reject(advertisement, this)
                     }
                 }
             }
-
         } catch (e: Exception) {
             log("Error processing resource advertisement: ${e.message}")
         }
@@ -1978,32 +2075,35 @@ class Link private constructor(
             // Format is either:
             // - [flags][hash] for normal requests
             // - [HASHMAP_IS_EXHAUSTED][maphash][hash] for exhausted hashmap requests
-            val resourceHash = if (plaintext.isNotEmpty() &&
-                plaintext[0].toInt() and 0xFF == network.reticulum.resource.ResourceConstants.HASHMAP_IS_EXHAUSTED) {
-                // Exhausted hashmap format: skip first byte + MAPHASH_LEN
-                val offset = 1 + network.reticulum.resource.ResourceConstants.MAPHASH_LEN
-                if (plaintext.size >= offset + RnsConstants.TRUNCATED_HASH_BYTES) {
-                    plaintext.copyOfRange(offset, offset + RnsConstants.TRUNCATED_HASH_BYTES)
+            val resourceHash =
+                if (plaintext.isNotEmpty() &&
+                    plaintext[0].toInt() and 0xFF == network.reticulum.resource.ResourceConstants.HASHMAP_IS_EXHAUSTED
+                ) {
+                    // Exhausted hashmap format: skip first byte + MAPHASH_LEN
+                    val offset = 1 + network.reticulum.resource.ResourceConstants.MAPHASH_LEN
+                    if (plaintext.size >= offset + RnsConstants.TRUNCATED_HASH_BYTES) {
+                        plaintext.copyOfRange(offset, offset + RnsConstants.TRUNCATED_HASH_BYTES)
+                    } else {
+                        log("Invalid exhausted hashmap request size: ${plaintext.size}")
+                        return
+                    }
                 } else {
-                    log("Invalid exhausted hashmap request size: ${plaintext.size}")
-                    return
+                    // Normal format: skip first byte (flags)
+                    if (plaintext.size >= 1 + RnsConstants.TRUNCATED_HASH_BYTES) {
+                        plaintext.copyOfRange(1, 1 + RnsConstants.TRUNCATED_HASH_BYTES)
+                    } else {
+                        log("Invalid resource request size: ${plaintext.size}")
+                        return
+                    }
                 }
-            } else {
-                // Normal format: skip first byte (flags)
-                if (plaintext.size >= 1 + RnsConstants.TRUNCATED_HASH_BYTES) {
-                    plaintext.copyOfRange(1, 1 + RnsConstants.TRUNCATED_HASH_BYTES)
-                } else {
-                    log("Invalid resource request size: ${plaintext.size}")
-                    return
-                }
-            }
 
             // Find matching outgoing resource - compare truncated hash (first 16 bytes)
-            val resource = synchronized(outgoingResources) {
-                outgoingResources.find {
-                    it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+            val resource =
+                synchronized(outgoingResources) {
+                    outgoingResources.find {
+                        it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+                    }
                 }
-            }
 
             if (resource == null) {
                 log("Received request for unknown resource: ${resourceHash.toHexString()}")
@@ -2013,7 +2113,6 @@ class Link private constructor(
             // Process the request - send requested parts
             log("Processing request for resource ${resourceHash.toHexString()}")
             resource.handleRequest(plaintext)
-
         } catch (e: Exception) {
             log("Error processing resource request: ${e.message}")
         }
@@ -2035,11 +2134,12 @@ class Link private constructor(
             val resourceHash = plaintext.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES)
 
             // Find matching incoming resource - compare truncated hash (first 16 bytes)
-            val resource = synchronized(incomingResources) {
-                incomingResources.find {
-                    it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+            val resource =
+                synchronized(incomingResources) {
+                    incomingResources.find {
+                        it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+                    }
                 }
-            }
 
             if (resource == null) {
                 log("Received HMU for unknown resource: ${resourceHash.toHexString()}")
@@ -2049,7 +2149,6 @@ class Link private constructor(
             // Process hashmap update - update received parts and request next
             log("Processing HMU for resource ${resourceHash.toHexString()}")
             resource.handleHashmapUpdate(plaintext)
-
         } catch (e: Exception) {
             log("Error processing resource HMU: ${e.message}")
         }
@@ -2072,11 +2171,12 @@ class Link private constructor(
 
             // Find matching incoming resource (we're receiving, initiator is cancelling)
             // Compare truncated hash (first 16 bytes)
-            val resource = synchronized(incomingResources) {
-                incomingResources.find {
-                    it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+            val resource =
+                synchronized(incomingResources) {
+                    incomingResources.find {
+                        it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+                    }
                 }
-            }
 
             if (resource == null) {
                 log("Received ICL for unknown resource: ${resourceHash.toHexString()}")
@@ -2085,7 +2185,6 @@ class Link private constructor(
 
             log("Initiator cancelled resource ${resourceHash.toHexString()}")
             resource.cancel()
-
         } catch (e: Exception) {
             log("Error processing resource ICL: ${e.message}")
         }
@@ -2108,11 +2207,12 @@ class Link private constructor(
 
             // Find matching outgoing resource (we're sending, receiver is rejecting)
             // Compare truncated hash (first 16 bytes)
-            val resource = synchronized(outgoingResources) {
-                outgoingResources.find {
-                    it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+            val resource =
+                synchronized(outgoingResources) {
+                    outgoingResources.find {
+                        it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+                    }
                 }
-            }
 
             if (resource == null) {
                 log("Received RCL for unknown resource: ${resourceHash.toHexString()}")
@@ -2122,7 +2222,6 @@ class Link private constructor(
             log("Receiver rejected resource ${resourceHash.toHexString()}")
             // TODO: Call resource.rejected() when method is available
             resource.cancel()
-
         } catch (e: Exception) {
             log("Error processing resource RCL: ${e.message}")
         }
@@ -2140,11 +2239,12 @@ class Link private constructor(
 
             // Find matching incoming resource by trying each one
             // Resource parts are identified by their map hash, not by an explicit resource hash in the packet
-            val resource = synchronized(incomingResources) {
-                incomingResources.toList()
-            }.firstOrNull { res ->
-                res.status == network.reticulum.resource.ResourceConstants.TRANSFERRING
-            }
+            val resource =
+                synchronized(incomingResources) {
+                    incomingResources.toList()
+                }.firstOrNull { res ->
+                    res.status == network.reticulum.resource.ResourceConstants.TRANSFERRING
+                }
 
             if (resource == null) {
                 log("Received resource data but no active incoming resource")
@@ -2153,7 +2253,6 @@ class Link private constructor(
 
             // Pass the data directly - it's already resource-level encrypted, NOT link-encrypted
             resource.receivePart(packet.data)
-
         } catch (e: Exception) {
             log("Error processing resource data: ${e.message}")
         }
@@ -2165,13 +2264,14 @@ class Link private constructor(
     private fun processKeepalive(packet: Packet) {
         // Receivers respond to keepalive requests
         if (!initiator && packet.data.contentEquals(byteArrayOf(0xFF.toByte()))) {
-            val keepaliveResponse = Packet.createRaw(
-                destinationHash = linkId,
-                data = byteArrayOf(0xFE.toByte()),
-                packetType = PacketType.DATA,
-                context = PacketContext.KEEPALIVE,
-                destinationType = DestinationType.LINK
-            )
+            val keepaliveResponse =
+                Packet.createRaw(
+                    destinationHash = linkId,
+                    data = byteArrayOf(0xFE.toByte()),
+                    packetType = PacketType.DATA,
+                    context = PacketContext.KEEPALIVE,
+                    destinationType = DestinationType.LINK,
+                )
             keepaliveResponse.link = this
             Transport.outbound(keepaliveResponse)
             hadOutbound(isKeepalive = true)
@@ -2251,11 +2351,12 @@ class Link private constructor(
             val resourceHash = resourceHashFull.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES)
 
             // Find matching outgoing resource - compare truncated hash (first 16 bytes)
-            val resource = synchronized(outgoingResources) {
-                outgoingResources.find {
-                    it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+            val resource =
+                synchronized(outgoingResources) {
+                    outgoingResources.find {
+                        it.hash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES).contentEquals(resourceHash)
+                    }
                 }
-            }
 
             if (resource == null) {
                 log("Received proof for unknown resource: ${resourceHash.toHexString()}")
@@ -2270,7 +2371,6 @@ class Link private constructor(
             } else {
                 log("Proof validation failed for resource ${resourceHash.toHexString()}")
             }
-
         } catch (e: Exception) {
             log("Error processing resource proof: ${e.message}")
         }
@@ -2308,12 +2408,14 @@ class Link private constructor(
      */
     fun resourceConcluded(resource: network.reticulum.resource.Resource) {
         val concludedAt = System.currentTimeMillis()
-        val wasIncoming = synchronized(incomingResources) {
-            incomingResources.contains(resource)
-        }
-        val wasOutgoing = synchronized(outgoingResources) {
-            outgoingResources.contains(resource)
-        }
+        val wasIncoming =
+            synchronized(incomingResources) {
+                incomingResources.contains(resource)
+            }
+        val wasOutgoing =
+            synchronized(outgoingResources) {
+                outgoingResources.contains(resource)
+            }
 
         // Update statistics based on resource performance
         if (wasIncoming) {
@@ -2369,7 +2471,10 @@ class Link private constructor(
      * @param requestId The unique request identifier
      * @param unpackedRequest Array of [timestamp, pathHash, data]
      */
-    fun handleRequest(requestId: ByteArray, unpackedRequest: List<Any?>) {
+    fun handleRequest(
+        requestId: ByteArray,
+        unpackedRequest: List<Any?>,
+    ) {
         if (status != LinkConstants.ACTIVE) return
 
         try {
@@ -2382,21 +2487,23 @@ class Link private constructor(
             val targetDestination = owner ?: attachedDestination ?: return
 
             // Look up the request handler
-            val handler = targetDestination.getRequestHandler(pathHash) ?: run {
-                log("No handler found for path hash ${pathHash.toHexString()}")
-                return
-            }
+            val handler =
+                targetDestination.getRequestHandler(pathHash) ?: run {
+                    log("No handler found for path hash ${pathHash.toHexString()}")
+                    return
+                }
 
             // Check access control
-            val allowed = when (handler.allow) {
-                network.reticulum.destination.RequestPolicy.ALLOW_NONE -> false
-                network.reticulum.destination.RequestPolicy.ALLOW_ALL -> true
-                network.reticulum.destination.RequestPolicy.ALLOW_LIST -> {
-                    val remoteId = remoteIdentity
-                    remoteId != null && handler.allowedList?.any { it.contentEquals(remoteId.hash) } == true
+            val allowed =
+                when (handler.allow) {
+                    network.reticulum.destination.RequestPolicy.ALLOW_NONE -> false
+                    network.reticulum.destination.RequestPolicy.ALLOW_ALL -> true
+                    network.reticulum.destination.RequestPolicy.ALLOW_LIST -> {
+                        val remoteId = remoteIdentity
+                        remoteId != null && handler.allowedList?.any { it.contentEquals(remoteId.hash) } == true
+                    }
+                    else -> false
                 }
-                else -> false
-            }
 
             if (!allowed) {
                 val identityStr = remoteIdentity?.hexHash ?: "<Unknown>"
@@ -2407,25 +2514,25 @@ class Link private constructor(
             log("Handling request ${requestId.toHexString()} for: ${handler.path}")
 
             // Generate response
-            val response = try {
-                handler.responseGenerator(
-                    handler.path,
-                    requestData,
-                    requestId,
-                    linkId,
-                    remoteIdentity,
-                    requestedAt
-                )
-            } catch (e: Exception) {
-                log("Error in response generator: ${e.message}")
-                null
-            }
+            val response =
+                try {
+                    handler.responseGenerator(
+                        handler.path,
+                        requestData,
+                        requestId,
+                        linkId,
+                        remoteIdentity,
+                        requestedAt,
+                    )
+                } catch (e: Exception) {
+                    log("Error in response generator: ${e.message}")
+                    null
+                }
 
             // Send response if not null
             if (response != null) {
                 sendResponse(requestId, response, handler.autoCompress)
             }
-
         } catch (e: Exception) {
             log("Error handling request: ${e.message}")
         }
@@ -2438,11 +2545,17 @@ class Link private constructor(
      * @param response The response data
      * @param autoCompress Whether to auto-compress (if large enough)
      */
-    private fun sendResponse(requestId: ByteArray, response: ByteArray, autoCompress: Boolean) {
+    private fun sendResponse(
+        requestId: ByteArray,
+        response: ByteArray,
+        autoCompress: Boolean,
+    ) {
         try {
             // Pack response as msgpack: [requestId, response]
             val output = java.io.ByteArrayOutputStream()
-            val packer = org.msgpack.core.MessagePack.newDefaultPacker(output)
+            val packer =
+                org.msgpack.core.MessagePack
+                    .newDefaultPacker(output)
             packer.packArrayHeader(2)
             packer.packBinaryHeader(requestId.size)
             packer.writePayload(requestId)
@@ -2454,14 +2567,15 @@ class Link private constructor(
 
             // Send as packet if small enough, otherwise as resource
             if (packedResponse.size <= mdu) {
-                val packet = Packet.createRaw(
-                    destinationHash = linkId,
-                    data = encrypt(packedResponse),
-                    packetType = PacketType.DATA,
-                    context = PacketContext.RESPONSE,
-                    destinationType = DestinationType.LINK,
-                    mtu = mtu
-                )
+                val packet =
+                    Packet.createRaw(
+                        destinationHash = linkId,
+                        data = encrypt(packedResponse),
+                        packetType = PacketType.DATA,
+                        context = PacketContext.RESPONSE,
+                        destinationType = DestinationType.LINK,
+                        mtu = mtu,
+                    )
                 packet.link = this
                 Transport.outbound(packet)
                 hadOutbound(isData = true)
@@ -2472,7 +2586,7 @@ class Link private constructor(
                     link = this,
                     requestId = requestId,
                     isResponse = true,
-                    autoCompress = autoCompress
+                    autoCompress = autoCompress,
                 )
             }
         } catch (e: Exception) {
@@ -2494,15 +2608,16 @@ class Link private constructor(
         responseData: ByteArray?,
         responseSize: Int,
         transferSize: Int,
-        metadata: ByteArray? = null
+        metadata: ByteArray? = null,
     ) {
         if (status != LinkConstants.ACTIVE) return
 
         try {
             // Find matching pending request
-            val receipt = synchronized(pendingRequests) {
-                pendingRequests.find { it.requestId.contentEquals(requestId) }
-            }
+            val receipt =
+                synchronized(pendingRequests) {
+                    pendingRequests.find { it.requestId.contentEquals(requestId) }
+                }
 
             if (receipt == null) {
                 log("Received response for unknown request: ${requestId.toHexString()}")
@@ -2523,7 +2638,6 @@ class Link private constructor(
             synchronized(pendingRequests) {
                 pendingRequests.remove(receipt)
             }
-
         } catch (e: Exception) {
             log("Error handling response: ${e.message}")
         }
@@ -2536,15 +2650,18 @@ class Link private constructor(
      */
     fun requestResourceConcluded(resource: network.reticulum.resource.Resource) {
         if (resource.status == network.reticulum.resource.ResourceConstants.COMPLETE) {
-            val packedRequest = resource.data ?: run {
-                log("Request resource completed but has no data")
-                return
-            }
+            val packedRequest =
+                resource.data ?: run {
+                    log("Request resource completed but has no data")
+                    return
+                }
 
             // Unpack the request and compute requestId from the packed data
             // (Python: Link.py:931-940)
             val requestId = Hashes.truncatedHash(packedRequest)
-            val unpacker = org.msgpack.core.MessagePack.newDefaultUnpacker(packedRequest)
+            val unpacker =
+                org.msgpack.core.MessagePack
+                    .newDefaultUnpacker(packedRequest)
             val arraySize = unpacker.unpackArrayHeader()
             if (arraySize != 3) {
                 log("Invalid resource request format: expected 3 elements, got $arraySize")
@@ -2553,23 +2670,25 @@ class Link private constructor(
 
             // Python sends time.time() which is a float; accept both types
             val nextFormat = unpacker.nextFormat
-            val timestamp = if (nextFormat.valueType == org.msgpack.value.ValueType.FLOAT) {
-                unpacker.unpackDouble().toLong()
-            } else {
-                unpacker.unpackLong()
-            }
+            val timestamp =
+                if (nextFormat.valueType == org.msgpack.value.ValueType.FLOAT) {
+                    unpacker.unpackDouble().toLong()
+                } else {
+                    unpacker.unpackLong()
+                }
             val pathHashSize = unpacker.unpackBinaryHeader()
             val pathHash = ByteArray(pathHashSize)
             unpacker.readPayload(pathHash)
 
-            val requestData = if (unpacker.tryUnpackNil()) {
-                null
-            } else {
-                val dataSize = unpacker.unpackBinaryHeader()
-                val data = ByteArray(dataSize)
-                unpacker.readPayload(data)
-                data
-            }
+            val requestData =
+                if (unpacker.tryUnpackNil()) {
+                    null
+                } else {
+                    val dataSize = unpacker.unpackBinaryHeader()
+                    val data = ByteArray(dataSize)
+                    unpacker.readPayload(data)
+                    data
+                }
             unpacker.close()
 
             val unpackedRequest = listOf(timestamp, pathHash, requestData)
@@ -2612,7 +2731,9 @@ class Link private constructor(
 
         try {
             // Unpack response: [request_id, response_data]
-            val unpacker = org.msgpack.core.MessagePack.newDefaultUnpacker(packedResponse)
+            val unpacker =
+                org.msgpack.core.MessagePack
+                    .newDefaultUnpacker(packedResponse)
             val arraySize = unpacker.unpackArrayHeader()
             if (arraySize != 2) {
                 log("Invalid response format: expected 2 elements, got $arraySize")
@@ -2627,22 +2748,24 @@ class Link private constructor(
             val responseValue = unpacker.unpackValue()
             unpacker.close()
 
-            val responseData: ByteArray? = when {
-                responseValue.isNilValue -> null
-                responseValue.isBinaryValue -> responseValue.asBinaryValue().asByteArray()
-                responseValue.isStringValue -> responseValue.asStringValue().asByteArray()
-                else -> {
-                    val responseBuffer = ByteArrayOutputStream()
-                    val responsePacker = org.msgpack.core.MessagePack.newDefaultPacker(responseBuffer)
-                    responseValue.writeTo(responsePacker)
-                    responsePacker.close()
-                    responseBuffer.toByteArray()
+            val responseData: ByteArray? =
+                when {
+                    responseValue.isNilValue -> null
+                    responseValue.isBinaryValue -> responseValue.asBinaryValue().asByteArray()
+                    responseValue.isStringValue -> responseValue.asStringValue().asByteArray()
+                    else -> {
+                        val responseBuffer = ByteArrayOutputStream()
+                        val responsePacker =
+                            org.msgpack.core.MessagePack
+                                .newDefaultPacker(responseBuffer)
+                        responseValue.writeTo(responsePacker)
+                        responsePacker.close()
+                        responseBuffer.toByteArray()
+                    }
                 }
-            }
 
             // Pass to handleResponse
             handleResponse(requestId, responseData, packedResponse.size, resource.totalSize)
-
         } catch (e: Exception) {
             log("Error processing response resource: ${e.message}")
         }
@@ -2662,27 +2785,21 @@ class Link private constructor(
      *
      * @return RSSI value if tracking is enabled and available, null otherwise
      */
-    fun getRssi(): Int? {
-        return if (trackPhyStats) phyRssi else null
-    }
+    fun getRssi(): Int? = if (trackPhyStats) phyRssi else null
 
     /**
      * Get the SNR (Signal-to-Noise Ratio) value.
      *
      * @return SNR value if tracking is enabled and available, null otherwise
      */
-    fun getSnr(): Float? {
-        return if (trackPhyStats) phySnr else null
-    }
+    fun getSnr(): Float? = if (trackPhyStats) phySnr else null
 
     /**
      * Get the Q (link quality) value.
      *
      * @return Q value if tracking is enabled and available, null otherwise
      */
-    fun getQ(): Float? {
-        return if (trackPhyStats) phyQ else null
-    }
+    fun getQ(): Float? = if (trackPhyStats) phyQ else null
 
     /**
      * Update physical layer statistics from interface.
@@ -2692,7 +2809,11 @@ class Link private constructor(
      * @param snr SNR value
      * @param q Link quality value
      */
-    fun updatePhyStats(rssi: Int? = null, snr: Float? = null, q: Float? = null) {
+    fun updatePhyStats(
+        rssi: Int? = null,
+        snr: Float? = null,
+        q: Float? = null,
+    ) {
         if (trackPhyStats) {
             rssi?.let { phyRssi = it }
             snr?.let { phySnr = it }
@@ -2705,18 +2826,14 @@ class Link private constructor(
      *
      * @return MTU if link is active, null otherwise
      */
-    fun getMtu(): Int? {
-        return if (status == LinkConstants.ACTIVE) mtu else null
-    }
+    fun getMtu(): Int? = if (status == LinkConstants.ACTIVE) mtu else null
 
     /**
      * Get the MDU (Maximum Data Unit) for this link.
      *
      * @return MDU if link is active, null otherwise
      */
-    fun getMdu(): Int? {
-        return if (status == LinkConstants.ACTIVE) mdu else null
-    }
+    fun getMdu(): Int? = if (status == LinkConstants.ACTIVE) mdu else null
 
     /**
      * Check if a resource is in the incoming resources list.
@@ -2859,7 +2976,7 @@ class Link private constructor(
      * @return Establishment rate in bits per second if available, null otherwise
      */
     fun getEstablishmentRate(): Float? {
-        return establishmentRate?.let { it * 8 }  // Convert bytes/ms to bits/second
+        return establishmentRate?.let { it * 8 } // Convert bytes/ms to bits/second
     }
 
     /**
@@ -2867,9 +2984,7 @@ class Link private constructor(
      *
      * @return Expected rate in bits per second if available, null otherwise
      */
-    fun getExpectedRate(): Float? {
-        return if (status == LinkConstants.ACTIVE) expectedRate else null
-    }
+    fun getExpectedRate(): Float? = if (status == LinkConstants.ACTIVE) expectedRate else null
 
     override fun toString(): String = "Link[${linkId.toHexString().take(12)}]"
 }
@@ -2885,7 +3000,7 @@ class RequestReceipt(
     private val responseCallback: ((RequestReceipt) -> Unit)? = null,
     private val failedCallback: ((RequestReceipt) -> Unit)? = null,
     private val progressCallback: ((RequestReceipt) -> Unit)? = null,
-    val timeout: Long
+    val timeout: Long,
 ) {
     companion object {
         const val FAILED = 0x00
@@ -2922,7 +3037,10 @@ class RequestReceipt(
     /**
      * Called when the response is received.
      */
-    internal fun responseReceived(responseData: ByteArray?, metadata: ByteArray? = null) {
+    internal fun responseReceived(
+        responseData: ByteArray?,
+        metadata: ByteArray? = null,
+    ) {
         if (status == FAILED) return
 
         this.progress = 1.0f

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2825,6 +2825,15 @@ object Transport {
         if (effectiveUsePathRouting) {
             // We have a path - use it
             val outboundInterface = findInterfaceByHash(pathEntry!!.receivingInterfaceHash)
+            if (outboundInterface == null) {
+                // Interface no longer available (e.g., AutoInterface recreated with new hash
+                // after app restart). Drop the stale path entry — matches Python behavior
+                // (Transport.py:105: "The interface is no longer available").
+                // The broadcast fallback below will handle the packet, and a path request
+                // will naturally re-discover the route with the current interface hash.
+                log("Removing stale path for $destHex: interface hash no longer matches any registered interface")
+                pathTable.remove(packet.destinationHash.toKey())
+            }
             if (outboundInterface != null) {
                 log("Sending to $destHex via path (${pathEntry.hops} hops) on ${outboundInterface.name}")
                 if (pathEntry.hops > 1) {

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -58,8 +58,13 @@ fun interface AnnounceHandler {
 }
 
 /**
- * Extended announce handler that receives hop count and receiving interface name.
- * Implement this instead of [AnnounceHandler] to get full announce context.
+ * Extended announce handler that receives full announce context including
+ * the matched aspect, hop count, and receiving interface name.
+ *
+ * Transport determines the aspect by computing
+ * `Destination.hashFromNameAndIdentity(aspectFilter, identity)` for each
+ * registered handler and comparing against the packet's destination hash
+ * — the same approach Python uses (Transport.py:1895-1896).
  */
 interface RichAnnounceHandler : AnnounceHandler {
     fun handleAnnounceWithContext(
@@ -68,14 +73,28 @@ interface RichAnnounceHandler : AnnounceHandler {
         appData: ByteArray?,
         hops: Int,
         receivingInterfaceName: String?,
+        matchedAspect: String?,
     ): Boolean
 
     override fun handleAnnounce(
         destinationHash: ByteArray,
         announcedIdentity: Identity,
         appData: ByteArray?,
-    ): Boolean = handleAnnounceWithContext(destinationHash, announcedIdentity, appData, 0, null)
+    ): Boolean = handleAnnounceWithContext(destinationHash, announcedIdentity, appData, 0, null, null)
 }
+
+/**
+ * A handler paired with its optional aspect filter, mirroring Python's
+ * `handler.aspect_filter` attribute (Transport.py:1890).
+ *
+ * When [aspectFilter] is non-null, Transport only calls the handler for
+ * announces whose destination hash matches `Destination.hashFromNameAndIdentity(aspectFilter, identity)`.
+ * When null, the handler receives all announces.
+ */
+internal data class RegisteredHandler(
+    val handler: AnnounceHandler,
+    val aspectFilter: String?,
+)
 
 /**
  * Callback for packet delivery.
@@ -248,8 +267,11 @@ object Transport {
     /** Registered destinations. */
     private val destinations = CopyOnWriteArrayList<Destination>()
 
-    /** Registered announce handlers. */
-    private val announceHandlers = CopyOnWriteArrayList<AnnounceHandler>()
+    /** Registered announce handlers with their aspect filters. */
+    private val announceHandlers = CopyOnWriteArrayList<RegisteredHandler>()
+
+    /** Known aspects for resolving destination hashes in null-filter handlers. */
+    private val knownAspects = ConcurrentHashMap.newKeySet<String>()
 
     /** Control destination hashes (path requests, etc.). */
     private val controlHashes = ConcurrentHashMap.newKeySet<ByteArrayKey>()
@@ -439,6 +461,7 @@ object Transport {
         discoveryPathRequests.clear()
         pendingReceipts.clear()
         announceHandlers.clear()
+        knownAspects.clear()
         pendingLinks.clear()
         activeLinks.clear()
         tunnels.clear()
@@ -839,16 +862,22 @@ object Transport {
 
     /**
      * Register an announce handler.
+     *
+     * @param handler The handler to call when announces arrive
+     * @param aspectFilter If non-null, only call this handler for announces whose
+     *   destination hash matches `Destination.hashFromNameAndIdentity(aspectFilter, identity)`.
+     *   If null, the handler receives all announces. Matches Python's `handler.aspect_filter`.
      */
-    fun registerAnnounceHandler(handler: AnnounceHandler) {
-        announceHandlers.add(handler)
+    fun registerAnnounceHandler(handler: AnnounceHandler, aspectFilter: String? = null) {
+        announceHandlers.add(RegisteredHandler(handler, aspectFilter))
+        if (aspectFilter != null) knownAspects.add(aspectFilter)
     }
 
     /**
      * Deregister an announce handler.
      */
     fun deregisterAnnounceHandler(handler: AnnounceHandler) {
-        announceHandlers.remove(handler)
+        announceHandlers.removeIf { it.handler === handler }
     }
 
     // ===== Interface Discovery =====
@@ -3125,6 +3154,14 @@ object Transport {
         }
     }
 
+    /**
+     * Notify registered announce handlers, applying aspect filtering.
+     *
+     * Mirrors Python Transport.py:1884-1896:
+     * - If handler.aspect_filter is None → execute callback
+     * - Otherwise, compute hash_from_name_and_identity(aspect_filter, identity)
+     *   and only execute if it matches the packet's destination hash.
+     */
     private fun notifyAnnounceHandlers(
         destHash: ByteArray,
         identity: Identity,
@@ -3132,14 +3169,34 @@ object Transport {
         hops: Int,
         interfaceName: String?,
     ) {
-        for (handler in announceHandlers) {
+        var resolvedAspect: String? = null // cached for multiple null-filter handlers
+        for (registered in announceHandlers) {
             try {
-                val handled =
-                    if (handler is RichAnnounceHandler) {
-                        handler.handleAnnounceWithContext(destHash, identity, appData, hops, interfaceName)
+                val handler = registered.handler
+
+                // Aspect filtering (Python Transport.py:1890-1896)
+                val matchedAspect: String?
+                if (registered.aspectFilter != null) {
+                    val expectedHash = Destination.hashFromNameAndIdentity(
+                        registered.aspectFilter, identity,
+                    )
+                    if (!expectedHash.contentEquals(destHash)) continue
+                    matchedAspect = registered.aspectFilter
+                } else {
+                    // No filter — resolve aspect for RichAnnounceHandler callers
+                    matchedAspect = if (handler is RichAnnounceHandler) {
+                        resolvedAspect ?: resolveAspect(destHash, identity).also { resolvedAspect = it }
                     } else {
-                        handler.handleAnnounce(destHash, identity, appData)
+                        null
                     }
+                }
+                val handled = if (handler is RichAnnounceHandler) {
+                    handler.handleAnnounceWithContext(
+                        destHash, identity, appData, hops, interfaceName, matchedAspect,
+                    )
+                } else {
+                    handler.handleAnnounce(destHash, identity, appData)
+                }
                 if (handled) break
             } catch (e: Exception) {
                 log("Announce handler error: ${e.message}")
@@ -3147,7 +3204,28 @@ object Transport {
         }
     }
 
-    // (retransmit logic moved into processAnnounce above via retransmitAnnounce)
+    /**
+     * Resolve which aspect a destination hash belongs to by trying all
+     * known aspects. Used when a null-filter RichAnnounceHandler needs
+     * to know the aspect.
+     */
+    private fun resolveAspect(destHash: ByteArray, identity: Identity): String? {
+        for (aspect in knownAspects) {
+            try {
+                val expectedHash = Destination.hashFromNameAndIdentity(aspect, identity)
+                if (expectedHash.contentEquals(destHash)) return aspect
+            } catch (_: Exception) {}
+        }
+        return null
+    }
+
+    /**
+     * Register an aspect for resolution by null-filter RichAnnounceHandlers.
+     * Aspects from filtered handlers are automatically included.
+     */
+    fun registerKnownAspect(aspect: String) {
+        knownAspects.add(aspect)
+    }
 
     /**
      * Immediately retransmit an announce to all local client interfaces.

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -868,7 +868,10 @@ object Transport {
      *   destination hash matches `Destination.hashFromNameAndIdentity(aspectFilter, identity)`.
      *   If null, the handler receives all announces. Matches Python's `handler.aspect_filter`.
      */
-    fun registerAnnounceHandler(handler: AnnounceHandler, aspectFilter: String? = null) {
+    fun registerAnnounceHandler(
+        handler: AnnounceHandler,
+        aspectFilter: String? = null,
+    ) {
         announceHandlers.add(RegisteredHandler(handler, aspectFilter))
         if (aspectFilter != null) knownAspects.add(aspectFilter)
     }
@@ -946,6 +949,11 @@ object Transport {
      * Returns list of (DiscoveredInterface, status) pairs.
      */
     fun listDiscoveredInterfaces(): List<Pair<network.reticulum.discovery.DiscoveredInterface, String>> = discoveryHandler?.listDiscovered() ?: emptyList()
+
+    /**
+     * Get the set of currently auto-connected endpoint strings ("host:port").
+     */
+    fun getAutoconnectedEndpoints(): Set<String> = discoveryHandler?.getAutoconnectedEndpoints() ?: emptySet()
 
     // ===== Link Management =====
 
@@ -3177,26 +3185,38 @@ object Transport {
                 // Aspect filtering (Python Transport.py:1890-1896)
                 val matchedAspect: String?
                 if (registered.aspectFilter != null) {
-                    val expectedHash = Destination.hashFromNameAndIdentity(
-                        registered.aspectFilter, identity,
-                    )
+                    val expectedHash =
+                        Destination.hashFromNameAndIdentity(
+                            registered.aspectFilter,
+                            identity,
+                        )
                     if (!expectedHash.contentEquals(destHash)) continue
                     matchedAspect = registered.aspectFilter
                 } else {
                     // No filter — resolve aspect for RichAnnounceHandler callers
-                    matchedAspect = if (handler is RichAnnounceHandler) {
-                        resolvedAspect ?: resolveAspect(destHash, identity).also { resolvedAspect = it }
+                    matchedAspect =
+                        if (handler is RichAnnounceHandler) {
+                            resolvedAspect ?: resolveAspect(destHash, identity).also { resolvedAspect = it }
+                        } else {
+                            null
+                        }
+                }
+                if (handler is RichAnnounceHandler) {
+                    log("notifyAnnounceHandlers: RichHandler matchedAspect=$matchedAspect dest=${destHash.toHexString().take(12)}")
+                }
+                val handled =
+                    if (handler is RichAnnounceHandler) {
+                        handler.handleAnnounceWithContext(
+                            destHash,
+                            identity,
+                            appData,
+                            hops,
+                            interfaceName,
+                            matchedAspect,
+                        )
                     } else {
-                        null
+                        handler.handleAnnounce(destHash, identity, appData)
                     }
-                }
-                val handled = if (handler is RichAnnounceHandler) {
-                    handler.handleAnnounceWithContext(
-                        destHash, identity, appData, hops, interfaceName, matchedAspect,
-                    )
-                } else {
-                    handler.handleAnnounce(destHash, identity, appData)
-                }
                 if (handled) break
             } catch (e: Exception) {
                 log("Announce handler error: ${e.message}")
@@ -3209,13 +3229,19 @@ object Transport {
      * known aspects. Used when a null-filter RichAnnounceHandler needs
      * to know the aspect.
      */
-    private fun resolveAspect(destHash: ByteArray, identity: Identity): String? {
+    private fun resolveAspect(
+        destHash: ByteArray,
+        identity: Identity,
+    ): String? {
         for (aspect in knownAspects) {
             try {
                 val expectedHash = Destination.hashFromNameAndIdentity(aspect, identity)
                 if (expectedHash.contentEquals(destHash)) return aspect
-            } catch (_: Exception) {}
+            } catch (e: Exception) {
+                log("resolveAspect: exception for $aspect: ${e.message}")
+            }
         }
+        log("resolveAspect: no match for ${destHash.toHexString()} among ${knownAspects.size} aspects (id=${identity.hexHash.take(12)})")
         return null
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2980,6 +2980,15 @@ object Transport {
         if (!isKnownDestination && interfaceRef.shouldIngressLimit()) {
             log("Holding announce for ${destHash.toHexString()} due to ingress limiting on ${interfaceRef.name}")
             interfaceRef.holdAnnounce(destHash, packet.raw ?: packet.pack(), packet.hops, interfaceRef)
+            // Still notify local handlers so display names are captured.
+            // Python processes the announce locally even when ingress-limited;
+            // it only holds the *retransmission*.
+            for (handler in announceHandlers) {
+                try {
+                    if (handler.handleAnnounce(destHash, identity, appData)) break
+                } catch (_: Exception) {
+                }
+            }
             return
         }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -882,7 +882,20 @@ object Transport {
      * Deregister an announce handler.
      */
     fun deregisterAnnounceHandler(handler: AnnounceHandler) {
+        // Collect the aspect filters of the handlers being removed
+        val removedAspects = announceHandlers
+            .filter { it.handler === handler }
+            .mapNotNull { it.aspectFilter }
+
         announceHandlers.removeIf { it.handler === handler }
+
+        // Remove aspects from knownAspects only if no remaining handler uses them
+        for (aspect in removedAspects) {
+            val stillUsed = announceHandlers.any { it.aspectFilter == aspect }
+            if (!stillUsed) {
+                knownAspects.remove(aspect)
+            }
+        }
     }
 
     // ===== Interface Discovery =====

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -3228,6 +3228,7 @@ object Transport {
         interfaceName: String?,
     ) {
         var resolvedAspect: String? = null // cached for multiple null-filter handlers
+        var aspectResolved = false
         for (registered in announceHandlers) {
             try {
                 val handler = registered.handler
@@ -3246,7 +3247,12 @@ object Transport {
                     // No filter — resolve aspect for RichAnnounceHandler callers
                     matchedAspect =
                         if (handler is RichAnnounceHandler) {
-                            resolvedAspect ?: resolveAspect(destHash, identity).also { resolvedAspect = it }
+                            if (!aspectResolved) {
+                                aspectResolved = true
+                                resolveAspect(destHash, identity).also { resolvedAspect = it }
+                            } else {
+                                resolvedAspect
+                            }
                         } else {
                             null
                         }

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -1652,6 +1652,15 @@ object Transport {
             val lines =
                 pathTable.entries.mapNotNull { (key, entry) ->
                     if (entry.isExpired()) return@mapNotNull null
+                    // Only skip paths with missing interfaces when interfaces are registered
+                    // (matches Python Transport.py:2905-2910)
+                    if (interfaces.isNotEmpty() && findInterfaceByHash(entry.receivingInterfaceHash) == null) {
+                        return@mapNotNull null
+                    }
+                    // Persist up to PERSIST_RANDOM_BLOBS most recent blobs
+                    val blobsHex = entry.randomBlobs
+                        .takeLast(TransportConstants.PERSIST_RANDOM_BLOBS)
+                        .joinToString(",") { it.toHexString() }
                     listOf(
                         key.toString(),
                         entry.nextHop.toHexString(),
@@ -1661,6 +1670,8 @@ object Transport {
                         entry.announcePacketHash.toHexString(),
                         entry.state.ordinal.toString(),
                         entry.failureCount.toString(),
+                        entry.timestamp.toString(),
+                        blobsHex,
                     ).joinToString("|")
                 }
             file.writeText(lines.joinToString("\n"))
@@ -1691,17 +1702,26 @@ object Transport {
                     val announceHash = hexToBytes(parts[5])
                     val stateOrdinal = parts[6].toInt()
                     val failureCount = parts[7].toInt()
+                    // New fields (backward-compatible: missing = defaults)
+                    val timestamp = parts.getOrNull(8)?.toLongOrNull()
+                        ?: System.currentTimeMillis()
+                    val randomBlobs = parts.getOrNull(9)
+                        ?.split(",")
+                        ?.filter { it.isNotBlank() }
+                        ?.map { hexToBytes(it) }
+                        ?.toMutableList()
+                        ?: mutableListOf()
 
                     // Skip expired entries
                     if (System.currentTimeMillis() > expires) continue
 
                     val entry =
                         PathEntry(
-                            timestamp = System.currentTimeMillis(),
+                            timestamp = timestamp,
                             nextHop = nextHop,
                             hops = hops,
                             expires = expires,
-                            randomBlobs = mutableListOf(),
+                            randomBlobs = randomBlobs,
                             receivingInterfaceHash = interfaceHash,
                             announcePacketHash = announceHash,
                             state = PathState.entries.getOrElse(stateOrdinal) { PathState.ACTIVE },
@@ -3686,6 +3706,55 @@ object Transport {
         }
     }
 
+    /**
+     * Validate an LRPROOF signature before forwarding it through the link table.
+     * Matches Python Transport.py:781-802.
+     *
+     * Returns true if the proof signature is valid, false otherwise.
+     * If the peer identity cannot be recalled, returns true (optimistic forwarding)
+     * to avoid dropping valid proofs when the identity cache is cold.
+     */
+    private fun validateLrproofForTransport(packet: Packet, linkEntry: LinkEntry): Boolean {
+        val sigLength = RnsConstants.SIGNATURE_SIZE
+        val pubSize = LinkConstants.KEYSIZE
+
+        // Check data length matches expected LRPROOF format (Python:781)
+        val expectedLen = sigLength + pubSize
+        val expectedLenWithMtu = expectedLen + LinkConstants.LINK_MTU_SIZE
+        if (packet.data.size != expectedLen && packet.data.size != expectedLenWithMtu) {
+            log("LRPROOF data size mismatch: ${packet.data.size} (expected $expectedLen or $expectedLenWithMtu)")
+            return false
+        }
+
+        // Extract signature and peer public key
+        val signature = packet.data.copyOfRange(0, sigLength)
+        val peerPubBytes = packet.data.copyOfRange(sigLength, sigLength + pubSize)
+
+        // Recall the peer identity for the destination (Python:787)
+        val peerIdentity = Identity.recall(linkEntry.destinationHash)
+        if (peerIdentity == null) {
+            // Cannot validate without the identity — allow optimistic forwarding.
+            // The final recipient (pending link) will do full validation.
+            log("Cannot recall identity for ${linkEntry.destinationHash.toHexString()}, forwarding LRPROOF optimistically")
+            return true
+        }
+
+        val peerSigPubBytes = peerIdentity.getPublicKey()
+            .copyOfRange(LinkConstants.KEYSIZE, LinkConstants.ECPUBSIZE)
+
+        // Build signalling bytes if MTU info present
+        var signallingBytes = ByteArray(0)
+        if (packet.data.size == expectedLenWithMtu) {
+            val mtuBytes = packet.data.copyOfRange(expectedLen, expectedLenWithMtu)
+            signallingBytes = mtuBytes
+        }
+
+        // Build signed data (Python:790)
+        val signedData = packet.destinationHash + peerPubBytes + peerSigPubBytes + signallingBytes
+
+        return peerIdentity.validate(signature, signedData)
+    }
+
     private fun processProof(
         packet: Packet,
         interfaceRef: InterfaceRef,
@@ -3705,12 +3774,36 @@ object Transport {
             PacketContext.LRPROOF -> {
                 val pendingLink = pendingLinks.find { getLinkId(it)?.toKey() == packet.destinationHash.toKey() }
                 if (pendingLink != null) {
+                    // Hop count validation (Python Transport.py:828):
+                    // Check that the LRPROOF traveled the expected number of hops.
+                    // Also allow PATHFINDER_M as a fallback when hops were unknown
+                    // at link creation time.
+                    val expectedHops = try {
+                        pendingLink::class.java.getMethod("getExpectedHops").invoke(pendingLink) as? Int
+                    } catch (_: Exception) { null }
+
+                    if (expectedHops != null &&
+                        packet.hops != expectedHops &&
+                        expectedHops != TransportConstants.PATHFINDER_M
+                    ) {
+                        log("LRPROOF hop mismatch for pending link: packet.hops=${packet.hops} != expectedHops=$expectedHops, ignoring")
+                        return
+                    }
+
+                    // Add to packet hash filter BEFORE validation (Python Transport.py:832).
+                    // This prevents duplicate LRPROOFs from being re-processed after the
+                    // link transitions from pendingLinks to activeLinks.
+                    addPacketHash(packet.packetHash)
+
                     log("Delivering LRPROOF to pending link ${packet.destinationHash.toHexString()}")
                     try {
                         val validateMethod = pendingLink::class.java.getMethod("validateProof", Packet::class.java)
-                        validateMethod.invoke(pendingLink, packet)
+                        val result = validateMethod.invoke(pendingLink, packet) as? Boolean ?: false
+                        if (!result) {
+                            log("LRPROOF validation failed for link ${packet.destinationHash.toHexString()}, proof consumed")
+                        }
                     } catch (e: Exception) {
-                        log("Error validating link proof: ${e.message}")
+                        log("Error validating link proof for ${packet.destinationHash.toHexString()}: ${e.message}")
                     }
                     return
                 }
@@ -3732,6 +3825,19 @@ object Transport {
                         return
                     }
 
+                    // Validate LRPROOF signature before forwarding (Python Transport.py:781-802).
+                    // This prevents invalid proofs from being propagated through the network.
+                    val proofValid = try {
+                        validateLrproofForTransport(packet, linkEntry)
+                    } catch (e: Exception) {
+                        log("Error validating LRPROOF for transport: ${e.message}")
+                        false
+                    }
+                    if (!proofValid) {
+                        log("Invalid LRPROOF signature for ${packet.destinationHash.toHexString()}, dropping")
+                        return
+                    }
+
                     val outboundInterface = findInterfaceByHash(linkEntry.receivingInterfaceHash)
                     if (outboundInterface != null) {
                         // Update hop byte in raw before forwarding (Python:2035-2036)
@@ -3745,7 +3851,7 @@ object Transport {
                     return
                 }
 
-                log("LRPROOF dest=${packet.destinationHash.toHexString()} not found in pending_links or link_table")
+                log("LRPROOF dest=${packet.destinationHash.toHexString()} not found in pending_links (${pendingLinks.size}) or link_table (${linkTable.size})")
             }
 
             // RESOURCE_PRF (Resource Proof) — Transport.py:2075-2078
@@ -3796,6 +3902,19 @@ object Transport {
                     if (callback != null) {
                         matchedKey = fullHashKey
                         log("Found pending receipt by full hash from proof data")
+                    } else {
+                        // Receipts are registered by truncated hash (16 bytes), but the
+                        // proof data contains the full hash (32 bytes). For link proofs,
+                        // packet.destinationHash is the link ID (not the packet hash),
+                        // so the first lookup misses. Try truncated hash derived from
+                        // the full hash in the proof data.
+                        val truncHash = fullHash.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES)
+                        val truncHashKey = truncHash.toKey()
+                        callback = pendingReceipts[truncHashKey]
+                        if (callback != null) {
+                            matchedKey = truncHashKey
+                            log("Found pending receipt by truncated hash from proof data")
+                        }
                     }
                 }
 
@@ -4341,6 +4460,7 @@ object Transport {
 
     private fun cullTables() {
         val now = System.currentTimeMillis()
+        val withinStartupGrace = now - startTime < TransportConstants.STARTUP_GRACE_PERIOD
 
         // Remove expired path entries and entries whose interface no longer exists
         // (matches Python Transport.py:707-720)
@@ -4348,9 +4468,14 @@ object Transport {
         pathTable.entries.removeIf { entry ->
             val pathEntry = entry.value
             if (pathEntry.isExpired()) {
+                pathStore?.removePath(entry.key.bytes)
                 log("Path to ${entry.key} timed out and was removed")
                 true
-            } else if (findInterfaceByHash(pathEntry.receivingInterfaceHash) == null) {
+            } else if (!withinStartupGrace && findInterfaceByHash(pathEntry.receivingInterfaceHash) == null) {
+                // Skip interface-based culling during startup grace period to allow
+                // async interface registration (e.g., BLE, TCP) to complete.
+                // Python registers interfaces synchronously before first cull.
+                pathStore?.removePath(entry.key.bytes)
                 log("Path to ${entry.key} was removed since the attached interface no longer exists")
                 true
             } else {
@@ -5244,7 +5369,7 @@ object Transport {
                 java.time.format.DateTimeFormatter
                     .ofPattern("yyyy-MM-dd HH:mm:ss.SSS"),
             )
-        System.err.println("[$timestamp] [Transport] $message")
+        println("[$timestamp] [Transport] $message")
     }
 }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -955,6 +955,13 @@ object Transport {
      */
     fun getAutoconnectedEndpoints(): Set<String> = discoveryHandler?.getAutoconnectedEndpoints() ?: emptySet()
 
+    /**
+     * Update the auto-connect limit at runtime without restarting.
+     */
+    fun setMaxAutoConnected(count: Int) {
+        discoveryHandler?.setMaxAutoConnected(count)
+    }
+
     // ===== Link Management =====
 
     /**

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -5,17 +5,17 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import network.reticulum.common.ByteArrayKey
 import network.reticulum.common.ContextFlag
 import network.reticulum.common.DestinationDirection
 import network.reticulum.common.DestinationType
 import network.reticulum.common.HeaderType
+import network.reticulum.common.InterfaceMode
 import network.reticulum.common.PacketContext
 import network.reticulum.common.PacketType
 import network.reticulum.common.Platform
 import network.reticulum.common.RnsConstants
-import network.reticulum.common.InterfaceMode
 import network.reticulum.common.TransportType
-import network.reticulum.common.ByteArrayKey
 import network.reticulum.common.concatBytes
 import network.reticulum.common.toHexString
 import network.reticulum.common.toKey
@@ -53,7 +53,7 @@ fun interface AnnounceHandler {
     fun handleAnnounce(
         destinationHash: ByteArray,
         announcedIdentity: Identity,
-        appData: ByteArray?
+        appData: ByteArray?,
     ): Boolean
 }
 
@@ -61,7 +61,10 @@ fun interface AnnounceHandler {
  * Callback for packet delivery.
  */
 fun interface PacketCallback {
-    fun onPacket(data: ByteArray, packet: Packet)
+    fun onPacket(
+        data: ByteArray,
+        packet: Packet,
+    )
 }
 
 /**
@@ -150,11 +153,12 @@ object Transport {
 
     /** Interface modes that trigger recursive path forwarding for unknown destinations. */
     // Python: Interface.DISCOVER_PATHS_FOR = [MODE_ACCESS_POINT, MODE_GATEWAY, MODE_ROAMING]
-    private val DISCOVER_PATHS_FOR = setOf(
-        InterfaceMode.ACCESS_POINT,
-        InterfaceMode.GATEWAY,
-        InterfaceMode.ROAMING
-    )
+    private val DISCOVER_PATHS_FOR =
+        setOf(
+            InterfaceMode.ACCESS_POINT,
+            InterfaceMode.GATEWAY,
+            InterfaceMode.ROAMING,
+        )
 
     // ===== Tables =====
 
@@ -180,17 +184,16 @@ object Transport {
     data class CachedPacket(
         val raw: ByteArray,
         val timestamp: Long,
-        val receivingInterfaceHash: ByteArray?
+        val receivingInterfaceHash: ByteArray?,
     ) {
-        fun isExpired(): Boolean =
-            System.currentTimeMillis() - timestamp > TransportConstants.PACKET_CACHE_TIMEOUT
+        fun isExpired(): Boolean = System.currentTimeMillis() - timestamp > TransportConstants.PACKET_CACHE_TIMEOUT
     }
 
     /** Pending discovery path request entry (Python: discovery_path_requests). */
     data class DiscoveryPathRequest(
         val destinationHash: ByteArray,
         val timeout: Long,
-        val requestingInterface: InterfaceRef
+        val requestingInterface: InterfaceRef,
     )
 
     /** Interface traffic statistics. */
@@ -200,7 +203,7 @@ object Transport {
         var txPackets: Long = 0,
         var rxPackets: Long = 0,
         var announcesSent: Long = 0,
-        var lastActivity: Long = System.currentTimeMillis()
+        var lastActivity: Long = System.currentTimeMillis(),
     )
 
     /** Packet cache: packet_hash -> CachedPacket. */
@@ -308,7 +311,10 @@ object Transport {
      * @param transportIdentity Identity for this transport node (or null to generate)
      * @param enableTransport Whether to enable transport (routing for others)
      */
-    fun start(transportIdentity: Identity? = null, enableTransport: Boolean = false) {
+    fun start(
+        transportIdentity: Identity? = null,
+        enableTransport: Boolean = false,
+    ) {
         if (started.getAndSet(true)) {
             return // Already started
         }
@@ -349,24 +355,26 @@ object Transport {
      */
     private fun initializeControlDestinations() {
         // Create path request destination
-        pathRequestDestination = Destination.create(
-            identity = null,
-            direction = DestinationDirection.IN,
-            type = DestinationType.PLAIN,
-            appName = TransportConstants.APP_NAME,
-            aspects = arrayOf("path", "request")
-        )
+        pathRequestDestination =
+            Destination.create(
+                identity = null,
+                direction = DestinationDirection.IN,
+                type = DestinationType.PLAIN,
+                appName = TransportConstants.APP_NAME,
+                aspects = arrayOf("path", "request"),
+            )
         controlHashes.add(pathRequestDestination!!.hash.toKey())
         log("Path request destination: ${pathRequestDestination!!.hexHash}")
 
         // Create tunnel synthesize destination
-        tunnelSynthesizeDestination = Destination.create(
-            identity = null,
-            direction = DestinationDirection.IN,
-            type = DestinationType.PLAIN,
-            appName = TransportConstants.APP_NAME,
-            aspects = arrayOf("tunnel", "synthesize")
-        )
+        tunnelSynthesizeDestination =
+            Destination.create(
+                identity = null,
+                direction = DestinationDirection.IN,
+                type = DestinationType.PLAIN,
+                appName = TransportConstants.APP_NAME,
+                aspects = arrayOf("tunnel", "synthesize"),
+            )
         controlHashes.add(tunnelSynthesizeDestination!!.hash.toKey())
         log("Tunnel synthesize destination: ${tunnelSynthesizeDestination!!.hexHash}")
     }
@@ -385,7 +393,8 @@ object Transport {
         useCoroutineJobLoop = false
 
         // Cancel all link watchdog coroutines
-        network.reticulum.link.Link.cancelAllWatchdogs()
+        network.reticulum.link.Link
+            .cancelAllWatchdogs()
 
         // Persist data BEFORE clearing tables
         if (transportEnabled) {
@@ -479,7 +488,8 @@ object Transport {
         log("Trimming memory...")
 
         // Clear byte array pool
-        network.reticulum.common.ByteArrayPool.clear()
+        network.reticulum.common.ByteArrayPool
+            .clear()
 
         // Trim packet hashlists (keep recent, drop old)
         val now = System.currentTimeMillis()
@@ -534,7 +544,8 @@ object Transport {
         log("Aggressive memory trim...")
 
         // Clear byte array pool
-        network.reticulum.common.ByteArrayPool.clear()
+        network.reticulum.common.ByteArrayPool
+            .clear()
 
         // Clear all hashlists (will cause some duplicate packet processing)
         packetHashlist.clear()
@@ -563,19 +574,20 @@ object Transport {
     /**
      * Get current memory statistics.
      */
-    fun getMemoryStats(): MemoryStats {
-        return MemoryStats(
+    fun getMemoryStats(): MemoryStats =
+        MemoryStats(
             pathTableSize = pathTable.size,
             linkTableSize = linkTable.size,
             announceTableSize = announceTable.size,
             packetHashlistSize = packetHashlist.size,
             queuedAnnouncesSize = queuedAnnounces.size,
             tunnelsSize = tunnels.size,
-            byteArrayPoolBytes = network.reticulum.common.ByteArrayPool.pooledBytes(),
+            byteArrayPoolBytes =
+                network.reticulum.common.ByteArrayPool
+                    .pooledBytes(),
             heapUsedBytes = network.reticulum.common.Platform.usedHeapMemory,
-            heapMaxBytes = network.reticulum.common.Platform.maxHeapMemory
+            heapMaxBytes = network.reticulum.common.Platform.maxHeapMemory,
         )
-    }
 
     /**
      * Memory statistics for monitoring.
@@ -589,7 +601,7 @@ object Transport {
         val tunnelsSize: Int,
         val byteArrayPoolBytes: Long,
         val heapUsedBytes: Long,
-        val heapMaxBytes: Long
+        val heapMaxBytes: Long,
     ) {
         val heapUsedPercent: Int
             get() = if (heapMaxBytes > 0) ((heapUsedBytes * 100) / heapMaxBytes).toInt() else 0
@@ -769,9 +781,7 @@ object Transport {
      * Get all registered destinations.
      * Used by Identity.recall() for fallback lookups.
      */
-    internal fun getDestinations(): List<Destination> {
-        return destinations.toList()
-    }
+    internal fun getDestinations(): List<Destination> = destinations.toList()
 
     /**
      * Find a registered destination by hash.
@@ -790,11 +800,10 @@ object Transport {
     fun registerReceipt(receipt: PacketReceipt) {
         receipts.add(receipt)
         // Also register for proof handling
-        pendingReceipts[receipt.hash.toKey()] = object : ProofCallback {
-            override fun onProofReceived(proofPacket: Packet): Boolean {
-                return receipt.validateProofPacket(proofPacket)
+        pendingReceipts[receipt.hash.toKey()] =
+            object : ProofCallback {
+                override fun onProofReceived(proofPacket: Packet): Boolean = receipt.validateProofPacket(proofPacket)
             }
-        }
         log("Registered receipt for ${receipt.hash.toHexString()}")
     }
 
@@ -858,15 +867,16 @@ object Transport {
         callback: ((network.reticulum.discovery.DiscoveredInterface) -> Unit)? = null,
     ) {
         if (discoveryHandler == null) {
-            discoveryHandler = network.reticulum.discovery.InterfaceDiscovery(
-                storagePath = storagePath,
-                requiredValue = requiredValue,
-                discoverySources = discoverySources,
-                autoConnectFactory = autoConnectFactory,
-                maxAutoConnected = maxAutoConnected,
-                discoveryCallback = callback,
-                discoveryStore = discoveryStore,
-            )
+            discoveryHandler =
+                network.reticulum.discovery.InterfaceDiscovery(
+                    storagePath = storagePath,
+                    requiredValue = requiredValue,
+                    discoverySources = discoverySources,
+                    autoConnectFactory = autoConnectFactory,
+                    maxAutoConnected = maxAutoConnected,
+                    discoveryCallback = callback,
+                    discoveryStore = discoveryStore,
+                )
             discoveryHandler?.start()
             log("Interface discovery listening enabled")
         }
@@ -876,9 +886,7 @@ object Transport {
      * List discovered interfaces (from disk persistence).
      * Returns list of (DiscoveredInterface, status) pairs.
      */
-    fun listDiscoveredInterfaces(): List<Pair<network.reticulum.discovery.DiscoveredInterface, String>> {
-        return discoveryHandler?.listDiscovered() ?: emptyList()
-    }
+    fun listDiscoveredInterfaces(): List<Pair<network.reticulum.discovery.DiscoveredInterface, String>> = discoveryHandler?.listDiscovered() ?: emptyList()
 
     // ===== Link Management =====
 
@@ -891,9 +899,12 @@ object Transport {
         val linkId = getLinkId(link) ?: return
         // Python Transport.py:2244-2247: initiator links go to pending_links,
         // non-initiator (server) links go to active_links
-        val isInitiator = try {
-            link::class.java.getMethod("getInitiator").invoke(link) as? Boolean ?: true
-        } catch (_: Exception) { true }
+        val isInitiator =
+            try {
+                link::class.java.getMethod("getInitiator").invoke(link) as? Boolean ?: true
+            } catch (_: Exception) {
+                true
+            }
         if (isInitiator) {
             pendingLinks.add(link)
             log("Registered pending link: ${linkId.toHexString()}")
@@ -917,17 +928,22 @@ object Transport {
      * Register a path entry for a link so that outbound packets use the correct interface.
      * This should be called when a link is established with the receiving interface hash.
      */
-    fun registerLinkPath(linkId: ByteArray, receivingInterfaceHash: ByteArray, hops: Int = 1) {
+    fun registerLinkPath(
+        linkId: ByteArray,
+        receivingInterfaceHash: ByteArray,
+        hops: Int = 1,
+    ) {
         val now = System.currentTimeMillis()
-        val entry = PathEntry(
-            timestamp = now,
-            nextHop = linkId,  // Use linkId as nextHop (will route to link)
-            hops = hops,
-            expires = now + TransportConstants.PATHFINDER_E,
-            randomBlobs = mutableListOf(),
-            receivingInterfaceHash = receivingInterfaceHash,
-            announcePacketHash = linkId  // Use linkId as placeholder
-        )
+        val entry =
+            PathEntry(
+                timestamp = now,
+                nextHop = linkId, // Use linkId as nextHop (will route to link)
+                hops = hops,
+                expires = now + TransportConstants.PATHFINDER_E,
+                randomBlobs = mutableListOf(),
+                receivingInterfaceHash = receivingInterfaceHash,
+                announcePacketHash = linkId, // Use linkId as placeholder
+            )
         pathTable[linkId.toKey()] = entry
         pathStore?.upsertPath(linkId, entry)
         log("Registered link path for ${linkId.toHexString()} via interface ${receivingInterfaceHash.toHexString()}")
@@ -955,8 +971,8 @@ object Transport {
     /**
      * Get link ID from a link object using reflection.
      */
-    private fun getLinkId(link: Any): ByteArray? {
-        return try {
+    private fun getLinkId(link: Any): ByteArray? =
+        try {
             val prop = link::class.java.getDeclaredMethod("getLinkId")
             prop.invoke(link) as? ByteArray
         } catch (e: Exception) {
@@ -968,7 +984,6 @@ object Transport {
                 null
             }
         }
-    }
 
     // ===== Receipt Management =====
 
@@ -978,7 +993,10 @@ object Transport {
      * @param packetHash The hash of the packet to wait for proof
      * @param callback The callback to invoke when proof is received
      */
-    fun registerReceipt(packetHash: ByteArray, callback: ProofCallback) {
+    fun registerReceipt(
+        packetHash: ByteArray,
+        callback: ProofCallback,
+    ) {
         pendingReceipts[packetHash.toKey()] = callback
         log("Registered receipt for ${packetHash.toHexString()}")
     }
@@ -1243,7 +1261,7 @@ object Transport {
         raw: ByteArray,
         interfaceRef: InterfaceRef,
         hops: Int,
-        emitted: Long
+        emitted: Long,
     ): Boolean {
         val ifaceKey = interfaceRef.hash.toKey()
         val queue = interfaceAnnounceQueues.getOrPut(ifaceKey) { mutableListOf() }
@@ -1274,13 +1292,14 @@ object Transport {
         val queueTime = now + graceMs + randomMs
 
         // Create queued announce
-        val queued = QueuedAnnounce(
-            destinationHash = destinationHash.copyOf(),
-            time = queueTime,
-            hops = hops,
-            emitted = emitted,
-            raw = raw.copyOf()
-        )
+        val queued =
+            QueuedAnnounce(
+                destinationHash = destinationHash.copyOf(),
+                time = queueTime,
+                hops = hops,
+                emitted = emitted,
+                raw = raw.copyOf(),
+            )
 
         queue.add(queued)
 
@@ -1340,17 +1359,19 @@ object Transport {
                 val bitrate = interfaceRef.bitrate
                 val announceCap = interfaceRef.announceCap
 
-                val txTime = if (bitrate > 0) {
-                    (selected.raw.size * 8.0) / bitrate
-                } else {
-                    0.0
-                }
+                val txTime =
+                    if (bitrate > 0) {
+                        (selected.raw.size * 8.0) / bitrate
+                    } else {
+                        0.0
+                    }
 
-                val waitTime = if (announceCap > 0) {
-                    (txTime / announceCap * 1000).toLong()
-                } else {
-                    0L
-                }
+                val waitTime =
+                    if (announceCap > 0) {
+                        (txTime / announceCap * 1000).toLong()
+                    } else {
+                        0L
+                    }
 
                 // Update allowed timestamp
                 interfaceAnnounceAllowedAt[ifaceKey] = now + waitTime
@@ -1390,7 +1411,10 @@ object Transport {
     /**
      * Schedule next announce time for a destination.
      */
-    private fun scheduleNextAnnounce(destinationHash: ByteArray, delayMs: Long) {
+    private fun scheduleNextAnnounce(
+        destinationHash: ByteArray,
+        delayMs: Long,
+    ) {
         announceAllowedAt[destinationHash.toKey()] = System.currentTimeMillis() + delayMs
     }
 
@@ -1409,7 +1433,10 @@ object Transport {
      * @param interfaceRef The interface that transmitted data
      * @param bytes Number of bytes transmitted
      */
-    fun recordTxBytes(interfaceRef: InterfaceRef, bytes: Int) {
+    fun recordTxBytes(
+        interfaceRef: InterfaceRef,
+        bytes: Int,
+    ) {
         val stats = interfaceStats.getOrPut(interfaceRef.hash.toKey()) { InterfaceTrafficStats() }
         stats.txBytes += bytes
         stats.txPackets++
@@ -1422,7 +1449,10 @@ object Transport {
      * @param interfaceRef The interface that received data
      * @param bytes Number of bytes received
      */
-    fun recordRxBytes(interfaceRef: InterfaceRef, bytes: Int) {
+    fun recordRxBytes(
+        interfaceRef: InterfaceRef,
+        bytes: Int,
+    ) {
         val stats = interfaceStats.getOrPut(interfaceRef.hash.toKey()) { InterfaceTrafficStats() }
         stats.rxBytes += bytes
         stats.rxPackets++
@@ -1445,9 +1475,7 @@ object Transport {
      * @param interfaceRef The interface to get stats for
      * @return Traffic stats or null if no data recorded
      */
-    fun getInterfaceStats(interfaceRef: InterfaceRef): InterfaceTrafficStats? {
-        return interfaceStats[interfaceRef.hash.toKey()]
-    }
+    fun getInterfaceStats(interfaceRef: InterfaceRef): InterfaceTrafficStats? = interfaceStats[interfaceRef.hash.toKey()]
 
     /**
      * Get all interfaces prioritized by capacity and current load.
@@ -1455,8 +1483,8 @@ object Transport {
      *
      * @return List of interfaces sorted by priority (highest first)
      */
-    fun prioritizeInterfaces(): List<InterfaceRef> {
-        return interfaces.sortedByDescending { interfaceRef ->
+    fun prioritizeInterfaces(): List<InterfaceRef> =
+        interfaces.sortedByDescending { interfaceRef ->
             val stats = interfaceStats[interfaceRef.hash.toKey()]
             val bitrate = interfaceRef.bitrate.toLong()
             val recentTx = stats?.txBytes ?: 0L
@@ -1469,16 +1497,13 @@ object Transport {
                 1.0 / (recentTx + 1)
             }
         }
-    }
 
     /**
      * Get active interfaces (online and can send).
      *
      * @return List of active interfaces
      */
-    fun getActiveInterfaces(): List<InterfaceRef> {
-        return interfaces.filter { it.online && it.canSend }
-    }
+    fun getActiveInterfaces(): List<InterfaceRef> = interfaces.filter { it.online && it.canSend }
 
     // ===== Local Client Support =====
 
@@ -1503,16 +1528,12 @@ object Transport {
     /**
      * Check if interface is a local client.
      */
-    fun isLocalClientInterface(interfaceRef: InterfaceRef): Boolean {
-        return localClientInterfaces.any { it.hash.contentEquals(interfaceRef.hash) }
-    }
+    fun isLocalClientInterface(interfaceRef: InterfaceRef): Boolean = localClientInterfaces.any { it.hash.contentEquals(interfaceRef.hash) }
 
     /**
      * Check if packet came from a local client.
      */
-    fun fromLocalClient(interfaceRef: InterfaceRef): Boolean {
-        return isLocalClientInterface(interfaceRef)
-    }
+    fun fromLocalClient(interfaceRef: InterfaceRef): Boolean = isLocalClientInterface(interfaceRef)
 
     /**
      * Handle shared connection disappearing.
@@ -1553,19 +1574,20 @@ object Transport {
      */
     fun savePathTable(file: java.io.File) {
         try {
-            val lines = pathTable.entries.mapNotNull { (key, entry) ->
-                if (entry.isExpired()) return@mapNotNull null
-                listOf(
-                    key.toString(),
-                    entry.nextHop.toHexString(),
-                    entry.hops.toString(),
-                    entry.expires.toString(),
-                    entry.receivingInterfaceHash.toHexString(),
-                    entry.announcePacketHash.toHexString(),
-                    entry.state.ordinal.toString(),
-                    entry.failureCount.toString()
-                ).joinToString("|")
-            }
+            val lines =
+                pathTable.entries.mapNotNull { (key, entry) ->
+                    if (entry.isExpired()) return@mapNotNull null
+                    listOf(
+                        key.toString(),
+                        entry.nextHop.toHexString(),
+                        entry.hops.toString(),
+                        entry.expires.toString(),
+                        entry.receivingInterfaceHash.toHexString(),
+                        entry.announcePacketHash.toHexString(),
+                        entry.state.ordinal.toString(),
+                        entry.failureCount.toString(),
+                    ).joinToString("|")
+                }
             file.writeText(lines.joinToString("\n"))
             log("Saved ${lines.size} path entries to ${file.absolutePath}")
         } catch (e: Exception) {
@@ -1598,17 +1620,18 @@ object Transport {
                     // Skip expired entries
                     if (System.currentTimeMillis() > expires) continue
 
-                    val entry = PathEntry(
-                        timestamp = System.currentTimeMillis(),
-                        nextHop = nextHop,
-                        hops = hops,
-                        expires = expires,
-                        randomBlobs = mutableListOf(),
-                        receivingInterfaceHash = interfaceHash,
-                        announcePacketHash = announceHash,
-                        state = PathState.entries.getOrElse(stateOrdinal) { PathState.ACTIVE },
-                        failureCount = failureCount
-                    )
+                    val entry =
+                        PathEntry(
+                            timestamp = System.currentTimeMillis(),
+                            nextHop = nextHop,
+                            hops = hops,
+                            expires = expires,
+                            randomBlobs = mutableListOf(),
+                            receivingInterfaceHash = interfaceHash,
+                            announcePacketHash = announceHash,
+                            state = PathState.entries.getOrElse(stateOrdinal) { PathState.ACTIVE },
+                            failureCount = failureCount,
+                        )
                     pathTable[destHash.toKey()] = entry
                     loaded++
                 } catch (e: Exception) {
@@ -1687,7 +1710,9 @@ object Transport {
      * Determine if a packet should be cached.
      * Currently returns false (caching disabled by default, matching Python RNS).
      */
-    fun shouldCache(@Suppress("UNUSED_PARAMETER") packet: Packet): Boolean {
+    fun shouldCache(
+        @Suppress("UNUSED_PARAMETER") packet: Packet,
+    ): Boolean {
         // TODO: Implement caching policy (e.g., for Resource proofs)
         // Currently disabled to match Python RNS behavior
         return false
@@ -1700,17 +1725,22 @@ object Transport {
      * @param forceCache Force caching even if shouldCache returns false
      * @param receivingInterface The interface that received the packet
      */
-    fun cache(packet: Packet, forceCache: Boolean = false, receivingInterface: InterfaceRef? = null) {
+    fun cache(
+        packet: Packet,
+        forceCache: Boolean = false,
+        receivingInterface: InterfaceRef? = null,
+    ) {
         if (!forceCache && !shouldCache(packet)) return
 
         val raw = packet.raw ?: return
         val hash = packet.packetHash
 
-        packetCache[hash.toKey()] = CachedPacket(
-            raw = raw.copyOf(),
-            timestamp = System.currentTimeMillis(),
-            receivingInterfaceHash = receivingInterface?.hash
-        )
+        packetCache[hash.toKey()] =
+            CachedPacket(
+                raw = raw.copyOf(),
+                timestamp = System.currentTimeMillis(),
+                receivingInterfaceHash = receivingInterface?.hash,
+            )
     }
 
     /**
@@ -1737,7 +1767,10 @@ object Transport {
      * @param requestingInterface The interface requesting the packet
      * @return True if packet was found and re-injected
      */
-    fun cacheRequest(packetHash: ByteArray, requestingInterface: InterfaceRef): Boolean {
+    fun cacheRequest(
+        packetHash: ByteArray,
+        requestingInterface: InterfaceRef,
+    ): Boolean {
         val cached = getCachedPacket(packetHash) ?: return false
 
         // Re-inject the cached packet
@@ -1792,8 +1825,11 @@ object Transport {
         val data = ByteArray(len / 2)
         var i = 0
         while (i < len) {
-            data[i / 2] = ((Character.digit(hex[i], 16) shl 4) +
-                          Character.digit(hex[i + 1], 16)).toByte()
+            data[i / 2] =
+                (
+                    (Character.digit(hex[i], 16) shl 4) +
+                        Character.digit(hex[i + 1], 16)
+                ).toByte()
             i += 2
         }
         return data
@@ -1829,7 +1865,7 @@ object Transport {
     fun requestPath(
         destinationHash: ByteArray,
         onInterface: InterfaceRef? = null,
-        callback: ((Boolean) -> Unit)? = null
+        callback: ((Boolean) -> Unit)? = null,
     ) {
         if (!started.get()) {
             callback?.invoke(false)
@@ -1855,13 +1891,14 @@ object Transport {
         val requestTag = Hashes.getRandomHash()
 
         // Build path request data
-        val pathRequestData = if (transportEnabled && identity != null) {
-            // Transport mode: include our transport ID
-            concatBytes(destinationHash, identity!!.hash, requestTag)
-        } else {
-            // Client mode: just destination and tag
-            concatBytes(destinationHash, requestTag)
-        }
+        val pathRequestData =
+            if (transportEnabled && identity != null) {
+                // Transport mode: include our transport ID
+                concatBytes(destinationHash, identity!!.hash, requestTag)
+            } else {
+                // Client mode: just destination and tag
+                concatBytes(destinationHash, requestTag)
+            }
 
         // Ensure path request destination exists (created during start)
         val prDest = pathRequestDestination
@@ -1872,26 +1909,28 @@ object Transport {
         }
 
         // Create and send the packet
-        val packet = Packet.createRaw(
-            destinationHash = prDest.hash,
-            data = pathRequestData,
-            packetType = PacketType.DATA,
-            destinationType = DestinationType.PLAIN,
-            transportType = TransportType.BROADCAST
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = prDest.hash,
+                data = pathRequestData,
+                packetType = PacketType.DATA,
+                destinationType = DestinationType.PLAIN,
+                transportType = TransportType.BROADCAST,
+            )
 
         // Send on specific interface or all
-        val sent = if (onInterface != null) {
-            try {
-                onInterface.send(packet.pack())
-                true
-            } catch (e: Exception) {
-                log("Failed to send path request: ${e.message}")
-                false
+        val sent =
+            if (onInterface != null) {
+                try {
+                    onInterface.send(packet.pack())
+                    true
+                } catch (e: Exception) {
+                    log("Failed to send path request: ${e.message}")
+                    false
+                }
+            } else {
+                outbound(packet)
             }
-        } else {
-            outbound(packet)
-        }
 
         if (sent) {
             pathRequests[destinationHash.toKey()] = now
@@ -1919,25 +1958,27 @@ object Transport {
         destinationHash: ByteArray,
         onInterface: InterfaceRef? = null,
         tag: ByteArray? = null,
-        recursive: Boolean = false
+        recursive: Boolean = false,
     ) {
         val requestTag = tag ?: Hashes.getRandomHash()
 
-        val pathRequestData = if (transportEnabled && identity != null) {
-            concatBytes(destinationHash, identity!!.hash, requestTag)
-        } else {
-            concatBytes(destinationHash, requestTag)
-        }
+        val pathRequestData =
+            if (transportEnabled && identity != null) {
+                concatBytes(destinationHash, identity!!.hash, requestTag)
+            } else {
+                concatBytes(destinationHash, requestTag)
+            }
 
         val prDest = pathRequestDestination ?: return
 
-        val packet = Packet.createRaw(
-            destinationHash = prDest.hash,
-            data = pathRequestData,
-            packetType = PacketType.DATA,
-            destinationType = DestinationType.PLAIN,
-            transportType = TransportType.BROADCAST
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = prDest.hash,
+                data = pathRequestData,
+                packetType = PacketType.DATA,
+                destinationType = DestinationType.PLAIN,
+                transportType = TransportType.BROADCAST,
+            )
 
         // Recursive path requests are throttled by announce cap to avoid flooding
         // Python Transport.py:2563-2585
@@ -1985,23 +2026,27 @@ object Transport {
     private fun handlePathRequest(
         data: ByteArray,
         @Suppress("UNUSED_PARAMETER") packet: Packet,
-        receivingInterface: InterfaceRef
+        receivingInterface: InterfaceRef,
     ) {
         if (data.size < RnsConstants.TRUNCATED_HASH_BYTES) return
 
         val destinationHash = data.copyOfRange(0, RnsConstants.TRUNCATED_HASH_BYTES)
 
         // Extract requesting transport ID if present
-        val requestingTransportId = if (data.size > RnsConstants.TRUNCATED_HASH_BYTES * 2) {
-            data.copyOfRange(RnsConstants.TRUNCATED_HASH_BYTES, RnsConstants.TRUNCATED_HASH_BYTES * 2)
-        } else null
+        val requestingTransportId =
+            if (data.size > RnsConstants.TRUNCATED_HASH_BYTES * 2) {
+                data.copyOfRange(RnsConstants.TRUNCATED_HASH_BYTES, RnsConstants.TRUNCATED_HASH_BYTES * 2)
+            } else {
+                null
+            }
 
         // Extract tag
-        val tagOffset = if (requestingTransportId != null) {
-            RnsConstants.TRUNCATED_HASH_BYTES * 2
-        } else {
-            RnsConstants.TRUNCATED_HASH_BYTES
-        }
+        val tagOffset =
+            if (requestingTransportId != null) {
+                RnsConstants.TRUNCATED_HASH_BYTES * 2
+            } else {
+                RnsConstants.TRUNCATED_HASH_BYTES
+            }
 
         if (data.size <= tagOffset) {
             log("Ignoring tagless path request")
@@ -2046,13 +2091,14 @@ object Transport {
         isFromLocalClient: Boolean,
         receivingInterface: InterfaceRef,
         requestingTransportId: ByteArray?,
-        tag: ByteArray
+        tag: ByteArray,
     ) {
         val destHex = destinationHash.toHexString()
 
         // Python Transport.py:2697-2701 — determine if we should forward for unknown destinations
-        val shouldSearchForUnknown = transportEnabled &&
-            receivingInterface.mode in DISCOVER_PATHS_FOR
+        val shouldSearchForUnknown =
+            transportEnabled &&
+                receivingInterface.mode in DISCOVER_PATHS_FOR
 
         // Case 1: Local destination — announce it directly, targeted at the requesting interface
         // Python: local_destination.announce(path_response=True, tag=tag, attached_interface=attached_interface)
@@ -2062,7 +2108,7 @@ object Transport {
             localDest.announce(
                 pathResponse = true,
                 tag = tag,
-                attachedInterface = receivingInterface
+                attachedInterface = receivingInterface,
             )
             return
         }
@@ -2070,9 +2116,10 @@ object Transport {
         // Case 2: Known path — forward cached announce
         // Python Transport.py:2723-2781
         val pathEntry = pathTable[destinationHash.toKey()]
-        if (pathEntry != null && !pathEntry.isExpired() &&
-            (transportEnabled || isFromLocalClient)) {
-
+        if (pathEntry != null &&
+            !pathEntry.isExpired() &&
+            (transportEnabled || isFromLocalClient)
+        ) {
             log("Path to $destHex known (${pathEntry.hops} hops), retrieving cached announce")
             val cachedData = getCachedAnnouncePacket(pathEntry.announcePacketHash)
 
@@ -2089,9 +2136,10 @@ object Transport {
             }
 
             // Find the original receiving interface
-            val originalInterface = interfaceName?.let { name ->
-                interfaces.find { it.name == name }
-            }
+            val originalInterface =
+                interfaceName?.let { name ->
+                    interfaces.find { it.name == name }
+                }
 
             // Set hop count from path table (Python line 2736)
             cachedPacket.hops = pathEntry.hops
@@ -2100,7 +2148,8 @@ object Transport {
             // Python line 2731-2732
             if (receivingInterface.mode == InterfaceMode.ROAMING &&
                 originalInterface != null &&
-                receivingInterface.hash.contentEquals(originalInterface.hash)) {
+                receivingInterface.hash.contentEquals(originalInterface.hash)
+            ) {
                 log("Not answering path request on roaming-mode interface (same interface)")
                 return
             }
@@ -2108,7 +2157,8 @@ object Transport {
             // Loop prevention: don't answer if next hop is the requestor
             // Python line 2738-2745
             if (requestingTransportId != null &&
-                pathEntry.nextHop.contentEquals(requestingTransportId)) {
+                pathEntry.nextHop.contentEquals(requestingTransportId)
+            ) {
                 log("Not answering path request, next hop is the requestor")
                 return
             }
@@ -2126,7 +2176,7 @@ object Transport {
             queueAnnounceRetransmit(
                 destinationHash,
                 cachedPacket,
-                originalInterface ?: receivingInterface
+                originalInterface ?: receivingInterface,
             )
             return
         }
@@ -2152,11 +2202,12 @@ object Transport {
                 log("Already a waiting path request for $destHex, not forwarding again")
             } else {
                 log("Attempting to discover unknown path to $destHex via recursive forwarding")
-                discoveryPathRequests[destKey] = DiscoveryPathRequest(
-                    destinationHash = destinationHash,
-                    timeout = System.currentTimeMillis() + TransportConstants.PATH_REQUEST_TIMEOUT,
-                    requestingInterface = receivingInterface
-                )
+                discoveryPathRequests[destKey] =
+                    DiscoveryPathRequest(
+                        destinationHash = destinationHash,
+                        timeout = System.currentTimeMillis() + TransportConstants.PATH_REQUEST_TIMEOUT,
+                        requestingInterface = receivingInterface,
+                    )
 
                 for (iface in interfaces) {
                     if (!iface.hash.contentEquals(receivingInterface.hash)) {
@@ -2165,7 +2216,7 @@ object Transport {
                             destinationHash,
                             onInterface = iface,
                             tag = tag,
-                            recursive = true
+                            recursive = true,
                         )
                     }
                 }
@@ -2195,7 +2246,10 @@ object Transport {
      * @param raw Raw packet bytes
      * @param interfaceRef Interface that received the packet
      */
-    fun inbound(raw: ByteArray, interfaceRef: InterfaceRef) {
+    fun inbound(
+        raw: ByteArray,
+        interfaceRef: InterfaceRef,
+    ) {
         if (!started.get()) {
             log("Transport not started, dropping packet")
             return
@@ -2207,21 +2261,22 @@ object Transport {
         }
 
         // Handle IFAC unmasking if interface has IFAC enabled
-        val processedRaw = if (interfaceRef.ifacIdentity != null && interfaceRef.ifacSize > 0) {
-            val unmasked = removeIfacMasking(raw, interfaceRef)
-            if (unmasked == null) {
-                // IFAC authentication failed, drop packet silently
-                return
+        val processedRaw =
+            if (interfaceRef.ifacIdentity != null && interfaceRef.ifacSize > 0) {
+                val unmasked = removeIfacMasking(raw, interfaceRef)
+                if (unmasked == null) {
+                    // IFAC authentication failed, drop packet silently
+                    return
+                }
+                unmasked
+            } else {
+                // No IFAC on interface - check if packet has IFAC flag set (shouldn't)
+                if (raw[0].toInt() and 0x80 == 0x80) {
+                    // Drop packets with IFAC flag on non-IFAC interface
+                    return
+                }
+                raw
             }
-            unmasked
-        } else {
-            // No IFAC on interface - check if packet has IFAC flag set (shouldn't)
-            if (raw[0].toInt() and 0x80 == 0x80) {
-                // Drop packets with IFAC flag on non-IFAC interface
-                return
-            }
-            raw
-        }
 
         jobsLock.withLock {
             try {
@@ -2236,7 +2291,10 @@ object Transport {
      * Remove IFAC (Interface Access Code) masking from a packet.
      * Returns null if authentication fails.
      */
-    private fun removeIfacMasking(raw: ByteArray, interfaceRef: InterfaceRef): ByteArray? {
+    private fun removeIfacMasking(
+        raw: ByteArray,
+        interfaceRef: InterfaceRef,
+    ): ByteArray? {
         val ifacIdentity = interfaceRef.ifacIdentity ?: return raw
         val ifacKey = interfaceRef.ifacKey ?: return raw
         val ifacSize = interfaceRef.ifacSize
@@ -2257,30 +2315,33 @@ object Transport {
         val ifac = raw.copyOfRange(2, 2 + ifacSize)
 
         // Generate mask using HKDF
-        val mask = crypto.hkdf(
-            length = raw.size,
-            ikm = ifac,
-            salt = ifacKey,
-            info = null
-        )
+        val mask =
+            crypto.hkdf(
+                length = raw.size,
+                ikm = ifac,
+                salt = ifacKey,
+                info = null,
+            )
 
         // Unmask the payload
         val unmaskedRaw = ByteArray(raw.size)
         for (i in raw.indices) {
-            unmaskedRaw[i] = if (i <= 1 || i > ifacSize + 1) {
-                // Unmask header bytes and payload (after IFAC)
-                (raw[i].toInt() xor mask[i].toInt()).toByte()
-            } else {
-                // Don't unmask IFAC itself
-                raw[i]
-            }
+            unmaskedRaw[i] =
+                if (i <= 1 || i > ifacSize + 1) {
+                    // Unmask header bytes and payload (after IFAC)
+                    (raw[i].toInt() xor mask[i].toInt()).toByte()
+                } else {
+                    // Don't unmask IFAC itself
+                    raw[i]
+                }
         }
 
         // Clear IFAC flag
-        val newHeader = byteArrayOf(
-            (unmaskedRaw[0].toInt() and 0x7F).toByte(),
-            unmaskedRaw[1]
-        )
+        val newHeader =
+            byteArrayOf(
+                (unmaskedRaw[0].toInt() and 0x7F).toByte(),
+                unmaskedRaw[1],
+            )
 
         // Re-assemble packet without IFAC
         val newRaw = newHeader + unmaskedRaw.copyOfRange(2 + ifacSize, unmaskedRaw.size)
@@ -2297,7 +2358,10 @@ object Transport {
         return newRaw
     }
 
-    private fun processInbound(raw: ByteArray, interfaceRef: InterfaceRef) {
+    private fun processInbound(
+        raw: ByteArray,
+        interfaceRef: InterfaceRef,
+    ) {
         // Parse the packet
         val packet = Packet.unpack(raw)
         if (packet == null) {
@@ -2336,12 +2400,13 @@ object Transport {
         }
 
         // Add to hashlist (with some exceptions)
-        val rememberHash = when {
-            linkTable.containsKey(packet.destinationHash.toKey()) -> false
-            packet.packetType == PacketType.PROOF &&
-                packet.context == PacketContext.LRPROOF -> false
-            else -> true
-        }
+        val rememberHash =
+            when {
+                linkTable.containsKey(packet.destinationHash.toKey()) -> false
+                packet.packetType == PacketType.PROOF &&
+                    packet.context == PacketContext.LRPROOF -> false
+                else -> true
+            }
 
         if (rememberHash) {
             addPacketHash(packet.packetHash)
@@ -2355,9 +2420,9 @@ object Transport {
         // Only applies to PLAIN+BROADCAST packets (path requests, control packets).
         // Announces (SINGLE+BROADCAST) are NOT forwarded here — they are handled
         // by processAnnounce() which re-packages them with HEADER_2 transport headers.
-        if (packet.destinationType == DestinationType.PLAIN
-            && packet.transportType == TransportType.BROADCAST
-            && !controlHashes.contains(packet.destinationHash.toKey())
+        if (packet.destinationType == DestinationType.PLAIN &&
+            packet.transportType == TransportType.BROADCAST &&
+            !controlHashes.contains(packet.destinationHash.toKey())
         ) {
             log("BROADCAST ROUTING: packet from ${interfaceRef.name}, localClients=${localClientInterfaces.size}")
 
@@ -2384,7 +2449,9 @@ object Transport {
                 for (iface in localClientInterfaces) {
                     if (iface.canSend && iface.online) {
                         try {
-                            log("BROADCAST ROUTING: Forwarding ${packet.packetType} (destType=${packet.destinationType}, transport=${packet.transportType}) to local client ${iface.name}")
+                            log(
+                                "BROADCAST ROUTING: Forwarding ${packet.packetType} (destType=${packet.destinationType}, transport=${packet.transportType}) to local client ${iface.name}",
+                            )
                             iface.send(raw)
                         } catch (e: Exception) {
                             log("Error forwarding from external to local client ${iface.name}: ${e.message}")
@@ -2398,21 +2465,25 @@ object Transport {
 
         // Detect packets for local clients (Python Transport.py:1378-1382)
         val fromLocalClient = localClientInterfaces.any { it.hash.contentEquals(interfaceRef.hash) }
-        val forLocalClient = packet.packetType != PacketType.ANNOUNCE &&
-            pathTable[packet.destinationHash.toKey()]?.let { it.hops == 0 } == true
-        val forLocalClientLink = packet.packetType != PacketType.ANNOUNCE &&
-            linkTable[packet.destinationHash.toKey()]?.let { entry ->
-                localClientInterfaces.any { it.hash.contentEquals(entry.receivingInterfaceHash) } ||
-                localClientInterfaces.any { it.hash.contentEquals(entry.nextHopInterfaceHash) }
-            } == true
+        val forLocalClient =
+            packet.packetType != PacketType.ANNOUNCE &&
+                pathTable[packet.destinationHash.toKey()]?.let { it.hops == 0 } == true
+        val forLocalClientLink =
+            packet.packetType != PacketType.ANNOUNCE &&
+                linkTable[packet.destinationHash.toKey()]?.let { entry ->
+                    localClientInterfaces.any { it.hash.contentEquals(entry.receivingInterfaceHash) } ||
+                        localClientInterfaces.any { it.hash.contentEquals(entry.nextHopInterfaceHash) }
+                } == true
 
         // Synthesize transport_id for local client routing (Python Transport.py:1413-1414)
         // When a HEADER_1 packet arrives for a destination behind a local client,
         // we insert our identity as transport_id so the transport forwarding can handle it.
         // LRPROOF is excluded: it is forwarded exclusively via link_table in processProof,
         // never via pathTable-based general transport forwarding.
-        if (packet.transportId == null && forLocalClient &&
-            packet.context != PacketContext.LRPROOF) {
+        if (packet.transportId == null &&
+            forLocalClient &&
+            packet.context != PacketContext.LRPROOF
+        ) {
             packet.transportId = identity?.hash
         }
 
@@ -2421,18 +2492,22 @@ object Transport {
         // existing forwarding logic can handle it. Python clients always send HEADER_2
         // for hops >= 1 (Transport.py:993-1011), but if a client omits transport
         // headers, the shared instance must still be able to forward the packet.
-        if (fromLocalClient && packet.transportId == null && !forLocalClient &&
+        if (fromLocalClient &&
+            packet.transportId == null &&
+            !forLocalClient &&
             packet.packetType != PacketType.ANNOUNCE &&
-            packet.context != PacketContext.LRPROOF) {
+            packet.context != PacketContext.LRPROOF
+        ) {
             val destPathEntry = pathTable[packet.destinationHash.toKey()]
             if (destPathEntry != null) {
                 val myHash = identity?.hash
                 val packetRaw = packet.raw
                 if (myHash != null && packetRaw != null) {
                     // Convert HEADER_1 raw to HEADER_2 by inserting transport_id
-                    val newFlags = (HeaderType.HEADER_2.value shl 6) or
-                                   (TransportType.TRANSPORT.value shl 4) or
-                                   (packetRaw[0].toInt() and 0x0F)
+                    val newFlags =
+                        (HeaderType.HEADER_2.value shl 6) or
+                            (TransportType.TRANSPORT.value shl 4) or
+                            (packetRaw[0].toInt() and 0x0F)
                     val newRaw = ByteArray(packetRaw.size + RnsConstants.TRUNCATED_HASH_BYTES)
                     newRaw[0] = newFlags.toByte()
                     newRaw[1] = packetRaw[1]
@@ -2452,8 +2527,10 @@ object Transport {
             // LRPROOF is forwarded exclusively via link_table in processProof
             // (Python Transport.py:2016-2039), never via pathTable. Without this guard,
             // LRPROOF can loop because it is not added to the packet hash filter.
-            if (packet.transportId != null && packet.packetType != PacketType.ANNOUNCE &&
-                packet.context != PacketContext.LRPROOF) {
+            if (packet.transportId != null &&
+                packet.packetType != PacketType.ANNOUNCE &&
+                packet.context != PacketContext.LRPROOF
+            ) {
                 val myHash = identity?.hash
                 if (myHash != null && packet.transportId!!.contentEquals(myHash)) {
                     val pathEntry = pathTable[packet.destinationHash.toKey()]
@@ -2463,66 +2540,72 @@ object Transport {
                             val packetRaw = packet.raw
                             if (packetRaw != null) {
                                 // Build forwarded raw based on remaining hops (Python:1433-1449)
-                                val newRaw = when {
-                                    pathEntry.hops > 1 -> {
-                                        // Keep HEADER_2, update next hop
-                                        val nr = packetRaw.copyOf()
-                                        nr[1] = packet.hops.toByte()
-                                        System.arraycopy(pathEntry.nextHop, 0, nr, 2, RnsConstants.TRUNCATED_HASH_BYTES)
-                                        nr
+                                val newRaw =
+                                    when {
+                                        pathEntry.hops > 1 -> {
+                                            // Keep HEADER_2, update next hop
+                                            val nr = packetRaw.copyOf()
+                                            nr[1] = packet.hops.toByte()
+                                            System.arraycopy(pathEntry.nextHop, 0, nr, 2, RnsConstants.TRUNCATED_HASH_BYTES)
+                                            nr
+                                        }
+                                        pathEntry.hops == 1 -> {
+                                            // Strip transport header → HEADER_1
+                                            // Destination is one hop away, no transport needed
+                                            val newFlags =
+                                                (HeaderType.HEADER_1.value shl 6) or
+                                                    (TransportType.BROADCAST.value shl 4) or
+                                                    (packetRaw[0].toInt() and 0x0F)
+                                            val nr = ByteArray(packetRaw.size - RnsConstants.TRUNCATED_HASH_BYTES)
+                                            nr[0] = newFlags.toByte()
+                                            nr[1] = packet.hops.toByte()
+                                            System.arraycopy(
+                                                packetRaw,
+                                                2 + RnsConstants.TRUNCATED_HASH_BYTES,
+                                                nr,
+                                                2,
+                                                packetRaw.size - 2 - RnsConstants.TRUNCATED_HASH_BYTES,
+                                            )
+                                            nr
+                                        }
+                                        else -> {
+                                            // hops==0: destination is behind a local client.
+                                            // Just update hop count in original raw (Python:1446-1449).
+                                            // The raw may be HEADER_1 (if transport_id was synthesized)
+                                            // or HEADER_2 — keep its format as-is.
+                                            val nr = packetRaw.copyOf()
+                                            nr[1] = packet.hops.toByte()
+                                            nr
+                                        }
                                     }
-                                    pathEntry.hops == 1 -> {
-                                        // Strip transport header → HEADER_1
-                                        // Destination is one hop away, no transport needed
-                                        val newFlags = (HeaderType.HEADER_1.value shl 6) or
-                                                       (TransportType.BROADCAST.value shl 4) or
-                                                       (packetRaw[0].toInt() and 0x0F)
-                                        val nr = ByteArray(packetRaw.size - RnsConstants.TRUNCATED_HASH_BYTES)
-                                        nr[0] = newFlags.toByte()
-                                        nr[1] = packet.hops.toByte()
-                                        System.arraycopy(
-                                            packetRaw, 2 + RnsConstants.TRUNCATED_HASH_BYTES,
-                                            nr, 2,
-                                            packetRaw.size - 2 - RnsConstants.TRUNCATED_HASH_BYTES
-                                        )
-                                        nr
-                                    }
-                                    else -> {
-                                        // hops==0: destination is behind a local client.
-                                        // Just update hop count in original raw (Python:1446-1449).
-                                        // The raw may be HEADER_1 (if transport_id was synthesized)
-                                        // or HEADER_2 — keep its format as-is.
-                                        val nr = packetRaw.copyOf()
-                                        nr[1] = packet.hops.toByte()
-                                        nr
-                                    }
-                                }
 
                                 // For LINKREQUEST: create link_table entry (Python:1453-1493)
                                 if (packet.packetType == PacketType.LINKREQUEST) {
                                     val linkId = Link.linkIdFromLrPacket(packet)
                                     val now = System.currentTimeMillis()
                                     val proofTimeout = now + LinkConstants.ESTABLISHMENT_TIMEOUT_PER_HOP * maxOf(1, pathEntry.hops)
-                                    val linkEntry = LinkEntry(
-                                        timestamp = now,
-                                        nextHop = pathEntry.nextHop,
-                                        nextHopInterfaceHash = pathEntry.receivingInterfaceHash,
-                                        remainingHops = pathEntry.hops,
-                                        receivingInterfaceHash = interfaceRef.hash,
-                                        takenHops = packet.hops,
-                                        destinationHash = packet.destinationHash,
-                                        validated = false,
-                                        proofTimeout = proofTimeout
-                                    )
+                                    val linkEntry =
+                                        LinkEntry(
+                                            timestamp = now,
+                                            nextHop = pathEntry.nextHop,
+                                            nextHopInterfaceHash = pathEntry.receivingInterfaceHash,
+                                            remainingHops = pathEntry.hops,
+                                            receivingInterfaceHash = interfaceRef.hash,
+                                            takenHops = packet.hops,
+                                            destinationHash = packet.destinationHash,
+                                            validated = false,
+                                            proofTimeout = proofTimeout,
+                                        )
                                     linkTable[linkId.toKey()] = linkEntry
                                     log("Created link table entry for ${linkId.toHexString()} (remaining=${pathEntry.hops}, taken=${packet.hops})")
                                 } else {
                                     // For other types: create reverse_table entry (Python:1495-1501)
-                                    val reverseEntry = ReverseEntry(
-                                        receivingInterfaceHash = interfaceRef.hash,
-                                        outboundInterfaceHash = outboundInterface.hash,
-                                        timestamp = System.currentTimeMillis()
-                                    )
+                                    val reverseEntry =
+                                        ReverseEntry(
+                                            receivingInterfaceHash = interfaceRef.hash,
+                                            outboundInterfaceHash = outboundInterface.hash,
+                                            timestamp = System.currentTimeMillis(),
+                                        )
                                     reverseTable[packet.truncatedHash.toKey()] = reverseEntry
                                 }
 
@@ -2530,7 +2613,9 @@ object Transport {
                                 val touched = pathEntry.touch()
                                 pathTable[packet.destinationHash.toKey()] = touched
                                 pathStore?.upsertPath(packet.destinationHash, touched)
-                                log("Transport forwarding ${packet.packetType} for ${packet.destinationHash.toHexString()} via ${outboundInterface.name} (remaining_hops=${pathEntry.hops})")
+                                log(
+                                    "Transport forwarding ${packet.packetType} for ${packet.destinationHash.toHexString()} via ${outboundInterface.name} (remaining_hops=${pathEntry.hops})",
+                                )
                             }
                         } else {
                             log("Transport forwarding: path exists for ${packet.destinationHash.toHexString()} but interface not found")
@@ -2602,9 +2687,10 @@ object Transport {
         if (packet.destinationType == DestinationType.LINK && packet.link != null) {
             val key = packet.destinationHash.toKey()
             val senderLink = packet.link
-            val peerLink = activeLinks.find {
-                getLinkId(it)?.toKey() == key && it !== senderLink
-            }
+            val peerLink =
+                activeLinks.find {
+                    getLinkId(it)?.toKey() == key && it !== senderLink
+                }
             if (peerLink != null) {
                 try {
                     val receiveMethod = peerLink::class.java.getMethod("receive", Packet::class.java)
@@ -2625,18 +2711,21 @@ object Transport {
         // For DATA packets with multi-hop paths, we still broadcast since HEADER_2 transport
         // routing has issues with nextHop. But for 1-hop (direct) paths, we use path routing
         // to avoid duplicate sends across multiple interfaces.
-        val usePathRouting = pathEntry != null && !pathEntry.isExpired() &&
-            packet.packetType != PacketType.ANNOUNCE &&
-            packet.destinationType != DestinationType.PLAIN &&
-            packet.destinationType != DestinationType.GROUP
+        val usePathRouting =
+            pathEntry != null &&
+                !pathEntry.isExpired() &&
+                packet.packetType != PacketType.ANNOUNCE &&
+                packet.destinationType != DestinationType.PLAIN &&
+                packet.destinationType != DestinationType.GROUP
 
         // For DATA packets, only use path routing for direct (1-hop) connections
         // Multi-hop DATA packets still need broadcasting until transport routing is fixed
-        val effectiveUsePathRouting = if (packet.packetType == PacketType.DATA && pathEntry != null) {
-            usePathRouting && pathEntry.hops == 1
-        } else {
-            usePathRouting
-        }
+        val effectiveUsePathRouting =
+            if (packet.packetType == PacketType.DATA && pathEntry != null) {
+                usePathRouting && pathEntry.hops == 1
+            } else {
+                usePathRouting
+            }
 
         if (effectiveUsePathRouting) {
             // We have a path - use it
@@ -2697,9 +2786,12 @@ object Transport {
                     if (packet.destinationType == DestinationType.LINK) {
                         val linkObj = packet.link
                         if (linkObj != null) {
-                            val attachedHash = try {
-                                linkObj::class.java.getMethod("getAttachedInterfaceHash").invoke(linkObj) as? ByteArray
-                            } catch (_: Exception) { null }
+                            val attachedHash =
+                                try {
+                                    linkObj::class.java.getMethod("getAttachedInterfaceHash").invoke(linkObj) as? ByteArray
+                                } catch (_: Exception) {
+                                    null
+                                }
                             if (attachedHash != null && !iface.hash.contentEquals(attachedHash)) {
                                 continue
                             }
@@ -2722,7 +2814,8 @@ object Transport {
         }
 
         // Create receipt after successful transmit, with guards matching Python Transport.py:947-956
-        if (sent && packet.createReceipt &&
+        if (sent &&
+            packet.createReceipt &&
             packet.packetType == PacketType.DATA &&
             packet.destination?.type != DestinationType.PLAIN &&
             !(packet.context.value in PacketContext.KEEPALIVE.value..PacketContext.LRPROOF.value) &&
@@ -2739,13 +2832,17 @@ object Transport {
      * Transmit raw data on an interface.
      * Applies IFAC masking if the interface has IFAC enabled.
      */
-    private fun transmit(interfaceRef: InterfaceRef, data: ByteArray) {
+    private fun transmit(
+        interfaceRef: InterfaceRef,
+        data: ByteArray,
+    ) {
         try {
-            val transmitData = if (interfaceRef.ifacIdentity != null && interfaceRef.ifacSize > 0) {
-                applyIfacMasking(data, interfaceRef)
-            } else {
-                data
-            }
+            val transmitData =
+                if (interfaceRef.ifacIdentity != null && interfaceRef.ifacSize > 0) {
+                    applyIfacMasking(data, interfaceRef)
+                } else {
+                    data
+                }
             // Debug: log packet header bytes
             if (data.size >= 19) {
                 val flags = data[0].toInt() and 0xFF
@@ -2766,7 +2863,10 @@ object Transport {
      * Apply IFAC (Interface Access Code) masking to a packet.
      * This authenticates the packet for the specific interface.
      */
-    private fun applyIfacMasking(raw: ByteArray, interfaceRef: InterfaceRef): ByteArray {
+    private fun applyIfacMasking(
+        raw: ByteArray,
+        interfaceRef: InterfaceRef,
+    ): ByteArray {
         val ifacIdentity = interfaceRef.ifacIdentity ?: return raw
         val ifacKey = interfaceRef.ifacKey ?: return raw
         val ifacSize = interfaceRef.ifacSize
@@ -2777,18 +2877,20 @@ object Transport {
         val ifac = signature.copyOfRange(signature.size - ifacSize, signature.size)
 
         // Generate mask using HKDF
-        val mask = crypto.hkdf(
-            length = raw.size + ifacSize,
-            ikm = ifac,
-            salt = ifacKey,
-            info = null
-        )
+        val mask =
+            crypto.hkdf(
+                length = raw.size + ifacSize,
+                ikm = ifac,
+                salt = ifacKey,
+                info = null,
+            )
 
         // Set IFAC flag in header (bit 7)
-        val newHeader = byteArrayOf(
-            (raw[0].toInt() or 0x80).toByte(),
-            raw[1]
-        )
+        val newHeader =
+            byteArrayOf(
+                (raw[0].toInt() or 0x80).toByte(),
+                raw[1],
+            )
 
         // Assemble new payload: header + ifac + rest of packet
         val newRaw = newHeader + ifac + raw.copyOfRange(2, raw.size)
@@ -2796,20 +2898,21 @@ object Transport {
         // Mask the payload
         val maskedRaw = ByteArray(newRaw.size)
         for (i in newRaw.indices) {
-            maskedRaw[i] = when {
-                i == 0 -> {
-                    // Mask first header byte but keep IFAC flag set
-                    ((newRaw[i].toInt() xor mask[i].toInt()) or 0x80).toByte()
+            maskedRaw[i] =
+                when {
+                    i == 0 -> {
+                        // Mask first header byte but keep IFAC flag set
+                        ((newRaw[i].toInt() xor mask[i].toInt()) or 0x80).toByte()
+                    }
+                    i == 1 || i > ifacSize + 1 -> {
+                        // Mask second header byte and payload (after IFAC)
+                        (newRaw[i].toInt() xor mask[i].toInt()).toByte()
+                    }
+                    else -> {
+                        // Don't mask the IFAC itself
+                        newRaw[i]
+                    }
                 }
-                i == 1 || i > ifacSize + 1 -> {
-                    // Mask second header byte and payload (after IFAC)
-                    (newRaw[i].toInt() xor mask[i].toInt()).toByte()
-                }
-                else -> {
-                    // Don't mask the IFAC itself
-                    newRaw[i]
-                }
-            }
         }
 
         return maskedRaw
@@ -2818,13 +2921,17 @@ object Transport {
     /**
      * Insert a packet into transport by adding HEADER_2.
      */
-    private fun insertIntoTransport(packet: Packet, nextHop: ByteArray): ByteArray {
+    private fun insertIntoTransport(
+        packet: Packet,
+        nextHop: ByteArray,
+    ): ByteArray {
         val raw = packet.raw ?: packet.pack()
 
         // Build new flags with HEADER_2 and TRANSPORT type
-        val newFlags = (HeaderType.HEADER_2.value shl 6) or
-                       (TransportType.TRANSPORT.value shl 4) or
-                       (raw[0].toInt() and 0x0F)
+        val newFlags =
+            (HeaderType.HEADER_2.value shl 6) or
+                (TransportType.TRANSPORT.value shl 4) or
+                (raw[0].toInt() and 0x0F)
 
         // Build new packet: flags + hops + transport_id + rest of original
         val result = ByteArray(raw.size + RnsConstants.TRUNCATED_HASH_BYTES)
@@ -2838,7 +2945,10 @@ object Transport {
 
     // ===== Packet Type Handlers =====
 
-    private fun processAnnounce(packet: Packet, interfaceRef: InterfaceRef) {
+    private fun processAnnounce(
+        packet: Packet,
+        interfaceRef: InterfaceRef,
+    ) {
         // Validate and extract announce data
         val announceData = validateAnnounce(packet)
         if (announceData == null) {
@@ -2875,32 +2985,34 @@ object Transport {
 
         // Determine next hop: transport_id for HEADER_2 announces, dest hash for direct
         // Python Transport.py:1575-1600
-        val receivedFrom = if (packet.transportId != null) {
-            packet.transportId!!.copyOf()
-        } else {
-            destHash.copyOf()
-        }
+        val receivedFrom =
+            if (packet.transportId != null) {
+                packet.transportId!!.copyOf()
+            } else {
+                destHash.copyOf()
+            }
 
         // Check if this announce should update the path table (Python:1604-1686)
         val existingEntry = pathTable[destHash.toKey()]
-        val shouldAdd = if (existingEntry != null) {
-            if (packet.hops <= existingEntry.hops) {
-                // Better or equal path — update if we haven't seen this random blob
-                !existingEntry.randomBlobs.any { it.contentEquals(announceData.randomHash) }
-            } else {
-                // Worse path — only update if existing is expired or unresponsive
-                val now = System.currentTimeMillis()
-                if (now >= existingEntry.expires) {
+        val shouldAdd =
+            if (existingEntry != null) {
+                if (packet.hops <= existingEntry.hops) {
+                    // Better or equal path — update if we haven't seen this random blob
                     !existingEntry.randomBlobs.any { it.contentEquals(announceData.randomHash) }
-                } else if (isPathUnresponsive(destHash)) {
-                    true
                 } else {
-                    false
+                    // Worse path — only update if existing is expired or unresponsive
+                    val now = System.currentTimeMillis()
+                    if (now >= existingEntry.expires) {
+                        !existingEntry.randomBlobs.any { it.contentEquals(announceData.randomHash) }
+                    } else if (isPathUnresponsive(destHash)) {
+                        true
+                    } else {
+                        false
+                    }
                 }
+            } else {
+                true // Unknown destination, always add
             }
-        } else {
-            true // Unknown destination, always add
-        }
 
         if (!shouldAdd) {
             // Python: when should_add is False, no retransmission or path update happens.
@@ -2920,15 +3032,16 @@ object Transport {
             randomBlobs.removeAt(0)
         }
 
-        val pathEntry = PathEntry(
-            timestamp = System.currentTimeMillis(),
-            nextHop = receivedFrom,
-            hops = packet.hops,
-            expires = System.currentTimeMillis() + AnnounceFilter.pathExpiryForMode(interfaceRef.mode),
-            randomBlobs = randomBlobs,
-            receivingInterfaceHash = interfaceRef.hash,
-            announcePacketHash = packet.packetHash
-        )
+        val pathEntry =
+            PathEntry(
+                timestamp = System.currentTimeMillis(),
+                nextHop = receivedFrom,
+                hops = packet.hops,
+                expires = System.currentTimeMillis() + AnnounceFilter.pathExpiryForMode(interfaceRef.mode),
+                randomBlobs = randomBlobs,
+                receivingInterfaceHash = interfaceRef.hash,
+                announcePacketHash = packet.packetHash,
+            )
 
         pathTable[destHash.toKey()] = pathEntry
         pathStore?.upsertPath(destHash, pathEntry)
@@ -2938,7 +3051,7 @@ object Transport {
             destHash = destHash,
             pathEntry = pathEntry,
             packet = packet,
-            interface_ = interfaceRef
+            interface_ = interfaceRef,
         )
 
         // Store the identity for later recall
@@ -2946,13 +3059,14 @@ object Transport {
             packetHash = packet.packetHash,
             destHash = destHash,
             publicKey = identity.getPublicKey(),
-            appData = appData
+            appData = appData,
         )
 
         // Store ratchet if present in announce
         val ratchet = announceData.ratchet
         if (ratchet != null) {
-            network.reticulum.destination.Destination.setRatchetForDestination(destHash, ratchet)
+            network.reticulum.destination.Destination
+                .setRatchetForDestination(destHash, ratchet)
             Identity.rememberRatchet(destHash, ratchet)
         }
 
@@ -3008,18 +3122,19 @@ object Transport {
 
         log("Immediately retransmitting announce to ${localClientInterfaces.size} local clients")
 
-        val forwardPacket = Packet.createRaw(
-            destinationHash = packet.destinationHash,
-            data = packet.data,
-            packetType = PacketType.ANNOUNCE,
-            destinationType = packet.destinationType,
-            context = PacketContext.NONE,
-            headerType = HeaderType.HEADER_2,
-            transportType = TransportType.TRANSPORT,
-            transportId = transportIdentityHash,
-            contextFlag = packet.contextFlag,
-            createReceipt = false
-        )
+        val forwardPacket =
+            Packet.createRaw(
+                destinationHash = packet.destinationHash,
+                data = packet.data,
+                packetType = PacketType.ANNOUNCE,
+                destinationType = packet.destinationType,
+                context = PacketContext.NONE,
+                headerType = HeaderType.HEADER_2,
+                transportType = TransportType.TRANSPORT,
+                transportId = transportIdentityHash,
+                contextFlag = packet.contextFlag,
+                createReceipt = false,
+            )
         forwardPacket.hops = packet.hops
         val forwardRaw = forwardPacket.pack()
 
@@ -3042,7 +3157,7 @@ object Transport {
         destinationHash: ByteArray,
         packet: Packet,
         receivingInterface: InterfaceRef,
-        fromLocalClient: Boolean = false
+        fromLocalClient: Boolean = false,
     ) {
         val destKey = destinationHash.toKey()
         val now = System.currentTimeMillis()
@@ -3082,20 +3197,21 @@ object Transport {
         rateTimestamps.add(now)
 
         // Store/update in announce table for potential path request responses
-        val announceEntry = existingEntry?.copy(
-            timestamp = now,
-            raw = packet.raw ?: packet.pack(),
-            receivingInterfaceHash = receivingInterface.hash
-        ) ?: AnnounceEntry(
-            destinationHash = destinationHash.copyOf(),
-            timestamp = now,
-            retransmits = 0,
-            retransmitTimeout = now,
-            raw = packet.raw ?: packet.pack(),
-            hops = packet.hops,
-            receivingInterfaceHash = receivingInterface.hash,
-            localRebroadcasts = 0
-        )
+        val announceEntry =
+            existingEntry?.copy(
+                timestamp = now,
+                raw = packet.raw ?: packet.pack(),
+                receivingInterfaceHash = receivingInterface.hash,
+            ) ?: AnnounceEntry(
+                destinationHash = destinationHash.copyOf(),
+                timestamp = now,
+                retransmits = 0,
+                retransmitTimeout = now,
+                raw = packet.raw ?: packet.pack(),
+                hops = packet.hops,
+                receivingInterfaceHash = receivingInterface.hash,
+                localRebroadcasts = 0,
+            )
         announceTable[destKey] = announceEntry
 
         // Python lines 570-573: reinstate held announce entry after rebroadcast
@@ -3116,18 +3232,19 @@ object Transport {
             return
         }
 
-        val retransmitPacket = Packet.createRaw(
-            destinationHash = packet.destinationHash,
-            data = packet.data,
-            packetType = PacketType.ANNOUNCE,
-            destinationType = packet.destinationType,
-            context = PacketContext.NONE,
-            headerType = HeaderType.HEADER_2,
-            transportType = TransportType.TRANSPORT,
-            transportId = transportIdentityHash,
-            contextFlag = packet.contextFlag,
-            createReceipt = false
-        )
+        val retransmitPacket =
+            Packet.createRaw(
+                destinationHash = packet.destinationHash,
+                data = packet.data,
+                packetType = PacketType.ANNOUNCE,
+                destinationType = packet.destinationType,
+                context = PacketContext.NONE,
+                headerType = HeaderType.HEADER_2,
+                transportType = TransportType.TRANSPORT,
+                transportId = transportIdentityHash,
+                contextFlag = packet.contextFlag,
+                createReceipt = false,
+            )
         retransmitPacket.hops = packet.hops
         val retransmitRaw = retransmitPacket.pack()
 
@@ -3141,9 +3258,13 @@ object Transport {
         val sourceMode = nextHopInterface(destinationHash)?.mode
 
         for (iface in interfaces) {
-            if (!iface.canSend || !iface.online ||
+            if (!iface.canSend ||
+                !iface.online ||
                 iface.hash.contentEquals(receivingInterface.hash) ||
-                isLocalClientInterface(iface)) continue
+                isLocalClientInterface(iface)
+            ) {
+                continue
+            }
 
             if (AnnounceFilter.shouldForward(iface.mode, isLocal, sourceMode)) {
                 queueAnnounce(
@@ -3151,27 +3272,32 @@ object Transport {
                     raw = retransmitRaw,
                     interfaceRef = iface,
                     hops = packet.hops,
-                    emitted = now
+                    emitted = now,
                 )
             }
         }
     }
 
-    private fun processData(packet: Packet, interfaceRef: InterfaceRef) {
+    private fun processData(
+        packet: Packet,
+        interfaceRef: InterfaceRef,
+    ) {
         log("processData: dest=${packet.destinationHash.toHexString()}, ${packet.data.size} bytes from ${interfaceRef.name}")
 
         // Check if this is a control packet (path request, tunnel synthesis, etc.)
         if (controlHashes.contains(packet.destinationHash.toKey())) {
             // Check if this is a path request
             if (pathRequestDestination != null &&
-                packet.destinationHash.contentEquals(pathRequestDestination!!.hash)) {
+                packet.destinationHash.contentEquals(pathRequestDestination!!.hash)
+            ) {
                 handlePathRequest(packet.data, packet, interfaceRef)
                 return
             }
 
             // Check if this is a tunnel synthesis request
             if (tunnelSynthesizeDestination != null &&
-                packet.destinationHash.contentEquals(tunnelSynthesizeDestination!!.hash)) {
+                packet.destinationHash.contentEquals(tunnelSynthesizeDestination!!.hash)
+            ) {
                 log("Received tunnel synthesis request on ${interfaceRef.name}")
                 tunnelSynthesizeHandler(packet.data, packet, interfaceRef)
                 return
@@ -3195,9 +3321,12 @@ object Transport {
         if (matchingLinks.isNotEmpty()) {
             for (link in matchingLinks) {
                 // Python: if link.attached_interface == packet.receiving_interface
-                val attachedHash = try {
-                    link::class.java.getMethod("getAttachedInterfaceHash").invoke(link) as? ByteArray
-                } catch (_: Exception) { null }
+                val attachedHash =
+                    try {
+                        link::class.java.getMethod("getAttachedInterfaceHash").invoke(link) as? ByteArray
+                    } catch (_: Exception) {
+                        null
+                    }
                 val pktIfaceHash = packet.receivingInterfaceHash
                 if (attachedHash != null && pktIfaceHash != null && !attachedHash.contentEquals(pktIfaceHash)) {
                     log("WARNING: Link interface mismatch on ${packet.destinationHash.toHexString()}, potential communication manipulation or misconfiguration")
@@ -3223,11 +3352,12 @@ object Transport {
 
                 // Create reverse entry for proof routing back to sender
                 // This is critical for shared instance clients to receive delivery proofs
-                val reverseEntry = ReverseEntry(
-                    receivingInterfaceHash = interfaceRef.hash,
-                    outboundInterfaceHash = outboundInterface.hash,
-                    timestamp = System.currentTimeMillis()
-                )
+                val reverseEntry =
+                    ReverseEntry(
+                        receivingInterfaceHash = interfaceRef.hash,
+                        outboundInterfaceHash = outboundInterface.hash,
+                        timestamp = System.currentTimeMillis(),
+                    )
                 reverseTable[packet.truncatedHash.toKey()] = reverseEntry
                 log("Created reverse entry for proof routing: ${packet.truncatedHash.toHexString()} -> ${interfaceRef.name}")
 
@@ -3245,31 +3375,37 @@ object Transport {
             if (linkEntry != null) {
                 val nhIface = findInterfaceByHash(linkEntry.nextHopInterfaceHash)
                 val rcvdIface = findInterfaceByHash(linkEntry.receivingInterfaceHash)
-                val outboundInterface = when {
-                    // Same interface for both directions — just repeat (Python lines 1521-1525)
-                    nhIface != null && rcvdIface != null &&
-                        nhIface.hash.contentEquals(rcvdIface.hash) -> {
-                        if (packet.hops == linkEntry.remainingHops || packet.hops == linkEntry.takenHops) nhIface
-                        else null
+                val outboundInterface =
+                    when {
+                        // Same interface for both directions — just repeat (Python lines 1521-1525)
+                        nhIface != null &&
+                            rcvdIface != null &&
+                            nhIface.hash.contentEquals(rcvdIface.hash) -> {
+                            if (packet.hops == linkEntry.remainingHops || packet.hops == linkEntry.takenHops) {
+                                nhIface
+                            } else {
+                                null
+                            }
+                        }
+                        // Different interfaces — transmit on opposite side (Python lines 1526-1537)
+                        nhIface != null && interfaceRef.hash.contentEquals(nhIface.hash) -> {
+                            if (packet.hops == linkEntry.remainingHops) rcvdIface else null
+                        }
+                        rcvdIface != null && interfaceRef.hash.contentEquals(rcvdIface.hash) -> {
+                            if (packet.hops == linkEntry.takenHops) nhIface else null
+                        }
+                        else -> null
                     }
-                    // Different interfaces — transmit on opposite side (Python lines 1526-1537)
-                    nhIface != null && interfaceRef.hash.contentEquals(nhIface.hash) -> {
-                        if (packet.hops == linkEntry.remainingHops) rcvdIface else null
-                    }
-                    rcvdIface != null && interfaceRef.hash.contentEquals(rcvdIface.hash) -> {
-                        if (packet.hops == linkEntry.takenHops) nhIface else null
-                    }
-                    else -> null
-                }
                 if (outboundInterface != null) {
-                    addPacketHash(packet.packetHash)  // Python line 1543
+                    addPacketHash(packet.packetHash) // Python line 1543
                     val raw = packet.raw ?: packet.pack()
                     val newRaw = raw.copyOf()
                     newRaw[1] = packet.hops.toByte()
                     transmit(outboundInterface, newRaw)
-                    linkTable[packet.destinationHash.toKey()] = linkEntry.copy(
-                        timestamp = System.currentTimeMillis()
-                    )
+                    linkTable[packet.destinationHash.toKey()] =
+                        linkEntry.copy(
+                            timestamp = System.currentTimeMillis(),
+                        )
                     log("Forwarding link data for ${packet.destinationHash.toHexString()} via ${outboundInterface.name}")
                     return
                 }
@@ -3281,7 +3417,10 @@ object Transport {
         // This ensures LINKREQUEST, PROOF, and DATA packets all get transport forwarding.
     }
 
-    private fun processLinkRequest(packet: Packet, interfaceRef: InterfaceRef) {
+    private fun processLinkRequest(
+        packet: Packet,
+        interfaceRef: InterfaceRef,
+    ) {
         // Python Transport.py:1937-1966: Only deliver locally if transport_id is null
         // (HEADER_1/direct) or matches our identity (we are the final transport hop).
         // Transport forwarding for HEADER_2 packets is handled in processInbound().
@@ -3312,7 +3451,7 @@ object Transport {
         raw: ByteArray,
         packet: Packet,
         outboundInterface: InterfaceRef,
-        receivingInterface: InterfaceRef
+        receivingInterface: InterfaceRef,
     ): ByteArray {
         val pathMtu = Link.mtuFromLrPacket(packet) ?: return raw
         val mode = Link.modeFromLrPacket(packet)
@@ -3351,7 +3490,10 @@ object Transport {
      * Modifies packet.data in-place to clamp signalling bytes to the
      * receiving interface's MTU.
      */
-    private fun clampLinkRequestMtuForLocal(packet: Packet, receivingInterface: InterfaceRef) {
+    private fun clampLinkRequestMtuForLocal(
+        packet: Packet,
+        receivingInterface: InterfaceRef,
+    ) {
         val pathMtu = Link.mtuFromLrPacket(packet) ?: return
         val mode = Link.modeFromLrPacket(packet)
 
@@ -3359,26 +3501,29 @@ object Transport {
         // Python checks: if HW_MTU is None → strip signalling bytes
         //                 elif AUTOCONFIGURE_MTU or FIXED_MTU → use HW_MTU for clamping
         //                 else → use default MTU (500) for clamping
-        val nhMtu = if (receivingInterface.supportsLinkMtuDiscovery) {
-            receivingInterface.hwMtu
-        } else if (receivingInterface.hwMtu > 0) {
-            // Interface has a HW_MTU but doesn't auto-configure — use default MTU
-            RnsConstants.MTU
-        } else {
-            // No HW_MTU at all — strip signalling bytes (Python: HW_MTU == None)
-            log("No next-hop HW MTU, stripping link MTU signalling bytes")
-            packet.data = packet.data.copyOf(packet.data.size - LinkConstants.LINK_MTU_SIZE)
-            return
-        }
+        val nhMtu =
+            if (receivingInterface.supportsLinkMtuDiscovery) {
+                receivingInterface.hwMtu
+            } else if (receivingInterface.hwMtu > 0) {
+                // Interface has a HW_MTU but doesn't auto-configure — use default MTU
+                RnsConstants.MTU
+            } else {
+                // No HW_MTU at all — strip signalling bytes (Python: HW_MTU == None)
+                log("No next-hop HW MTU, stripping link MTU signalling bytes")
+                packet.data = packet.data.copyOf(packet.data.size - LinkConstants.LINK_MTU_SIZE)
+                return
+            }
 
         if (nhMtu < pathMtu) {
             try {
                 val clampedBytes = Link.signallingBytes(nhMtu, mode)
                 log("Clamping link MTU to $nhMtu for local delivery")
                 System.arraycopy(
-                    clampedBytes, 0,
-                    packet.data, packet.data.size - LinkConstants.LINK_MTU_SIZE,
-                    LinkConstants.LINK_MTU_SIZE
+                    clampedBytes,
+                    0,
+                    packet.data,
+                    packet.data.size - LinkConstants.LINK_MTU_SIZE,
+                    LinkConstants.LINK_MTU_SIZE,
                 )
             } catch (e: Exception) {
                 log("Error clamping link MTU for local delivery: ${e.message}")
@@ -3386,7 +3531,10 @@ object Transport {
         }
     }
 
-    private fun processProof(packet: Packet, interfaceRef: InterfaceRef) {
+    private fun processProof(
+        packet: Packet,
+        interfaceRef: InterfaceRef,
+    ) {
         log("Processing proof: dest=${packet.destinationHash.toHexString()}, context=${packet.context}, from ${interfaceRef.name}")
 
         // Proof handling uses when {} to match the Python if/elif/else structure
@@ -3510,13 +3658,18 @@ object Transport {
                         log("Proof callback error: ${e.message}")
                     }
                 } else {
-                    log("Proof dest=${packet.destinationHash.toHexString()} not found in link_table (${linkTable.size} entries) or reverse_table (${reverseTable.size} entries)")
+                    log(
+                        "Proof dest=${packet.destinationHash.toHexString()} not found in link_table (${linkTable.size} entries) or reverse_table (${reverseTable.size} entries)",
+                    )
                 }
             }
         }
     }
 
-    private fun forwardPacket(packet: Packet, receivingInterface: InterfaceRef) {
+    private fun forwardPacket(
+        packet: Packet,
+        receivingInterface: InterfaceRef,
+    ) {
         val pathEntry = pathTable[packet.destinationHash.toKey()] ?: return
         val outboundInterface = findInterfaceByHash(pathEntry.receivingInterfaceHash) ?: return
 
@@ -3532,16 +3685,19 @@ object Transport {
             }
             pathEntry.hops == 1 -> {
                 // Strip transport header, convert to HEADER_1 (Python Transport.py:1439-1444)
-                val newFlags = (HeaderType.HEADER_1.value shl 6) or
-                               (TransportType.BROADCAST.value shl 4) or
-                               (raw[0].toInt() and 0x0F)
+                val newFlags =
+                    (HeaderType.HEADER_1.value shl 6) or
+                        (TransportType.BROADCAST.value shl 4) or
+                        (raw[0].toInt() and 0x0F)
                 val newRaw = ByteArray(raw.size - RnsConstants.TRUNCATED_HASH_BYTES)
                 newRaw[0] = newFlags.toByte()
                 newRaw[1] = packet.hops.toByte()
                 System.arraycopy(
-                    raw, 2 + RnsConstants.TRUNCATED_HASH_BYTES,
-                    newRaw, 2,
-                    raw.size - 2 - RnsConstants.TRUNCATED_HASH_BYTES
+                    raw,
+                    2 + RnsConstants.TRUNCATED_HASH_BYTES,
+                    newRaw,
+                    2,
+                    raw.size - 2 - RnsConstants.TRUNCATED_HASH_BYTES,
                 )
                 transmit(outboundInterface, newRaw)
             }
@@ -3554,11 +3710,12 @@ object Transport {
         }
 
         // Record reverse entry for proofs
-        val reverseEntry = ReverseEntry(
-            receivingInterfaceHash = receivingInterface.hash,
-            outboundInterfaceHash = outboundInterface.hash,
-            timestamp = System.currentTimeMillis()
-        )
+        val reverseEntry =
+            ReverseEntry(
+                receivingInterfaceHash = receivingInterface.hash,
+                outboundInterfaceHash = outboundInterface.hash,
+                timestamp = System.currentTimeMillis(),
+            )
         reverseTable[packet.truncatedHash.toKey()] = reverseEntry
 
         // Update path timestamp
@@ -3567,7 +3724,10 @@ object Transport {
         pathStore?.upsertPath(packet.destinationHash, touched)
     }
 
-    private fun deliverPacket(destination: Destination, packet: Packet) {
+    private fun deliverPacket(
+        destination: Destination,
+        packet: Packet,
+    ) {
         val data = packet.data
         if (data.isEmpty()) {
             log("Ignoring empty packet for ${destination.hexHash}")
@@ -3582,13 +3742,15 @@ object Transport {
             when (packet.packetType) {
                 PacketType.DATA -> {
                     // Decrypt the data if needed
-                    val plaintext = when (destination.type) {
-                        DestinationType.PLAIN -> data
-                        else -> destination.decrypt(data) ?: run {
-                            log("Failed to decrypt packet for ${destination.hexHash}")
-                            return
+                    val plaintext =
+                        when (destination.type) {
+                            DestinationType.PLAIN -> data
+                            else ->
+                                destination.decrypt(data) ?: run {
+                                    log("Failed to decrypt packet for ${destination.hexHash}")
+                                    return
+                                }
                         }
-                    }
 
                     // Deliver via callback
                     val callback = destination.packetCallback
@@ -3634,7 +3796,7 @@ object Transport {
         val nameHash: ByteArray,
         val randomHash: ByteArray,
         val appData: ByteArray?,
-        val ratchet: ByteArray?
+        val ratchet: ByteArray?,
     )
 
     private fun validateAnnounce(packet: Packet): AnnounceData? {
@@ -3694,12 +3856,13 @@ object Transport {
         }
 
         // Create identity from public key
-        val identity = try {
-            Identity.fromPublicKey(publicKey)
-        } catch (e: Exception) {
-            log("Failed to create identity from public key: ${e.message}")
-            return null
-        }
+        val identity =
+            try {
+                Identity.fromPublicKey(publicKey)
+            } catch (e: Exception) {
+                log("Failed to create identity from public key: ${e.message}")
+                return null
+            }
 
         // Verify destination hash matches
         val computedDestHash = Destination.computeHash(nameHash, identity.hash)
@@ -3718,14 +3881,20 @@ object Transport {
         }
 
         return AnnounceData(
-            identity, nameHash, randomHash, appData,
-            ratchet = if (hasRatchet && ratchet.isNotEmpty()) ratchet else null
+            identity,
+            nameHash,
+            randomHash,
+            appData,
+            ratchet = if (hasRatchet && ratchet.isNotEmpty()) ratchet else null,
         )
     }
 
     // ===== Packet Filter (Duplicate Detection) =====
 
-    private fun packetFilter(packet: Packet, receivingInterface: InterfaceRef): Boolean {
+    private fun packetFilter(
+        packet: Packet,
+        receivingInterface: InterfaceRef,
+    ): Boolean {
         // Python RNS: Bypass local filtering if connected to shared instance
         // (Python Transport.py:1187-1190)
         if (isConnectedToSharedInstance) {
@@ -3748,7 +3917,8 @@ object Transport {
         when (packet.context) {
             PacketContext.KEEPALIVE, PacketContext.RESOURCE_REQ,
             PacketContext.RESOURCE_PRF, PacketContext.RESOURCE,
-            PacketContext.CACHE_REQUEST, PacketContext.CHANNEL -> return true
+            PacketContext.CACHE_REQUEST, PacketContext.CHANNEL,
+            -> return true
             else -> {}
         }
 
@@ -3775,8 +3945,9 @@ object Transport {
         if (!packetHashlist.contains(key) && !packetHashlistPrev.contains(key)) {
             return true
         } else if (packet.packetType == PacketType.ANNOUNCE &&
-                   packet.destinationType == DestinationType.SINGLE) {
-            return true  // Allow duplicate SINGLE announces through
+            packet.destinationType == DestinationType.SINGLE
+        ) {
+            return true // Allow duplicate SINGLE announces through
         }
 
         return false
@@ -3812,13 +3983,12 @@ object Transport {
      * Get the effective job interval.
      * Uses custom interval if set, platform-appropriate default otherwise.
      */
-    private fun getJobInterval(): Long {
-        return customJobIntervalMs ?: if (Platform.isAndroid) {
+    private fun getJobInterval(): Long =
+        customJobIntervalMs ?: if (Platform.isAndroid) {
             Platform.recommendedJobIntervalMs
         } else {
             TransportConstants.JOB_INTERVAL
         }
-    }
 
     /**
      * Thread-based job loop (legacy, for JVM).
@@ -3845,19 +4015,20 @@ object Transport {
     private fun startCoroutineJobLoop() {
         val scope = jobLoopScope ?: return
 
-        jobLoopJob = scope.launch {
-            while (isActive && started.get()) {
-                try {
-                    delay(getJobInterval())
-                    if (!paused.get()) {
-                        runJobs()
+        jobLoopJob =
+            scope.launch {
+                while (isActive && started.get()) {
+                    try {
+                        delay(getJobInterval())
+                        if (!paused.get()) {
+                            runJobs()
+                        }
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        log("Coroutine job error: ${e.message}")
                     }
-                } catch (e: Exception) {
-                    if (e is kotlinx.coroutines.CancellationException) throw e
-                    log("Coroutine job error: ${e.message}")
                 }
             }
-        }
     }
 
     /**
@@ -3873,7 +4044,7 @@ object Transport {
         scope: CoroutineScope,
         intervalMs: Long? = null,
         tablesCullIntervalMs: Long? = null,
-        announcesCheckIntervalMs: Long? = null
+        announcesCheckIntervalMs: Long? = null,
     ) {
         jobLoopScope = scope
         customJobIntervalMs = intervalMs
@@ -3982,7 +4153,6 @@ object Transport {
         receipts.removeAll(toRemove)
     }
 
-
     /**
      * Update traffic speed calculations.
      */
@@ -4006,7 +4176,9 @@ object Transport {
      * This is now handled per-interface, but we keep this for backwards compatibility
      * with the old global queue (queuedAnnounces).
      */
-    private fun processQueuedAnnounces(@Suppress("UNUSED_PARAMETER") now: Long) {
+    private fun processQueuedAnnounces(
+        @Suppress("UNUSED_PARAMETER") now: Long,
+    ) {
         // The old global queue is no longer used - announces are now queued per-interface
         // and processed asynchronously via scheduleAnnounceQueueProcessing()
         // This method is kept empty for compatibility with the job loop
@@ -4042,7 +4214,8 @@ object Transport {
                 log("Removing unvalidated link entry: ${entry.key}")
                 true
             } else if (linkEntry.validated &&
-                       now - linkEntry.timestamp > TransportConstants.LINK_TIMEOUT) {
+                now - linkEntry.timestamp > TransportConstants.LINK_TIMEOUT
+            ) {
                 // Also clean up old validated entries
                 true
             } else {
@@ -4090,10 +4263,11 @@ object Transport {
      * @return Tunnel ID, or null if synthesis failed
      */
     fun synthesizeTunnel(interface_: InterfaceRef): ByteArray? {
-        val transportIdentity = identity ?: run {
-            log("Cannot synthesize tunnel: no transport identity")
-            return null
-        }
+        val transportIdentity =
+            identity ?: run {
+                log("Cannot synthesize tunnel: no transport identity")
+                return null
+            }
 
         // Get interface hash (32 bytes)
         val interfaceHash = interface_.getInterfaceHash()
@@ -4121,14 +4295,15 @@ object Transport {
         val destHash = Destination.computeHash("rnstransport", listOf("tunnel", "synthesize"), null)
 
         // Send as broadcast packet directly on the interface
-        val packet = Packet.createRaw(
-            destinationHash = destHash,
-            data = packetData,
-            packetType = PacketType.DATA,
-            destinationType = DestinationType.PLAIN,
-            transportType = TransportType.BROADCAST,
-            headerType = HeaderType.HEADER_1
-        )
+        val packet =
+            Packet.createRaw(
+                destinationHash = destHash,
+                data = packetData,
+                packetType = PacketType.DATA,
+                destinationType = DestinationType.PLAIN,
+                transportType = TransportType.BROADCAST,
+                headerType = HeaderType.HEADER_1,
+            )
 
         // Send directly on this interface (not through outbound routing)
         try {
@@ -4161,7 +4336,11 @@ object Transport {
      * @param receivingInterface The interface that received the packet
      * @return true if tunnel was created successfully
      */
-    fun tunnelSynthesizeHandler(data: ByteArray, @Suppress("UNUSED_PARAMETER") packet: Packet, receivingInterface: InterfaceRef): Boolean {
+    fun tunnelSynthesizeHandler(
+        data: ByteArray,
+        @Suppress("UNUSED_PARAMETER") packet: Packet,
+        receivingInterface: InterfaceRef,
+    ): Boolean {
         // Expected: public_key(64) + interface_hash(32) + random_hash(16) + signature(64) = 176 bytes
         val expectedLength = 64 + 32 + 16 + 64
         if (data.size != expectedLength) {
@@ -4193,7 +4372,6 @@ object Transport {
             // Valid signature - handle the tunnel
             handleTunnelEstablishment(tunnelId, receivingInterface)
             return true
-
         } catch (e: Exception) {
             log("Error validating tunnel synthesis: ${e.message}")
             return false
@@ -4206,7 +4384,10 @@ object Transport {
      * If the tunnel already exists (reconnection), restores paths.
      * If new, creates an empty tunnel entry.
      */
-    private fun handleTunnelEstablishment(tunnelId: ByteArray, interface_: InterfaceRef) {
+    private fun handleTunnelEstablishment(
+        tunnelId: ByteArray,
+        interface_: InterfaceRef,
+    ) {
         val key = ByteArrayKey(tunnelId)
         val now = System.currentTimeMillis()
         val expires = now + TransportConstants.DESTINATION_TIMEOUT
@@ -4223,11 +4404,12 @@ object Transport {
             }
 
             log("Tunnel endpoint ${tunnelId.toHexString()} established")
-            val tunnel = TunnelInfo(
-                tunnelId = tunnelId,
-                interface_ = interface_,
-                expires = expires
-            )
+            val tunnel =
+                TunnelInfo(
+                    tunnelId = tunnelId,
+                    interface_ = interface_,
+                    expires = expires,
+                )
             interface_.tunnelId = tunnelId
             tunnels[key] = tunnel
             tunnelInterfaces[key] = interface_
@@ -4250,14 +4432,17 @@ object Transport {
      * Restore paths from a tunnel to the main path table.
      * Only restores paths that are still valid and better than existing paths.
      */
-    private fun restoreTunnelPaths(tunnel: TunnelInfo, interface_: InterfaceRef) {
+    private fun restoreTunnelPaths(
+        tunnel: TunnelInfo,
+        interface_: InterfaceRef,
+    ) {
         val now = System.currentTimeMillis()
         val deprecatedPaths = mutableListOf<ByteArrayKey>()
 
         for ((destKey, pathEntry) in tunnel.paths) {
             // Check if path has expired
             if (now > pathEntry.expires) {
-                log("Not restoring expired path to ${destKey}")
+                log("Not restoring expired path to $destKey")
                 deprecatedPaths.add(destKey)
                 continue
             }
@@ -4266,24 +4451,25 @@ object Transport {
             val existingPath = pathTable[destKey]
             if (existingPath != null) {
                 if (pathEntry.hops > existingPath.hops && now < existingPath.expires) {
-                    log("Not restoring path to ${destKey}: better path exists")
+                    log("Not restoring path to $destKey: better path exists")
                     continue
                 }
             }
 
             // Restore path to path table
-            val restoredPath = PathEntry(
-                timestamp = now,
-                nextHop = pathEntry.receivedFrom,
-                hops = pathEntry.hops,
-                expires = pathEntry.expires,
-                randomBlobs = pathEntry.randomBlobs.toMutableList(),
-                receivingInterfaceHash = interface_.hash,
-                announcePacketHash = pathEntry.packetHash
-            )
+            val restoredPath =
+                PathEntry(
+                    timestamp = now,
+                    nextHop = pathEntry.receivedFrom,
+                    hops = pathEntry.hops,
+                    expires = pathEntry.expires,
+                    randomBlobs = pathEntry.randomBlobs.toMutableList(),
+                    receivingInterfaceHash = interface_.hash,
+                    announcePacketHash = pathEntry.packetHash,
+                )
             pathTable[destKey] = restoredPath
             pathStore?.upsertPath(destKey.bytes, restoredPath)
-            log("Restored path to ${destKey} (${pathEntry.hops} hops) via tunnel ${tunnel.tunnelId.toHexString()}")
+            log("Restored path to $destKey (${pathEntry.hops} hops) via tunnel ${tunnel.tunnelId.toHexString()}")
         }
 
         // Remove expired paths from tunnel
@@ -4305,20 +4491,21 @@ object Transport {
         destHash: ByteArray,
         pathEntry: PathEntry,
         packet: Packet,
-        interface_: InterfaceRef
+        interface_: InterfaceRef,
     ) {
         val tunnelId = interface_.tunnelId ?: return
         val tunnel = tunnels[ByteArrayKey(tunnelId)] ?: return
 
         // Create tunnel path entry
-        val tunnelPath = TunnelPathEntry(
-            timestamp = pathEntry.timestamp,
-            receivedFrom = pathEntry.nextHop.copyOf(),
-            hops = pathEntry.hops,
-            expires = pathEntry.expires,
-            randomBlobs = pathEntry.randomBlobs.toMutableList(),
-            packetHash = packet.packetHash.copyOf()
-        )
+        val tunnelPath =
+            TunnelPathEntry(
+                timestamp = pathEntry.timestamp,
+                receivedFrom = pathEntry.nextHop.copyOf(),
+                hops = pathEntry.hops,
+                expires = pathEntry.expires,
+                randomBlobs = pathEntry.randomBlobs.toMutableList(),
+                packetHash = packet.packetHash.copyOf(),
+            )
 
         tunnel.paths[destHash.toKey()] = tunnelPath
         tunnel.expires = System.currentTimeMillis() + TransportConstants.DESTINATION_TIMEOUT
@@ -4341,7 +4528,10 @@ object Transport {
      * @param packet The announce packet to cache
      * @param interface_ The receiving interface
      */
-    private fun cacheAnnouncePacket(packet: Packet, interface_: InterfaceRef) {
+    private fun cacheAnnouncePacket(
+        packet: Packet,
+        interface_: InterfaceRef,
+    ) {
         // Use store if available (Room on Android)
         announceStore?.let { store ->
             val raw = packet.raw ?: return
@@ -4625,12 +4815,13 @@ object Transport {
                 unpacker.readPayload(tunnelId)
 
                 // interface_hash (may be nil)
-                val interfaceHash: ByteArray? = if (unpacker.tryUnpackNil()) {
-                    null
-                } else {
-                    val hashLen = unpacker.unpackBinaryHeader()
-                    ByteArray(hashLen).also { unpacker.readPayload(it) }
-                }
+                val interfaceHash: ByteArray? =
+                    if (unpacker.tryUnpackNil()) {
+                        null
+                    } else {
+                        val hashLen = unpacker.unpackBinaryHeader()
+                        ByteArray(hashLen).also { unpacker.readPayload(it) }
+                    }
 
                 // paths array
                 val pathCount = unpacker.unpackArrayHeader()
@@ -4689,14 +4880,15 @@ object Transport {
                     // Check if cached announce packet exists
                     val cachedAnnounce = getCachedAnnouncePacket(packetHash)
                     if (cachedAnnounce != null && !isPathExpired(expires)) {
-                        val pathEntry = TunnelPathEntry(
-                            timestamp = timestamp,
-                            receivedFrom = receivedFrom,
-                            hops = hops,
-                            expires = expires,
-                            randomBlobs = randomBlobs,
-                            packetHash = packetHash
-                        )
+                        val pathEntry =
+                            TunnelPathEntry(
+                                timestamp = timestamp,
+                                receivedFrom = receivedFrom,
+                                hops = hops,
+                                expires = expires,
+                                randomBlobs = randomBlobs,
+                                packetHash = packetHash,
+                            )
                         paths[ByteArrayKey(destHash)] = pathEntry
                     }
                 }
@@ -4706,11 +4898,12 @@ object Transport {
 
                 // Only add tunnel if it has valid paths
                 if (paths.isNotEmpty()) {
-                    val tunnel = TunnelInfo(
-                        tunnelId = tunnelId,
-                        interface_ = null, // Will be reconnected when interface comes back
-                        expires = tunnelExpires
-                    )
+                    val tunnel =
+                        TunnelInfo(
+                            tunnelId = tunnelId,
+                            interface_ = null, // Will be reconnected when interface comes back
+                            expires = tunnelExpires,
+                        )
                     tunnel.paths.putAll(paths)
                     tunnels[ByteArrayKey(tunnelId)] = tunnel
                     log("Loaded tunnel ${tunnelId.toHexString().take(12)} with ${paths.size} paths")
@@ -4728,9 +4921,7 @@ object Transport {
     /**
      * Check if a path has expired.
      */
-    private fun isPathExpired(expires: Long): Boolean {
-        return System.currentTimeMillis() > expires
-    }
+    private fun isPathExpired(expires: Long): Boolean = System.currentTimeMillis() > expires
 
     /**
      * Persist all transport data.
@@ -4815,7 +5006,10 @@ object Transport {
      * @param packet The packet data to transmit
      * @return true if transmitted successfully
      */
-    fun handleTunnel(tunnelId: ByteArray, packet: ByteArray): Boolean {
+    fun handleTunnel(
+        tunnelId: ByteArray,
+        packet: ByteArray,
+    ): Boolean {
         val key = ByteArrayKey(tunnelId)
         val tunnel = tunnels[key] ?: return false
 
@@ -4843,9 +5037,7 @@ object Transport {
      * @param tunnelId The tunnel ID
      * @return TunnelInfo or null if not found
      */
-    fun getTunnel(tunnelId: ByteArray): TunnelInfo? {
-        return tunnels[ByteArrayKey(tunnelId)]
-    }
+    fun getTunnel(tunnelId: ByteArray): TunnelInfo? = tunnels[ByteArrayKey(tunnelId)]
 
     /**
      * Check if a tunnel exists.
@@ -4853,18 +5045,14 @@ object Transport {
      * @param tunnelId The tunnel ID to check
      * @return true if tunnel exists
      */
-    fun hasTunnel(tunnelId: ByteArray): Boolean {
-        return tunnels.containsKey(ByteArrayKey(tunnelId))
-    }
+    fun hasTunnel(tunnelId: ByteArray): Boolean = tunnels.containsKey(ByteArrayKey(tunnelId))
 
     /**
      * Get all active tunnels.
      *
      * @return Map of tunnel IDs to TunnelInfo
      */
-    fun getTunnels(): Map<ByteArrayKey, TunnelInfo> {
-        return tunnels.toMap()
-    }
+    fun getTunnels(): Map<ByteArrayKey, TunnelInfo> = tunnels.toMap()
 
     /**
      * Get interface for a tunnel.
@@ -4872,9 +5060,7 @@ object Transport {
      * @param tunnelId The tunnel ID
      * @return InterfaceRef or null if not found
      */
-    fun getTunnelInterface(tunnelId: ByteArray): InterfaceRef? {
-        return tunnelInterfaces[ByteArrayKey(tunnelId)]
-    }
+    fun getTunnelInterface(tunnelId: ByteArray): InterfaceRef? = tunnelInterfaces[ByteArrayKey(tunnelId)]
 
     /**
      * Remove expired tunnels.
@@ -4898,9 +5084,11 @@ object Transport {
     }
 
     private fun log(message: String) {
-        val timestamp = java.time.LocalDateTime.now().format(
-            java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-        )
+        val timestamp =
+            java.time.LocalDateTime.now().format(
+                java.time.format.DateTimeFormatter
+                    .ofPattern("yyyy-MM-dd HH:mm:ss.SSS"),
+            )
         System.err.println("[$timestamp] [Transport] $message")
     }
 }
@@ -4917,6 +5105,10 @@ interface InterfaceRef {
     val canSend: Boolean
     val canReceive: Boolean
     val online: Boolean
+
+    /** Traffic counters. */
+    val rxBytes: Long get() = 0
+    val txBytes: Long get() = 0
 
     /** Interface operational mode. */
     val mode: InterfaceMode
@@ -5028,9 +5220,7 @@ interface InterfaceRef {
      * Get a hash uniquely identifying this interface.
      * Used for tunnel ID calculation: hash(public_key + interface_hash).
      */
-    fun getInterfaceHash(): ByteArray {
-        return Hashes.fullHash(name.toByteArray(Charsets.UTF_8))
-    }
+    fun getInterfaceHash(): ByteArray = Hashes.fullHash(name.toByteArray(Charsets.UTF_8))
 
     // Ingress control methods — implemented by Interface (via InterfaceAdapter),
     // no-ops by default for test/stub interfaces.
@@ -5045,7 +5235,12 @@ interface InterfaceRef {
     // Implemented by Interface (via InterfaceAdapter), no-ops for test/stub interfaces.
 
     /** Hold an announce for later release when burst subsides. */
-    fun holdAnnounce(destinationHash: ByteArray, raw: ByteArray, hops: Int, receivingInterface: InterfaceRef) {}
+    fun holdAnnounce(
+        destinationHash: ByteArray,
+        raw: ByteArray,
+        hops: Int,
+        receivingInterface: InterfaceRef,
+    ) {}
 
     /** Process held announces: release one (min-hops) if burst has subsided. */
     fun processHeldAnnounces() {}
@@ -5064,6 +5259,5 @@ data class HeldAnnounce(
     val destinationHash: ByteArray,
     val raw: ByteArray,
     val hops: Int,
-    val receivingInterface: InterfaceRef
+    val receivingInterface: InterfaceRef,
 )
-

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -58,6 +58,26 @@ fun interface AnnounceHandler {
 }
 
 /**
+ * Extended announce handler that receives hop count and receiving interface name.
+ * Implement this instead of [AnnounceHandler] to get full announce context.
+ */
+interface RichAnnounceHandler : AnnounceHandler {
+    fun handleAnnounceWithContext(
+        destinationHash: ByteArray,
+        announcedIdentity: Identity,
+        appData: ByteArray?,
+        hops: Int,
+        receivingInterfaceName: String?,
+    ): Boolean
+
+    override fun handleAnnounce(
+        destinationHash: ByteArray,
+        announcedIdentity: Identity,
+        appData: ByteArray?,
+    ): Boolean = handleAnnounceWithContext(destinationHash, announcedIdentity, appData, 0, null)
+}
+
+/**
  * Callback for packet delivery.
  */
 fun interface PacketCallback {
@@ -2983,12 +3003,7 @@ object Transport {
             // Still notify local handlers so display names are captured.
             // Python processes the announce locally even when ingress-limited;
             // it only holds the *retransmission*.
-            for (handler in announceHandlers) {
-                try {
-                    if (handler.handleAnnounce(destHash, identity, appData)) break
-                } catch (_: Exception) {
-                }
-            }
+            notifyAnnounceHandlers(destHash, identity, appData, packet.hops, interfaceRef.name)
             return
         }
 
@@ -3092,15 +3107,7 @@ object Transport {
         log("Learned path to ${destHash.toHexString()} via ${interfaceRef.name} (${packet.hops} hops)")
 
         // Notify announce handlers
-        for (handler in announceHandlers) {
-            try {
-                if (handler.handleAnnounce(destHash, identity, appData)) {
-                    break
-                }
-            } catch (e: Exception) {
-                log("Announce handler error: ${e.message}")
-            }
-        }
+        notifyAnnounceHandlers(destHash, identity, appData, packet.hops, interfaceRef.name)
 
         // Cache the announce packet for later path request responses
         // Python Transport.py:1867 — cache pre-increment raw announce to disk
@@ -3112,13 +3119,35 @@ object Transport {
         retransmitAnnounceToLocalClients(packet, interfaceRef)
 
         // Retransmit if transport is enabled OR announce came from a local client
-        // Python Transport.py:1741 — local client announces are always retransmitted
-        // to external interfaces, even when transport routing is disabled
         val fromLocal = fromLocalClient(interfaceRef)
         if ((transportEnabled || fromLocal) && packet.hops < TransportConstants.PATHFINDER_M) {
             queueAnnounceRetransmit(destHash, packet, interfaceRef, fromLocalClient = fromLocal)
         }
     }
+
+    private fun notifyAnnounceHandlers(
+        destHash: ByteArray,
+        identity: Identity,
+        appData: ByteArray?,
+        hops: Int,
+        interfaceName: String?,
+    ) {
+        for (handler in announceHandlers) {
+            try {
+                val handled =
+                    if (handler is RichAnnounceHandler) {
+                        handler.handleAnnounceWithContext(destHash, identity, appData, hops, interfaceName)
+                    } else {
+                        handler.handleAnnounce(destHash, identity, appData)
+                    }
+                if (handled) break
+            } catch (e: Exception) {
+                log("Announce handler error: ${e.message}")
+            }
+        }
+    }
+
+    // (retransmit logic moved into processAnnounce above via retransmitAnnounce)
 
     /**
      * Immediately retransmit an announce to all local client interfaces.

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -250,6 +250,7 @@ object Transport {
 
     /** Last time cache was cleaned. */
     private var cacheLastCleaned: Long = 0
+    private var identitiesLastSaved: Long = 0
 
     /** Cache path for persistent announce storage. Set by Reticulum during init. */
     @Volatile
@@ -4409,6 +4410,17 @@ object Transport {
         if (now - cacheLastCleaned > TransportConstants.CACHE_CLEAN_INTERVAL) {
             cleanAnnounceCache()
             cacheLastCleaned = now
+        }
+
+        // Persist known destinations periodically (every 5 minutes)
+        // Ensures identities survive process kills without clean shutdown
+        if (now - identitiesLastSaved > TransportConstants.CACHE_CLEAN_INTERVAL) {
+            try {
+                Identity.saveKnownDestinations()
+            } catch (e: Exception) {
+                log("Error saving known destinations: ${e.message}")
+            }
+            identitiesLastSaved = now
         }
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -850,6 +850,16 @@ object Transport {
         }
     }
 
+    fun disableDiscovery() {
+        interfaceAnnouncer?.stop()
+        interfaceAnnouncer = null
+        discoveryHandler?.stop()
+        discoveryHandler = null
+        log("Interface discovery disabled")
+    }
+
+    fun isDiscoveryEnabled(): Boolean = interfaceAnnouncer != null
+
     /**
      * Start listening for interface discovery announces.
      *

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -5552,6 +5552,9 @@ interface InterfaceRef {
     fun heldAnnounceCount(): Int = 0
 
     fun send(data: ByteArray)
+
+    /** Detach the underlying interface (close connections, release resources). */
+    fun detach() {}
 }
 
 /**

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -3047,7 +3047,7 @@ object Transport {
             // Still notify local handlers so display names are captured.
             // Python processes the announce locally even when ingress-limited;
             // it only holds the *retransmission*.
-            notifyAnnounceHandlers(destHash, identity, appData, packet.hops, interfaceRef.name)
+            notifyAnnounceHandlers(destHash, identity, appData, packet.hops, interfaceRef.qualifiedName)
             return
         }
 
@@ -3151,7 +3151,7 @@ object Transport {
         log("Learned path to ${destHash.toHexString()} via ${interfaceRef.name} (${packet.hops} hops)")
 
         // Notify announce handlers
-        notifyAnnounceHandlers(destHash, identity, appData, packet.hops, interfaceRef.name)
+        notifyAnnounceHandlers(destHash, identity, appData, packet.hops, interfaceRef.qualifiedName)
 
         // Cache the announce packet for later path request responses
         // Python Transport.py:1867 — cache pre-increment raw announce to disk
@@ -5371,6 +5371,9 @@ interface InterfaceRef {
 
     /** The interface type name as it appears in discovery announces. */
     val discoveryInterfaceType: String get() = "Interface"
+
+    /** Python-style qualified name: "TCPClientInterface[homelab]". Used for interface type detection. */
+    val qualifiedName: String get() = "$discoveryInterfaceType[$name]"
 
     /** Type-specific discovery data (TCP: reachable_on/port, RNode: freq/bw/sf/cr, etc.). */
     fun getDiscoveryData(): Map<Int, Any>? = null

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -3209,9 +3209,6 @@ object Transport {
                             null
                         }
                 }
-                if (handler is RichAnnounceHandler) {
-                    log("notifyAnnounceHandlers: RichHandler matchedAspect=$matchedAspect dest=${destHash.toHexString().take(12)}")
-                }
                 val handled =
                     if (handler is RichAnnounceHandler) {
                         handler.handleAnnounceWithContext(
@@ -3245,11 +3242,9 @@ object Transport {
             try {
                 val expectedHash = Destination.hashFromNameAndIdentity(aspect, identity)
                 if (expectedHash.contentEquals(destHash)) return aspect
-            } catch (e: Exception) {
-                log("resolveAspect: exception for $aspect: ${e.message}")
+            } catch (_: Exception) {
             }
         }
-        log("resolveAspect: no match for ${destHash.toHexString()} among ${knownAspects.size} aspects (id=${identity.hexHash.take(12)})")
         return null
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -3071,14 +3071,16 @@ object Transport {
         // Python Transport.py:1563-1571 — only limit announces for destinations
         // not already in the path table (known destinations use normal rate limiting)
         val isKnownDestination = pathTable.containsKey(destHash.toKey())
-        if (!isKnownDestination && interfaceRef.shouldIngressLimit()) {
-            log("Holding announce for ${destHash.toHexString()} due to ingress limiting on ${interfaceRef.name}")
+        val ingressLimited = !isKnownDestination && interfaceRef.shouldIngressLimit()
+        if (ingressLimited) {
+            log("Ingress-limited announce for ${destHash.toHexString()} on ${interfaceRef.name}, processing locally but holding retransmission")
             interfaceRef.holdAnnounce(destHash, packet.raw ?: packet.pack(), packet.hops, interfaceRef)
-            // Still notify local handlers so display names are captured.
-            // Python processes the announce locally even when ingress-limited;
-            // it only holds the *retransmission*.
-            notifyAnnounceHandlers(destHash, identity, appData, packet.hops, interfaceRef.qualifiedName)
-            return
+            // Don't return — fall through to process the announce locally
+            // (learn path + store identity). Only retransmission is suppressed.
+            // Python holds and returns here, but Python also has a working
+            // processHeldAnnounces that re-injects later. Since our held announce
+            // processing is not yet implemented, we process locally instead of
+            // losing the path entirely.
         }
 
         // Skip announces for our own local destinations (Python Transport.py:1573-1574).
@@ -3190,12 +3192,16 @@ object Transport {
             cacheAnnouncePacket(packet, interfaceRef)
         }
 
-        retransmitAnnounceToLocalClients(packet, interfaceRef)
+        // Skip retransmission for ingress-limited announces — we process them
+        // locally (path + identity) but don't forward to other interfaces.
+        if (!ingressLimited) {
+            retransmitAnnounceToLocalClients(packet, interfaceRef)
 
-        // Retransmit if transport is enabled OR announce came from a local client
-        val fromLocal = fromLocalClient(interfaceRef)
-        if ((transportEnabled || fromLocal) && packet.hops < TransportConstants.PATHFINDER_M) {
-            queueAnnounceRetransmit(destHash, packet, interfaceRef, fromLocalClient = fromLocal)
+            // Retransmit if transport is enabled OR announce came from a local client
+            val fromLocal = fromLocalClient(interfaceRef)
+            if ((transportEnabled || fromLocal) && packet.hops < TransportConstants.PATHFINDER_M) {
+                queueAnnounceRetransmit(destHash, packet, interfaceRef, fromLocalClient = fromLocal)
+            }
         }
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -3071,16 +3071,13 @@ object Transport {
         // Python Transport.py:1563-1571 — only limit announces for destinations
         // not already in the path table (known destinations use normal rate limiting)
         val isKnownDestination = pathTable.containsKey(destHash.toKey())
-        val ingressLimited = !isKnownDestination && interfaceRef.shouldIngressLimit()
-        if (ingressLimited) {
-            log("Ingress-limited announce for ${destHash.toHexString()} on ${interfaceRef.name}, processing locally but holding retransmission")
+        if (!isKnownDestination && interfaceRef.shouldIngressLimit()) {
+            // Python Transport.py:1563-1571 — hold and return immediately.
+            // Interface.processHeldAnnounces() will re-inject via Transport.inbound()
+            // when the burst subsides, so the path/identity will be learned then.
+            log("Holding announce for ${destHash.toHexString()} due to ingress limiting on ${interfaceRef.name}")
             interfaceRef.holdAnnounce(destHash, packet.raw ?: packet.pack(), packet.hops, interfaceRef)
-            // Don't return — fall through to process the announce locally
-            // (learn path + store identity). Only retransmission is suppressed.
-            // Python holds and returns here, but Python also has a working
-            // processHeldAnnounces that re-injects later. Since our held announce
-            // processing is not yet implemented, we process locally instead of
-            // losing the path entirely.
+            return
         }
 
         // Skip announces for our own local destinations (Python Transport.py:1573-1574).
@@ -3192,16 +3189,12 @@ object Transport {
             cacheAnnouncePacket(packet, interfaceRef)
         }
 
-        // Skip retransmission for ingress-limited announces — we process them
-        // locally (path + identity) but don't forward to other interfaces.
-        if (!ingressLimited) {
-            retransmitAnnounceToLocalClients(packet, interfaceRef)
+        retransmitAnnounceToLocalClients(packet, interfaceRef)
 
-            // Retransmit if transport is enabled OR announce came from a local client
-            val fromLocal = fromLocalClient(interfaceRef)
-            if ((transportEnabled || fromLocal) && packet.hops < TransportConstants.PATHFINDER_M) {
-                queueAnnounceRetransmit(destHash, packet, interfaceRef, fromLocalClient = fromLocal)
-            }
+        // Retransmit if transport is enabled OR announce came from a local client
+        val fromLocal = fromLocalClient(interfaceRef)
+        if ((transportEnabled || fromLocal) && packet.hops < TransportConstants.PATHFINDER_M) {
+            queueAnnounceRetransmit(destHash, packet, interfaceRef, fromLocalClient = fromLocal)
         }
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -4990,8 +4990,7 @@ object Transport {
 
     // ===== Tunnel Table Persistence =====
 
-    /** Maximum random blobs to persist per path */
-    private const val PERSIST_RANDOM_BLOBS = 32
+    /** Maximum random blobs to persist per path — reuses TransportConstants value */
 
     /**
      * Save tunnel table to persistent storage.
@@ -5053,7 +5052,7 @@ object Transport {
                     packer.packLong(pathEntry.expires)
 
                     // random_blobs (limit to last PERSIST_RANDOM_BLOBS)
-                    val blobsToSave = pathEntry.randomBlobs.takeLast(PERSIST_RANDOM_BLOBS)
+                    val blobsToSave = pathEntry.randomBlobs.takeLast(TransportConstants.PERSIST_RANDOM_BLOBS)
                     packer.packArrayHeader(blobsToSave.size)
                     for (blob in blobsToSave) {
                         packer.packBinaryHeader(blob.size)

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -842,12 +842,13 @@ object Transport {
      */
     fun registerReceipt(receipt: PacketReceipt) {
         receipts.add(receipt)
-        // Also register for proof handling
-        pendingReceipts[receipt.hash.toKey()] =
+        // Register by TRUNCATED hash — proof packets carry the original packet's
+        // truncated hash as their destination, matching Python's get_hash() usage.
+        pendingReceipts[receipt.truncatedHash.toKey()] =
             object : ProofCallback {
                 override fun onProofReceived(proofPacket: Packet): Boolean = receipt.validateProofPacket(proofPacket)
             }
-        log("Registered receipt for ${receipt.hash.toHexString()}")
+        log("Registered receipt for ${receipt.truncatedHash.toHexString()}")
     }
 
     /**

--- a/rns-core/src/main/kotlin/network/reticulum/transport/TransportConstants.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/TransportConstants.kt
@@ -168,4 +168,7 @@ object TransportConstants {
 
     /** Maximum number of tunnels to maintain. */
     const val MAX_TUNNELS = 10000
+
+    /** Grace period after startup before interface-based path culling (30 seconds). */
+    const val STARTUP_GRACE_PERIOD = 30_000L
 }

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/InterfaceAdapter.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/InterfaceAdapter.kt
@@ -10,12 +10,16 @@ import java.util.concurrent.ConcurrentHashMap
  * Adapter to bridge Interface to InterfaceRef for Transport integration.
  * Also sets up the receive callback to deliver packets to Transport.
  */
-class InterfaceAdapter private constructor(private val iface: Interface) : InterfaceRef {
+class InterfaceAdapter private constructor(
+    private val iface: Interface,
+) : InterfaceRef {
     override val name: String = iface.name
     override val hash: ByteArray = iface.getHash()
     override val canSend: Boolean = iface.canSend
     override val canReceive: Boolean = iface.canReceive
     override val online: Boolean get() = iface.online.get()
+    override val rxBytes: Long get() = iface.rxBytes.get()
+    override val txBytes: Long get() = iface.txBytes.get()
     override val mode: InterfaceMode get() = iface.mode
     override val announceCap: Double get() = iface.announceCap
     override val hwMtu: Int get() = iface.hwMtu ?: RnsConstants.MTU
@@ -24,11 +28,15 @@ class InterfaceAdapter private constructor(private val iface: Interface) : Inter
     // Tunnel properties - delegate to underlying interface
     override var tunnelId: ByteArray?
         get() = iface.tunnelId
-        set(value) { iface.tunnelId = value }
+        set(value) {
+            iface.tunnelId = value
+        }
 
     override var wantsTunnel: Boolean
         get() = iface.wantsTunnel
-        set(value) { iface.wantsTunnel = value }
+        set(value) {
+            iface.wantsTunnel = value
+        }
 
     // Shared instance properties (Python RNS compatibility)
     override val isLocalSharedInstance: Boolean
@@ -53,7 +61,9 @@ class InterfaceAdapter private constructor(private val iface: Interface) : Inter
     override val discoverable: Boolean get() = iface.discoverable
     override var lastDiscoveryAnnounce: Long
         get() = iface.lastDiscoveryAnnounce
-        set(value) { iface.lastDiscoveryAnnounce = value }
+        set(value) {
+            iface.lastDiscoveryAnnounce = value
+        }
     override val discoveryAnnounceInterval: Long get() = iface.discoveryAnnounceInterval
     override val discoveryName: String? get() = iface.discoveryName
     override val discoveryEncrypt: Boolean get() = iface.discoveryEncrypt
@@ -65,6 +75,7 @@ class InterfaceAdapter private constructor(private val iface: Interface) : Inter
     override val discoveryInterfaceType: String get() = iface.discoveryInterfaceType
     override val ifacNetname: String? get() = iface.ifacNetname
     override val ifacNetkey: String? get() = iface.ifacNetkey
+
     override fun getDiscoveryData(): Map<Int, Any>? = iface.getDiscoveryData()
 
     // IFAC properties - delegate to underlying interface
@@ -83,11 +94,12 @@ class InterfaceAdapter private constructor(private val iface: Interface) : Inter
         if (iface.onPacketReceived == null) {
             iface.onPacketReceived = { data, fromInterface ->
                 // Get or create InterfaceRef for the source interface
-                val sourceRef = if (fromInterface === iface) {
-                    this
-                } else {
-                    fromInterface.toRef()
-                }
+                val sourceRef =
+                    if (fromInterface === iface) {
+                        this
+                    } else {
+                        fromInterface.toRef()
+                    }
                 Transport.inbound(data, sourceRef)
             }
         }
@@ -95,12 +107,19 @@ class InterfaceAdapter private constructor(private val iface: Interface) : Inter
 
     // Ingress control delegation
     override fun shouldIngressLimit(): Boolean = iface.shouldIngressLimit()
+
     override fun recordIncomingAnnounce() = iface.recordIncomingAnnounce()
 
     // Held announce delegation
-    override fun holdAnnounce(destinationHash: ByteArray, raw: ByteArray, hops: Int, receivingInterface: InterfaceRef) =
-        iface.holdAnnounce(destinationHash, raw, hops, receivingInterface)
+    override fun holdAnnounce(
+        destinationHash: ByteArray,
+        raw: ByteArray,
+        hops: Int,
+        receivingInterface: InterfaceRef,
+    ) = iface.holdAnnounce(destinationHash, raw, hops, receivingInterface)
+
     override fun processHeldAnnounces() = iface.processHeldAnnounces()
+
     override fun heldAnnounceCount(): Int = iface.heldAnnounceCount()
 
     override fun send(data: ByteArray) {
@@ -111,9 +130,7 @@ class InterfaceAdapter private constructor(private val iface: Interface) : Inter
         // Cache adapters to avoid creating duplicates
         private val adapterCache = ConcurrentHashMap<Interface, InterfaceAdapter>()
 
-        fun getOrCreate(iface: Interface): InterfaceAdapter {
-            return adapterCache.computeIfAbsent(iface) { InterfaceAdapter(iface) }
-        }
+        fun getOrCreate(iface: Interface): InterfaceAdapter = adapterCache.computeIfAbsent(iface) { InterfaceAdapter(iface) }
     }
 }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/InterfaceAdapter.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/InterfaceAdapter.kt
@@ -126,6 +126,10 @@ class InterfaceAdapter private constructor(
         iface.processOutgoing(data)
     }
 
+    override fun detach() {
+        iface.detach()
+    }
+
     companion object {
         // Cache adapters to avoid creating duplicates
         private val adapterCache = ConcurrentHashMap<Interface, InterfaceAdapter>()

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -6,7 +6,6 @@ import network.reticulum.interfaces.Interface
 import network.reticulum.interfaces.toRef
 import network.reticulum.transport.Transport
 import java.net.*
-import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -40,13 +39,12 @@ class AutoInterface(
     /** Network interfaces to ignore. */
     private val ignoredDevices: List<String> = emptyList(),
     /** Configured bitrate override. */
-    val configuredBitrate: Int? = null
+    val configuredBitrate: Int? = null,
 ) : Interface(name) {
-
     // Peer tracking
     private data class PeerInfo(
         val interfaceName: String,
-        var lastHeard: Long = System.currentTimeMillis()
+        var lastHeard: Long = System.currentTimeMillis(),
     )
 
     private val peers = ConcurrentHashMap<String, PeerInfo>()
@@ -64,7 +62,11 @@ class AutoInterface(
     private val linkLocalAddresses = ConcurrentHashMap<String, Inet6Address>()
 
     // Recent packets for duplicate detection (multi-interface)
-    private data class RecentPacket(val hash: Int, val timestamp: Long)
+    private data class RecentPacket(
+        val hash: Int,
+        val timestamp: Long,
+    )
+
     private val recentPackets = ConcurrentHashMap.newKeySet<RecentPacket>()
 
     // Coroutine management
@@ -115,7 +117,6 @@ class AutoInterface(
 
             online.set(true)
             log("AutoInterface started on ${linkLocalAddresses.size} interface(s)")
-
         } catch (e: Exception) {
             log("Failed to start AutoInterface: ${e.message}")
             e.printStackTrace()
@@ -206,9 +207,11 @@ class AutoInterface(
             }
 
             // Find link-local IPv6 address
-            val linkLocal = netIf.inetAddresses.asSequence()
-                .filterIsInstance<Inet6Address>()
-                .firstOrNull { it.isLinkLocalAddress }
+            val linkLocal =
+                netIf.inetAddresses
+                    .asSequence()
+                    .filterIsInstance<Inet6Address>()
+                    .firstOrNull { it.isLinkLocalAddress }
 
             if (linkLocal == null) {
                 log("Skipping $ifName: no IPv6 link-local address")
@@ -220,33 +223,39 @@ class AutoInterface(
 
             try {
                 // Create discovery input socket (multicast receiver)
-                val discoveryIn = MulticastSocket(discoveryPort).apply {
-                    reuseAddress = true
-                    networkInterface = netIf
-                    joinGroup(multicastGroup, netIf)
-                }
+                val discoveryIn =
+                    MulticastSocket(discoveryPort).apply {
+                        reuseAddress = true
+                        networkInterface = netIf
+                        joinGroup(multicastGroup, netIf)
+                    }
                 discoverySocketsIn[ifName] = discoveryIn
                 log("Successfully joined multicast group ${multicastGroup.address.hostAddress} on $ifName")
 
                 // Create discovery output socket (for sending announcements)
                 // Must use MulticastSocket and set the outgoing interface
-                val discoveryOut = MulticastSocket().apply {
-                    reuseAddress = true
-                    networkInterface = netIf
-                }
+                val discoveryOut =
+                    MulticastSocket().apply {
+                        reuseAddress = true
+                        networkInterface = netIf
+                    }
                 discoverySocketsOut[ifName] = discoveryOut
 
                 // Create data socket (for receiving unicast data)
                 // Use DatagramChannel for potential SO_REUSEPORT support
-                val dataChannel = DatagramChannel.open(StandardProtocolFamily.INET6).apply {
-                    setOption(StandardSocketOptions.SO_REUSEADDR, true)
-                    // Try to set SO_REUSEPORT via reflection (JDK 14+)
-                    trySetReusePort(this)
-                    bind(InetSocketAddress(linkLocal, dataPort))
-                    configureBlocking(true)
+                try {
+                    val dataChannel =
+                        DatagramChannel.open(StandardProtocolFamily.INET6).apply {
+                            setOption(StandardSocketOptions.SO_REUSEADDR, true)
+                            // Try to set SO_REUSEPORT via reflection (JDK 14+)
+                            trySetReusePort(this)
+                            bind(InetSocketAddress(linkLocal, dataPort))
+                            configureBlocking(true)
+                        }
+                    dataSockets[ifName] = dataChannel.socket()
+                } catch (e: java.net.BindException) {
+                    log("Data port $dataPort already in use on $ifName (another RNS instance running?) — peer connections will still work", "WARNING")
                 }
-                dataSockets[ifName] = dataChannel.socket()
-
             } catch (e: java.io.IOException) {
                 log("I/O error setting up sockets for $ifName: ${e.message}", "ERROR")
                 e.printStackTrace()
@@ -308,7 +317,10 @@ class AutoInterface(
     /**
      * Handle discovery packets on a specific interface.
      */
-    private suspend fun discoveryHandler(ifName: String, socket: MulticastSocket) {
+    private suspend fun discoveryHandler(
+        ifName: String,
+        socket: MulticastSocket,
+    ) {
         // SHA-256 produces 32 bytes
         val buffer = ByteArray(32)
 
@@ -353,7 +365,6 @@ class AutoInterface(
 
                 // Valid peer discovered
                 addPeer(senderAddrStr, ifName)
-
             } catch (e: SocketException) {
                 if (running.get()) {
                     log("Discovery socket error on $ifName: ${e.message}")
@@ -383,7 +394,10 @@ class AutoInterface(
     /**
      * Handle incoming data packets on a specific interface.
      */
-    private suspend fun dataHandler(ifName: String, socket: DatagramSocket) {
+    private suspend fun dataHandler(
+        ifName: String,
+        socket: DatagramSocket,
+    ) {
         val buffer = ByteArray(AutoInterfaceConstants.HW_MTU + 64)
 
         log("Data handler started for $ifName")
@@ -421,7 +435,6 @@ class AutoInterface(
                     // Unknown peer - might be a new discovery
                     log("Data from unknown peer: $senderAddrStr")
                 }
-
             } catch (e: SocketException) {
                 if (running.get()) {
                     log("Data socket error on $ifName: ${e.message}")
@@ -480,7 +493,6 @@ class AutoInterface(
                 // Send to multicast group
                 val packet = DatagramPacket(token, token.size, multicastGroup)
                 socket.send(packet)
-
             } catch (e: Exception) {
                 log("Failed to send announcement on $ifName: ${e.message}")
             }
@@ -601,7 +613,10 @@ class AutoInterface(
     /**
      * Add a newly discovered peer.
      */
-    private fun addPeer(address: String, interfaceName: String) {
+    private fun addPeer(
+        address: String,
+        interfaceName: String,
+    ) {
         val cleanAddr = address.substringBefore('%')
 
         // Atomic check-and-insert to prevent race condition when peer is
@@ -620,19 +635,21 @@ class AutoInterface(
         // For IPv6 link-local addresses, we need to include the scope ID (interface)
         // to ensure proper routing
         val networkInterface = NetworkInterface.getByName(interfaceName)
-        val peerInet6Addr = Inet6Address.getByAddress(
-            null,
-            InetAddress.getByName(cleanAddr).address,
-            networkInterface
-        )
+        val peerInet6Addr =
+            Inet6Address.getByAddress(
+                null,
+                InetAddress.getByName(cleanAddr).address,
+                networkInterface,
+            )
         val targetAddr = InetSocketAddress(peerInet6Addr, dataPort)
 
-        val peer = AutoInterfacePeer(
-            name = "$name[$cleanAddr]",
-            parent = this,
-            targetAddress = targetAddr,
-            interfaceName = interfaceName
-        )
+        val peer =
+            AutoInterfacePeer(
+                name = "$name[$cleanAddr]",
+                parent = this,
+                targetAddress = targetAddr,
+                interfaceName = interfaceName,
+            )
 
         peer.start()
 
@@ -693,6 +710,7 @@ class AutoInterface(
             // Try to access jdk.net.ExtendedSocketOptions.SO_REUSEPORT via reflection
             val extOptClass = Class.forName("jdk.net.ExtendedSocketOptions")
             val reusePortField = extOptClass.getField("SO_REUSEPORT")
+
             @Suppress("UNCHECKED_CAST")
             val reusePortOption = reusePortField.get(null) as SocketOption<Boolean>
             channel.setOption(reusePortOption, true)
@@ -701,22 +719,37 @@ class AutoInterface(
         }
     }
 
-    private fun log(message: String, level: String = "INFO") {
-        val timestamp = java.time.LocalTime.now().toString().take(12)
+    private fun log(
+        message: String,
+        level: String = "INFO",
+    ) {
+        val timestamp =
+            java.time.LocalTime
+                .now()
+                .toString()
+                .take(12)
         val logMessage = "[$timestamp] [$name] $message"
 
         // Try Android logging first
         try {
             val logClass = Class.forName("android.util.Log")
             when (level) {
-                "ERROR" -> logClass.getMethod("e", String::class.java, String::class.java)
-                    .invoke(null, "AutoInterface", logMessage)
-                "WARNING", "WARN" -> logClass.getMethod("w", String::class.java, String::class.java)
-                    .invoke(null, "AutoInterface", logMessage)
-                "DEBUG" -> logClass.getMethod("d", String::class.java, String::class.java)
-                    .invoke(null, "AutoInterface", logMessage)
-                else -> logClass.getMethod("i", String::class.java, String::class.java)
-                    .invoke(null, "AutoInterface", logMessage)
+                "ERROR" ->
+                    logClass
+                        .getMethod("e", String::class.java, String::class.java)
+                        .invoke(null, "AutoInterface", logMessage)
+                "WARNING", "WARN" ->
+                    logClass
+                        .getMethod("w", String::class.java, String::class.java)
+                        .invoke(null, "AutoInterface", logMessage)
+                "DEBUG" ->
+                    logClass
+                        .getMethod("d", String::class.java, String::class.java)
+                        .invoke(null, "AutoInterface", logMessage)
+                else ->
+                    logClass
+                        .getMethod("i", String::class.java, String::class.java)
+                        .invoke(null, "AutoInterface", logMessage)
             }
         } catch (e: Exception) {
             // Fall back to println for non-Android platforms

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -61,6 +61,14 @@ class AutoInterface(
     private val maxAnnounceIntervalMs = 120_000L  // 2 minutes
     private val rampUpDurationMs = 60_000L  // reach max interval 60s after last peer change
 
+    /**
+     * External throttle multiplier (e.g., from ConnectionPolicy).
+     * 1.0 = normal, 5.0 = Doze/low battery.
+     * Applied to maxAnnounceIntervalMs so steady-state interval goes from
+     * 2 minutes (normal) to 10 minutes (Doze).
+     */
+    @Volatile var throttleMultiplier: Float = 1.0f
+
     // Network sockets per interface
     private val discoverySocketsIn = ConcurrentHashMap<String, MulticastSocket>()
     private val discoverySocketsOut = ConcurrentHashMap<String, MulticastSocket>()
@@ -523,7 +531,8 @@ class AutoInterface(
     private fun updateAnnounceInterval() {
         val timeSinceChange = System.currentTimeMillis() - lastPeerChangeTime
         val progress = (timeSinceChange.toDouble() / rampUpDurationMs).coerceIn(0.0, 1.0)
-        currentAnnounceIntervalMs = (minAnnounceIntervalMs + (maxAnnounceIntervalMs - minAnnounceIntervalMs) * progress).toLong()
+        val effectiveMax = (maxAnnounceIntervalMs * throttleMultiplier).toLong()
+        currentAnnounceIntervalMs = (minAnnounceIntervalMs + (effectiveMax - minAnnounceIntervalMs) * progress).toLong()
     }
 
     /**

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -50,6 +50,16 @@ class AutoInterface(
     private val peers = ConcurrentHashMap<String, PeerInfo>()
     private val spawnedPeers = ConcurrentHashMap<String, AutoInterfacePeer>()
 
+    // Adaptive announce interval: fast after changes, progressively slower when stable.
+    // Receiving peers' multicast is free (socket.receive blocks without CPU cost).
+    // Sending is what costs battery, so we only need to send often enough that
+    // OTHER devices discover US within a reasonable time.
+    @Volatile private var currentAnnounceIntervalMs = AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS
+    @Volatile private var lastPeerChangeTime = System.currentTimeMillis()
+    private val minAnnounceIntervalMs = AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS  // 1.6s
+    private val maxAnnounceIntervalMs = 120_000L  // 2 minutes
+    private val rampUpDurationMs = 60_000L  // reach max interval 60s after last peer change
+
     // Network sockets per interface
     private val discoverySocketsIn = ConcurrentHashMap<String, MulticastSocket>()
     private val discoverySocketsOut = ConcurrentHashMap<String, MulticastSocket>()
@@ -134,8 +144,18 @@ class AutoInterface(
         // Cancel all coroutines
         scope.cancel()
 
-        // Close all sockets
-        discoverySocketsIn.values.forEach { it.close() }
+        // Leave multicast groups and close all sockets
+        discoverySocketsIn.forEach { (ifName, socket) ->
+            try {
+                val netIf = NetworkInterface.getByName(ifName)
+                if (netIf != null && ::multicastGroup.isInitialized) {
+                    socket.leaveGroup(multicastGroup, netIf)
+                }
+            } catch (e: Exception) {
+                log("Error leaving multicast group on $ifName: ${e.message}")
+            }
+            socket.close()
+        }
         discoverySocketsOut.values.forEach { it.close() }
         dataSockets.values.forEach { it.close() }
 
@@ -469,13 +489,40 @@ class AutoInterface(
      */
     private fun startAnnouncementLoop() {
         scope.launch {
-            log("Announcement loop started")
+            log("Announcement loop started (adaptive interval: ${minAnnounceIntervalMs}ms → ${maxAnnounceIntervalMs}ms)")
             while (running.get()) {
                 sendDiscoveryAnnouncements()
-                delay(AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS)
+                updateAnnounceInterval()
+                delay(currentAnnounceIntervalMs)
             }
             log("Announcement loop stopped")
         }
+    }
+
+    /**
+     * Adapt the announce interval based on time since last peer change.
+     *
+     * Immediately after a peer is added/removed (or on startup), we announce
+     * at the fast Python-compatible rate (1.6s). Over the next 60 seconds,
+     * we linearly ramp up to the max interval (2 minutes). This means:
+     * - New peers are discovered quickly after network changes
+     * - Steady-state battery usage is ~75x lower than Python's fixed 1.6s
+     * - Other devices sending at THEIR rate still discover us via receiving
+     */
+    private fun updateAnnounceInterval() {
+        val timeSinceChange = System.currentTimeMillis() - lastPeerChangeTime
+        val progress = (timeSinceChange.toDouble() / rampUpDurationMs).coerceIn(0.0, 1.0)
+        currentAnnounceIntervalMs = (minAnnounceIntervalMs + (maxAnnounceIntervalMs - minAnnounceIntervalMs) * progress).toLong()
+    }
+
+    /**
+     * Signal that peers changed — reset announce interval to fast mode.
+     * Called when a peer is added, removed, or on network change.
+     */
+    fun resetAnnounceInterval() {
+        lastPeerChangeTime = System.currentTimeMillis()
+        currentAnnounceIntervalMs = minAnnounceIntervalMs
+        log("Announce interval reset to fast mode (${minAnnounceIntervalMs}ms)")
     }
 
     /**
@@ -668,6 +715,7 @@ class AutoInterface(
             Transport.inbound(data, peerRef)
         }
         Transport.registerInterface(peerRef)
+        resetAnnounceInterval() // New peer discovered — announce fast so they discover us too
 
         log("Peer $cleanAddr added and registered with Transport")
     }
@@ -677,6 +725,7 @@ class AutoInterface(
      */
     private fun removePeer(address: String) {
         log("Removing timed-out peer: $address")
+        resetAnnounceInterval() // Peer topology changed
 
         peers.remove(address)
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -56,6 +56,7 @@ class AutoInterface(
     // OTHER devices discover US within a reasonable time.
     @Volatile private var currentAnnounceIntervalMs = AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS
     @Volatile private var lastPeerChangeTime = System.currentTimeMillis()
+    @Volatile private var announceImmediately = false
     private val minAnnounceIntervalMs = AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS  // 1.6s
     private val maxAnnounceIntervalMs = 120_000L  // 2 minutes
     private val rampUpDurationMs = 60_000L  // reach max interval 60s after last peer change
@@ -490,10 +491,20 @@ class AutoInterface(
     private fun startAnnouncementLoop() {
         scope.launch {
             log("Announcement loop started (adaptive interval: ${minAnnounceIntervalMs}ms → ${maxAnnounceIntervalMs}ms)")
+            var lastAnnouncedAt = 0L
             while (running.get()) {
-                sendDiscoveryAnnouncements()
-                updateAnnounceInterval()
-                delay(currentAnnounceIntervalMs)
+                val now = System.currentTimeMillis()
+                val shouldSend = announceImmediately || (now - lastAnnouncedAt >= currentAnnounceIntervalMs)
+
+                if (shouldSend) {
+                    announceImmediately = false
+                    sendDiscoveryAnnouncements()
+                    lastAnnouncedAt = System.currentTimeMillis()
+                    updateAnnounceInterval()
+                }
+
+                // Sleep in short increments so we can react to announceImmediately quickly
+                delay(minOf(currentAnnounceIntervalMs, 1000L))
             }
             log("Announcement loop stopped")
         }
@@ -522,6 +533,7 @@ class AutoInterface(
     fun resetAnnounceInterval() {
         lastPeerChangeTime = System.currentTimeMillis()
         currentAnnounceIntervalMs = minAnnounceIntervalMs
+        announceImmediately = true  // Send ASAP so the new peer discovers us
         log("Announce interval reset to fast mode (${minAnnounceIntervalMs}ms)")
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -684,7 +684,7 @@ class AutoInterface(
         if (peer != null) {
             spawnedInterfaces?.remove(peer)
             peer.detach()
-            // Note: Transport.deregisterInterface would need to be implemented
+            Transport.deregisterInterface(peer.toRef())
         }
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -56,7 +56,7 @@ class AutoInterface(
     // OTHER devices discover US within a reasonable time.
     @Volatile private var currentAnnounceIntervalMs = AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS
     @Volatile private var lastPeerChangeTime = System.currentTimeMillis()
-    @Volatile private var announceImmediately = false
+    private val announceImmediately = AtomicBoolean(false)
     private val minAnnounceIntervalMs = AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS  // 1.6s
     private val maxAnnounceIntervalMs = 120_000L  // 2 minutes
     private val rampUpDurationMs = 60_000L  // reach max interval 60s after last peer change
@@ -502,10 +502,10 @@ class AutoInterface(
             var lastAnnouncedAt = 0L
             while (running.get()) {
                 val now = System.currentTimeMillis()
-                val shouldSend = announceImmediately || (now - lastAnnouncedAt >= currentAnnounceIntervalMs)
+                val shouldSend = announceImmediately.compareAndSet(true, false) ||
+                    (now - lastAnnouncedAt >= currentAnnounceIntervalMs)
 
                 if (shouldSend) {
-                    announceImmediately = false
                     sendDiscoveryAnnouncements()
                     lastAnnouncedAt = System.currentTimeMillis()
                     updateAnnounceInterval()
@@ -542,7 +542,7 @@ class AutoInterface(
     fun resetAnnounceInterval() {
         lastPeerChangeTime = System.currentTimeMillis()
         currentAnnounceIntervalMs = minAnnounceIntervalMs
-        announceImmediately = true  // Send ASAP so the new peer discovers us
+        announceImmediately.set(true)  // Send ASAP so the new peer discovers us
         log("Announce interval reset to fast mode (${minAnnounceIntervalMs}ms)")
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -283,7 +283,11 @@ class AutoInterface(
                         }
                     dataSockets[ifName] = dataChannel.socket()
                 } catch (e: java.net.BindException) {
-                    log("Data port $dataPort already in use on $ifName (another RNS instance running?) — peer connections will still work", "WARNING")
+                    log("Data port $dataPort already in use on $ifName (another RNS instance running?) — rolling back discovery sockets", "WARNING")
+                    // Roll back discovery sockets so this interface is either fully configured or not at all
+                    discoverySocketsIn.remove(ifName)?.close()
+                    discoverySocketsOut.remove(ifName)?.close()
+                    linkLocalAddresses.remove(ifName)
                 }
             } catch (e: java.io.IOException) {
                 log("I/O error setting up sockets for $ifName: ${e.message}", "ERROR")

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEDriver.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEDriver.kt
@@ -50,6 +50,12 @@ interface BLEDriver {
     suspend fun stopScanning()
 
     /**
+     * Switch BLE scan mode for battery optimization.
+     * @param lowPower true for LOW_POWER mode (Doze/background), false for BALANCED (normal)
+     */
+    suspend fun setScanLowPower(lowPower: Boolean) {}
+
+    /**
      * Initiate an outgoing connection to a peer at the given BLE address.
      * Returns a [BLEPeerConnection] representing the GATT client connection.
      *

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -123,6 +123,14 @@ class BLEInterface(
         // No-op: Transport calls each spawned BLEPeerInterface's processOutgoing() directly
     }
 
+    /**
+     * Switch BLE scan mode for battery optimization.
+     * Call with true during Doze/background, false when active.
+     */
+    suspend fun setScanLowPower(lowPower: Boolean) {
+        driver.setScanLowPower(lowPower)
+    }
+
     override fun detach() {
         super.detach()
         scope.cancel()

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -45,6 +45,8 @@ class RNodeInterface(
     private val codingRate: Int,
     private val flowControl: Boolean = true,
     private val parentScope: CoroutineScope? = null,
+    /** Optional 512-byte framebuffer image to display on the RNode screen after init. */
+    val displayImageData: ByteArray? = null,
 ) : Interface(name) {
 
     companion object {
@@ -56,6 +58,7 @@ class RNodeInterface(
         private const val DETECT_TIMEOUT_MS = 5_000L
         private const val VALIDATE_TIMEOUT_MS = 2_000L
         private const val READ_TIMEOUT_MS = 1_250L
+        private const val FB_BYTES_PER_LINE = 8
 
         // Signal quality computation constants (matching Python RNodeInterface)
         private const val Q_SNR_MIN_BASE = -9f
@@ -200,9 +203,49 @@ class RNodeInterface(
             delay(300)
             online.set(true)
             log("RNode is configured and online")
+
+            // Display logo on RNode screen if framebuffer is supported
+            if (displayImageData != null) {
+                try {
+                    enableExternalFramebuffer()
+                    delay(100)
+                    displayImage(displayImageData!!)
+                    log("Displayed logo on RNode screen")
+                } catch (e: Exception) {
+                    log("Could not display logo: ${e.message}")
+                }
+            }
         } else {
             throw IOException("Radio parameter validation failed — device reported different values than configured")
         }
+    }
+
+    // -- Framebuffer / display helpers (matching Python RNodeInterface) --
+
+    /** Enable external framebuffer control on the RNode display. */
+    private fun enableExternalFramebuffer() {
+        val cmd = byteArrayOf(KISS.FEND, KISS.CMD_FB_EXT, 0x01, KISS.FEND)
+        outputStream.write(cmd)
+        outputStream.flush()
+    }
+
+    /** Write a 64x64 monochrome bitmap (512 bytes) to the RNode display. */
+    private fun displayImage(imageData: ByteArray) {
+        val lines = imageData.size / FB_BYTES_PER_LINE
+        for (line in 0 until lines) {
+            val lineStart = line * FB_BYTES_PER_LINE
+            val lineData = imageData.copyOfRange(lineStart, lineStart + FB_BYTES_PER_LINE)
+            writeFramebuffer(line, lineData)
+        }
+    }
+
+    /** Write a single line to the RNode framebuffer. */
+    private fun writeFramebuffer(line: Int, lineData: ByteArray) {
+        val data = byteArrayOf(line.toByte()) + lineData
+        val escaped = KISS.escape(data)
+        val cmd = byteArrayOf(KISS.FEND, KISS.CMD_FB_WRITE) + escaped + byteArrayOf(KISS.FEND)
+        outputStream.write(cmd)
+        outputStream.flush()
     }
 
     // -- KISS command helpers (matching Python's detect/setFrequency/etc.) --

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -231,6 +231,9 @@ class RNodeInterface(
      *  one line at a time. BLE pacing is handled by the OutputStream's
      *  latch-per-write synchronization — no artificial delay needed. */
     private fun displayImage(imageData: ByteArray) {
+        require(imageData.size == FB_BYTES_PER_LINE * 64) {
+            "displayImage expects ${FB_BYTES_PER_LINE * 64} bytes (64x64 monochrome), got ${imageData.size}"
+        }
         val lines = imageData.size / FB_BYTES_PER_LINE
         for (line in 0 until lines) {
             val lineStart = line * FB_BYTES_PER_LINE

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -206,7 +206,9 @@ class RNodeInterface(
 
             // Display logo on RNode screen if configured.
             // Matches columba's Python rnode_interface.py:_display_logo():
-            // display_image FIRST, then enable_external_framebuffer with delay.
+            //   1. display_image() — 64 lines, 15ms delay per line
+            //   2. time.sleep(0.05)
+            //   3. enable_external_framebuffer()
             if (displayImageData != null) {
                 try {
                     displayImage(displayImageData!!)
@@ -231,22 +233,25 @@ class RNodeInterface(
         outputStream.flush()
     }
 
-    /** Write a 64x64 monochrome bitmap (512 bytes) to the RNode display. */
-    private fun displayImage(imageData: ByteArray) {
-        // Batch all framebuffer lines into a single write to avoid per-line
-        // BLE latch overhead. The BLE layer will chunk by MTU internally.
-        val buffer = java.io.ByteArrayOutputStream(imageData.size * 2)
+    /** Write a 64x64 monochrome bitmap (512 bytes) to the RNode display.
+     *  Matches columba Python rnode_interface.py:display_image() exactly:
+     *  each line written individually with 15ms delay for BLE pacing. */
+    private suspend fun displayImage(imageData: ByteArray) {
         val lines = imageData.size / FB_BYTES_PER_LINE
         for (line in 0 until lines) {
             val lineStart = line * FB_BYTES_PER_LINE
             val lineData = imageData.copyOfRange(lineStart, lineStart + FB_BYTES_PER_LINE)
-            val data = byteArrayOf(line.toByte()) + lineData
-            val escaped = KISS.escape(data)
-            buffer.write(byteArrayOf(KISS.FEND, KISS.CMD_FB_WRITE))
-            buffer.write(escaped)
-            buffer.write(byteArrayOf(KISS.FEND))
+            writeFramebuffer(line, lineData)
+            delay(15) // Match Python's time.sleep(0.015) for BLE write pacing
         }
-        outputStream.write(buffer.toByteArray())
+    }
+
+    /** Write a single line to the RNode framebuffer. */
+    private fun writeFramebuffer(line: Int, lineData: ByteArray) {
+        val data = byteArrayOf(line.toByte()) + lineData
+        val escaped = KISS.escape(data)
+        val cmd = byteArrayOf(KISS.FEND, KISS.CMD_FB_WRITE) + escaped + byteArrayOf(KISS.FEND)
+        outputStream.write(cmd)
         outputStream.flush()
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -204,8 +204,11 @@ class RNodeInterface(
             online.set(true)
             log("RNode is configured and online")
 
-            // Display logo on RNode screen if framebuffer is supported
-            if (displayImageData != null) {
+            // Display logo on RNode screen if framebuffer is supported.
+            // Skip if flowControl is disabled (BLE) — the rapid-fire framebuffer
+            // writes overwhelm the BLE latch-based write synchronization and can
+            // desynchronize the write path, causing subsequent data writes to fail.
+            if (displayImageData != null && flowControl) {
                 try {
                     enableExternalFramebuffer()
                     delay(100)

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -204,20 +204,11 @@ class RNodeInterface(
             online.set(true)
             log("RNode is configured and online")
 
-            // Display logo on RNode screen if framebuffer is supported.
-            // Skip if flowControl is disabled (BLE) — the rapid-fire framebuffer
-            // writes overwhelm the BLE latch-based write synchronization and can
-            // desynchronize the write path, causing subsequent data writes to fail.
-            if (displayImageData != null && flowControl) {
-                try {
-                    enableExternalFramebuffer()
-                    delay(100)
-                    displayImage(displayImageData!!)
-                    log("Displayed logo on RNode screen")
-                } catch (e: Exception) {
-                    log("Could not display logo: ${e.message}")
-                }
-            }
+            // Note: framebuffer display (logo) is NOT done during init.
+            // Python RNodeInterface doesn't do it either — the display_image()
+            // methods exist for external use (e.g., Sideband/NomadNet UI updates).
+            // Attempting rapid-fire framebuffer writes during init over BLE causes
+            // write desync. If needed, call displayImage() externally after init.
         } else {
             throw IOException("Radio parameter validation failed — device reported different values than configured")
         }

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -233,20 +233,20 @@ class RNodeInterface(
 
     /** Write a 64x64 monochrome bitmap (512 bytes) to the RNode display. */
     private fun displayImage(imageData: ByteArray) {
+        // Batch all framebuffer lines into a single write to avoid per-line
+        // BLE latch overhead. The BLE layer will chunk by MTU internally.
+        val buffer = java.io.ByteArrayOutputStream(imageData.size * 2)
         val lines = imageData.size / FB_BYTES_PER_LINE
         for (line in 0 until lines) {
             val lineStart = line * FB_BYTES_PER_LINE
             val lineData = imageData.copyOfRange(lineStart, lineStart + FB_BYTES_PER_LINE)
-            writeFramebuffer(line, lineData)
+            val data = byteArrayOf(line.toByte()) + lineData
+            val escaped = KISS.escape(data)
+            buffer.write(byteArrayOf(KISS.FEND, KISS.CMD_FB_WRITE))
+            buffer.write(escaped)
+            buffer.write(byteArrayOf(KISS.FEND))
         }
-    }
-
-    /** Write a single line to the RNode framebuffer. */
-    private fun writeFramebuffer(line: Int, lineData: ByteArray) {
-        val data = byteArrayOf(line.toByte()) + lineData
-        val escaped = KISS.escape(data)
-        val cmd = byteArrayOf(KISS.FEND, KISS.CMD_FB_WRITE) + escaped + byteArrayOf(KISS.FEND)
-        outputStream.write(cmd)
+        outputStream.write(buffer.toByteArray())
         outputStream.flush()
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -204,15 +204,9 @@ class RNodeInterface(
             online.set(true)
             log("RNode is configured and online")
 
-            // Display logo on RNode screen if configured.
-            // Matches columba's Python rnode_interface.py:_display_logo():
-            //   1. display_image() — 64 lines, 15ms delay per line
-            //   2. time.sleep(0.05)
-            //   3. enable_external_framebuffer()
             if (displayImageData != null) {
                 try {
                     displayImage(displayImageData!!)
-                    delay(50)  // Match Python's time.sleep(0.05)
                     enableExternalFramebuffer()
                     log("Displayed logo on RNode screen")
                 } catch (e: Exception) {
@@ -233,16 +227,15 @@ class RNodeInterface(
         outputStream.flush()
     }
 
-    /** Write a 64x64 monochrome bitmap (512 bytes) to the RNode display.
-     *  Matches columba Python rnode_interface.py:display_image() exactly:
-     *  each line written individually with 15ms delay for BLE pacing. */
-    private suspend fun displayImage(imageData: ByteArray) {
+    /** Write a 64x64 monochrome bitmap (512 bytes) to the RNode display,
+     *  one line at a time. BLE pacing is handled by the OutputStream's
+     *  latch-per-write synchronization — no artificial delay needed. */
+    private fun displayImage(imageData: ByteArray) {
         val lines = imageData.size / FB_BYTES_PER_LINE
         for (line in 0 until lines) {
             val lineStart = line * FB_BYTES_PER_LINE
             val lineData = imageData.copyOfRange(lineStart, lineStart + FB_BYTES_PER_LINE)
             writeFramebuffer(line, lineData)
-            delay(15) // Match Python's time.sleep(0.015) for BLE write pacing
         }
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -204,11 +204,19 @@ class RNodeInterface(
             online.set(true)
             log("RNode is configured and online")
 
-            // Note: framebuffer display (logo) is NOT done during init.
-            // Python RNodeInterface doesn't do it either — the display_image()
-            // methods exist for external use (e.g., Sideband/NomadNet UI updates).
-            // Attempting rapid-fire framebuffer writes during init over BLE causes
-            // write desync. If needed, call displayImage() externally after init.
+            // Display logo on RNode screen if configured.
+            // Matches columba's Python rnode_interface.py:_display_logo():
+            // display_image FIRST, then enable_external_framebuffer with delay.
+            if (displayImageData != null) {
+                try {
+                    displayImage(displayImageData!!)
+                    delay(50)  // Match Python's time.sleep(0.05)
+                    enableExternalFramebuffer()
+                    log("Displayed logo on RNode screen")
+                } catch (e: Exception) {
+                    log("Could not display logo: ${e.message}")
+                }
+            }
         } else {
             throw IOException("Radio parameter validation failed — device reported different values than configured")
         }

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPServerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPServerInterface.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import network.reticulum.interfaces.toRef
+import network.reticulum.transport.Transport
 import kotlinx.coroutines.withContext
 import network.reticulum.identity.Identity
 import network.reticulum.interfaces.IfacCredentials
@@ -184,6 +186,7 @@ class TCPServerInterface(
     internal fun clientDisconnected(client: TCPServerClientInterface) {
         clients.remove(client)
         spawnedInterfaces?.remove(client)
+        Transport.deregisterInterface(client.toRef())
         onClientDisconnected?.invoke(client)
         log("Client disconnected: ${client.name}")
     }

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/auto/AutoInterfaceAdaptiveIntervalTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/auto/AutoInterfaceAdaptiveIntervalTest.kt
@@ -1,0 +1,108 @@
+package network.reticulum.interfaces.auto
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for AutoInterface's adaptive announce interval logic.
+ *
+ * Verifies the battery-saving multicast throttling:
+ * - Fast 1.6s rate on startup and peer changes
+ * - Linear ramp to 2 minutes when stable
+ * - 5x throttle multiplier scales max interval to 10 minutes
+ * - Immediate announce flag on peer change
+ */
+@DisplayName("AutoInterface Adaptive Interval")
+class AutoInterfaceAdaptiveIntervalTest {
+
+    // Mirror the constants from AutoInterface for testing
+    private val minInterval = AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS  // 1600
+    private val maxInterval = 120_000L  // 2 minutes
+    private val rampDuration = 60_000L  // 60 seconds
+
+    /**
+     * Compute interval the same way AutoInterface.updateAnnounceInterval does.
+     */
+    private fun computeInterval(
+        timeSinceChange: Long,
+        throttleMultiplier: Float = 1.0f,
+    ): Long {
+        val progress = (timeSinceChange.toDouble() / rampDuration).coerceIn(0.0, 1.0)
+        val effectiveMax = (maxInterval * throttleMultiplier).toLong()
+        return (minInterval + (effectiveMax - minInterval) * progress).toLong()
+    }
+
+    @Test
+    @DisplayName("Interval starts at min (1.6s) immediately after peer change")
+    fun `interval starts at min`() {
+        val interval = computeInterval(0)
+        assertEquals(minInterval, interval)
+    }
+
+    @Test
+    @DisplayName("Interval reaches max (2 min) after ramp duration")
+    fun `interval reaches max after ramp`() {
+        val interval = computeInterval(rampDuration)
+        assertEquals(maxInterval, interval)
+    }
+
+    @Test
+    @DisplayName("Interval stays at max beyond ramp duration")
+    fun `interval stays at max beyond ramp`() {
+        val interval = computeInterval(rampDuration * 2)
+        assertEquals(maxInterval, interval)
+    }
+
+    @Test
+    @DisplayName("Interval is halfway at half ramp duration")
+    fun `interval is halfway at half ramp`() {
+        val interval = computeInterval(rampDuration / 2)
+        val expected = minInterval + (maxInterval - minInterval) / 2
+        assertEquals(expected, interval)
+    }
+
+    @Test
+    @DisplayName("Throttle multiplier 5x scales max to 10 minutes")
+    fun `throttle multiplier scales max`() {
+        val interval = computeInterval(rampDuration, throttleMultiplier = 5.0f)
+        val expected = (maxInterval * 5.0f).toLong()
+        assertEquals(expected, interval)
+    }
+
+    @Test
+    @DisplayName("Throttle multiplier 5x at midpoint is between min and 10 min")
+    fun `throttle multiplier at midpoint`() {
+        val interval = computeInterval(rampDuration / 2, throttleMultiplier = 5.0f)
+        assertTrue(interval > minInterval)
+        assertTrue(interval < maxInterval * 5)
+    }
+
+    @Test
+    @DisplayName("Throttle multiplier 1.0 has no effect on max")
+    fun `throttle multiplier 1 is identity`() {
+        val withoutThrottle = computeInterval(rampDuration, throttleMultiplier = 1.0f)
+        assertEquals(maxInterval, withoutThrottle)
+    }
+
+    @Test
+    @DisplayName("Interval never goes below min regardless of throttle")
+    fun `interval never below min`() {
+        // Even with throttle, at time 0 should be min
+        val interval = computeInterval(0, throttleMultiplier = 5.0f)
+        assertEquals(minInterval, interval)
+    }
+
+    @Test
+    @DisplayName("Announce interval constant matches Python 1.6s")
+    fun `min interval matches python`() {
+        assertEquals(1600L, AutoInterfaceConstants.ANNOUNCE_INTERVAL_MS)
+    }
+
+    @Test
+    @DisplayName("Peer timeout constant matches Python")
+    fun `peer timeout matches python`() {
+        assertEquals(22.0, AutoInterfaceConstants.PEERING_TIMEOUT)
+    }
+}

--- a/rns-test/src/test/kotlin/network/reticulum/integration/LiveTcpServerTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/LiveTcpServerTest.kt
@@ -4,6 +4,7 @@ import network.reticulum.Reticulum
 import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.toRef
 import network.reticulum.transport.Transport
+import network.reticulum.transport.AnnounceHandler
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
@@ -47,12 +48,12 @@ class LiveTcpServerTest {
             enableTransport = false
         )
 
-        Transport.registerAnnounceHandler { destHash, _, _ ->
+        Transport.registerAnnounceHandler(handler = AnnounceHandler { destHash, _, _ ->
             val hex = destHash.joinToString("") { "%02x".format(it) }
             println("  [Announce] Discovered destination: $hex")
             discoveredPaths.add(hex)
             true
-        }
+        })
 
         tcpClient = TCPClientInterface(
             name = "LiveTest",

--- a/rns-test/src/test/kotlin/network/reticulum/integration/TcpIntegrationTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/TcpIntegrationTest.kt
@@ -10,6 +10,7 @@ import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.tcp.TCPServerInterface
 import network.reticulum.packet.Packet
 import network.reticulum.transport.Transport
+import network.reticulum.transport.AnnounceHandler
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -155,12 +156,12 @@ class TcpIntegrationTest {
         Transport.registerInterface(serverRef)
 
         // Set up announce handler
-        Transport.registerAnnounceHandler { destHash, identity, appData ->
+        Transport.registerAnnounceHandler(handler = AnnounceHandler { destHash, identity, appData ->
             println("Received announce for ${destHash.map { String.format("%02x", it) }.joinToString("")}")
             receivedAnnounce = true
             announceLatch.countDown()
             true
-        }
+        })
 
         // Hook up server received packets to transport
         server.onPacketReceived = { data, iface ->

--- a/rns-test/src/test/kotlin/network/reticulum/integration/TunnelIntegrationTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/TunnelIntegrationTest.kt
@@ -9,6 +9,7 @@ import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.tcp.TCPServerInterface
 import network.reticulum.packet.Packet
 import network.reticulum.transport.Transport
+import network.reticulum.transport.AnnounceHandler
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -166,11 +167,11 @@ class TunnelIntegrationTest {
         }
 
         // Set announce handler
-        Transport.registerAnnounceHandler { destHash, identity, appData ->
+        Transport.registerAnnounceHandler(handler = AnnounceHandler { destHash, identity, appData ->
             println("Received announce for ${destHash.take(8).joinToString("") { "%02x".format(it) }}")
             announceLatch.countDown()
             true
-        }
+        })
 
         client.start()
 

--- a/rns-test/src/test/kotlin/network/reticulum/interop/crypto/PropagationDecryptTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/interop/crypto/PropagationDecryptTest.kt
@@ -1,0 +1,97 @@
+package network.reticulum.interop.crypto
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import network.reticulum.common.RnsConstants
+import network.reticulum.common.toHexString
+import network.reticulum.crypto.Token
+import network.reticulum.crypto.defaultCryptoProvider
+import network.reticulum.identity.Identity
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Test that Kotlin can decrypt data encrypted by Python's
+ * Destination.encrypt() / Identity.encrypt() - the propagation path.
+ *
+ * Uses exact intermediate values from Python for debugging.
+ */
+@DisplayName("Propagation Decrypt Interop")
+class PropagationDecryptTest {
+
+    private val crypto = defaultCryptoProvider()
+
+    private fun hexToBytes(hex: String): ByteArray =
+        hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    @Test
+    @DisplayName("Kotlin decrypts Python propagation-encrypted data")
+    fun kotlinDecryptsPythonPropagationData() {
+        // Values from Python test
+        val privateKey = hexToBytes(
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" +
+            "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        )
+        val ephemeralPub = hexToBytes("06dfc472f53b4fe3ab2e2865a6efb67108533f9f964ee0b11ce8ab9bbe937b6c")
+        val pythonSharedKey = hexToBytes("f6729322d353c7f05665815ac8d6a69494e4ea9b54da6f0047ac84695a654312")
+        val pythonDerivedKey = hexToBytes(
+            "8cf7b55036fc7037bd95a4b2c622c30cb6b1b572315a63da78aaabdd49a85abe" +
+            "753bbe5b96030f171c352511deb761d2f76482b91310895132f2da2c88ee5cc9"
+        )
+        val fullEncrypted = hexToBytes(
+            "06dfc472f53b4fe3ab2e2865a6efb67108533f9f964ee0b11ce8ab9bbe937b6c" +
+            "c4f27c892d9185b17859d2b99ef10166fea8eeb45000e4f2fc502456ee7b1321" +
+            "ebb89a6d8edc8aa3404b13735cb304f630022c0b15ed1c568de2301cd268ee4c" +
+            "27a9d8ee81c871f626eb765d03e348d1"
+        )
+        val expectedPlaintext = hexToBytes("48656c6c6f2066726f6d20507974686f6e2070726f7061676174696f6e21")
+
+        // Create identity from private key
+        val identity = Identity.fromPrivateKey(privateKey, crypto)
+        
+        // Step 1: Verify identity hash matches Python
+        val expectedHash = "eb0e071a3f342bf3ee467fb22149eafd"
+        println("Kotlin identity hash: ${identity.hash.toHexString()}")
+        println("Python identity hash: $expectedHash")
+        identity.hash.toHexString() shouldBe expectedHash
+        
+        // Step 2: Verify X25519 public key matches Python
+        val expectedPubBytes = "d946390220202c7b7a195d6eb90553926fc7fa23c23322f18837c2e2b0fb8318"
+        val x25519Public = identity.getPublicKey().copyOfRange(0, 32)
+        println("Kotlin X25519 pub: ${x25519Public.toHexString()}")
+        println("Python X25519 pub: $expectedPubBytes")
+        x25519Public.toHexString() shouldBe expectedPubBytes
+        
+        // Step 3: Compute shared key and compare
+        val x25519Private = privateKey.copyOfRange(0, 32)
+        val sharedKey = crypto.x25519Exchange(x25519Private, ephemeralPub)
+        println("Kotlin shared key: ${sharedKey.toHexString()}")
+        println("Python shared key: ${pythonSharedKey.toHexString()}")
+        sharedKey.toHexString() shouldBe pythonSharedKey.toHexString()
+        
+        // Step 4: HKDF and compare derived key
+        val salt = identity.hash
+        val derivedKey = crypto.hkdf(
+            length = RnsConstants.DERIVED_KEY_LENGTH,
+            ikm = sharedKey,
+            salt = salt,
+            info = null
+        )
+        println("Kotlin derived key: ${derivedKey.toHexString()}")
+        println("Python derived key: ${pythonDerivedKey.toHexString()}")
+        derivedKey.toHexString() shouldBe pythonDerivedKey.toHexString()
+        
+        // Step 5: Token decrypt
+        val tokenData = fullEncrypted.copyOfRange(32, fullEncrypted.size)
+        val token = Token(derivedKey, crypto)
+        val decryptedFromToken = token.decrypt(tokenData)
+        println("Token decrypt: ${String(decryptedFromToken)}")
+        decryptedFromToken.contentEquals(expectedPlaintext) shouldBe true
+        
+        // Step 6: Full identity decrypt (the real test)
+        val decrypted = identity.decrypt(fullEncrypted)
+        decrypted shouldNotBe null
+        println("Identity decrypt: ${String(decrypted!!)}")
+        decrypted.contentEquals(expectedPlaintext) shouldBe true
+    }
+}

--- a/rns-test/src/test/kotlin/network/reticulum/interop/crypto/PropagationE2EDecryptTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/interop/crypto/PropagationE2EDecryptTest.kt
@@ -1,0 +1,123 @@
+package network.reticulum.interop.crypto
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import network.reticulum.common.DestinationDirection
+import network.reticulum.common.DestinationType
+import network.reticulum.common.RnsConstants
+import network.reticulum.common.toHexString
+import network.reticulum.crypto.defaultCryptoProvider
+import network.reticulum.destination.Destination
+import network.reticulum.identity.Identity
+import network.reticulum.interop.InteropTestBase
+import network.reticulum.interop.getBytes
+import network.reticulum.interop.getBoolean
+import network.reticulum.interop.getString
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end test for propagated LXMF message decryption.
+ *
+ * Simulates the exact data flow:
+ * 1. Python encrypts packed[DEST_LEN:] with Destination.encrypt()
+ * 2. Python builds lxmf_data = dest_hash + encrypted_data
+ * 3. Kotlin extracts encrypted_data and decrypts with Destination.decrypt()
+ *
+ * This tests the EXACT same code path as real propagation delivery.
+ */
+@DisplayName("Propagation E2E Decrypt")
+class PropagationE2EDecryptTest : InteropTestBase() {
+
+    private val crypto = defaultCryptoProvider()
+
+    @Test
+    @DisplayName("Kotlin Destination.decrypt works for Python propagation-encrypted data")
+    fun kotlinDestinationDecryptsPythonPropagationData() {
+        // Step 1: Create Kotlin identity and destination (the recipient)
+        val recipientIdentity = Identity.create(crypto)
+        val recipientDestination = Destination.create(
+            identity = recipientIdentity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            "delivery"
+        )
+
+        println("Kotlin recipient dest hash: ${recipientDestination.hexHash}")
+        println("Kotlin recipient identity hash: ${recipientIdentity.hexHash}")
+        println("Kotlin recipient public key: ${recipientIdentity.getPublicKey().toHexString()}")
+
+        // Step 2: Have Python create the exact propagation-encrypted data
+        // Python will: create an OUT destination for this identity,
+        // encrypt plaintext using Destination.encrypt(), then return
+        // the full lxmf_data (dest_hash + encrypted)
+        val plaintext = "Hello from Python propagation via Destination.encrypt!"
+        val pyResult = python(
+            "propagation_encrypt_for_recipient",
+            "recipient_public_key" to recipientIdentity.getPublicKey(),
+            "plaintext" to plaintext.toByteArray()
+        )
+
+        val pythonDestHash = pyResult.getBytes("dest_hash")
+        val encryptedData = pyResult.getBytes("encrypted_data")
+        val pythonIdentityHash = pyResult.getString("identity_hash")
+        val pythonUsedRatchet = pyResult.getBoolean("used_ratchet")
+        
+        println("Python dest hash: ${pythonDestHash.toHexString()}")
+        println("Python identity hash: $pythonIdentityHash")
+        println("Python used ratchet: $pythonUsedRatchet")
+        println("Encrypted data size: ${encryptedData.size}")
+
+        // Verify destination hashes match
+        pythonDestHash.toHexString() shouldBe recipientDestination.hexHash
+        
+        // Verify identity hashes match
+        pythonIdentityHash shouldBe recipientIdentity.hexHash
+        
+        // Step 3: Decrypt using Kotlin Destination.decrypt() 
+        // This is the EXACT same path as processInboundDelivery
+        val decryptedData = recipientDestination.decrypt(encryptedData)
+        
+        decryptedData shouldNotBe null
+        println("Kotlin decrypted: ${String(decryptedData!!)}")
+        String(decryptedData) shouldBe plaintext
+    }
+
+    @Test
+    @DisplayName("Full lxmf_data format: dest_hash + encrypted works")
+    fun fullLxmfDataFormatWorks() {
+        // Simulates the complete format that arrives from a propagation node
+        val recipientIdentity = Identity.create(crypto)
+        val recipientDestination = Destination.create(
+            identity = recipientIdentity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lxmf",
+            "delivery"
+        )
+
+        val plaintext = "Full format test"
+        val pyResult = python(
+            "propagation_encrypt_for_recipient",
+            "recipient_public_key" to recipientIdentity.getPublicKey(),
+            "plaintext" to plaintext.toByteArray()
+        )
+
+        val encryptedData = pyResult.getBytes("encrypted_data")
+        val destHash = pyResult.getBytes("dest_hash")
+
+        // Build the full lxmf_data as it would come from the prop node
+        val lxmfData = destHash + encryptedData
+        
+        // Process like processInboundDelivery does
+        val extractedDestHash = lxmfData.copyOfRange(0, 16)
+        val extractedEncrypted = lxmfData.copyOfRange(16, lxmfData.size)
+        
+        extractedDestHash.toHexString() shouldBe recipientDestination.hexHash
+        
+        val decrypted = recipientDestination.decrypt(extractedEncrypted)
+        decrypted shouldNotBe null
+        String(decrypted!!) shouldBe plaintext
+    }
+}

--- a/rns-test/src/test/kotlin/network/reticulum/test/TunnelTestMain.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/test/TunnelTestMain.kt
@@ -6,6 +6,7 @@ import network.reticulum.identity.Identity
 import network.reticulum.interfaces.toRef
 import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.transport.Transport
+import network.reticulum.transport.AnnounceHandler
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -56,12 +57,12 @@ fun main() {
     val announceLatch = CountDownLatch(1)
 
     // Register announce handler
-    Transport.registerAnnounceHandler { destHash, identity, appData ->
+    Transport.registerAnnounceHandler(AnnounceHandler { destHash, identity, appData ->
         val destHex = destHash.joinToString("") { "%02x".format(it) }
         println("\n✓ Received announce for destination: $destHex")
         announceLatch.countDown()
         true
-    }
+    })
 
     println("Connecting to Python server at 127.0.0.1:4244...")
     tcpClient.start()


### PR DESCRIPTION
## Summary
- Transport fixes: delivery proofs, path persistence, LRPROOF reliability, ingress limiting, interface deregistration
- Interface discovery: auto-connect, hot-update limits, backbone support, disconnect on disable
- AutoInterface: adaptive multicast interval, Doze-aware throttling, immediate peer reply
- RNode: framebuffer display support, BLE write delay removal (pacing handled by caller)
- Announce handling: aspect filtering, rich handler context, ingress-limited local processing
- BLE scan mode: Doze-aware BALANCED/LOW_POWER switching
- Known destinations: persist on shutdown, load on startup
- Python deviations documented in PYTHON_DEVIATIONS.md

38 commits, 31 files changed, +3,347 / -1,356

## Test plan
- [ ] All reticulum-kt JVM tests pass (78+)
- [ ] Conformance suite 78/79 (bz2 library diff only)
- [ ] On-device: direct messaging, propagation, RNode BLE, AutoInterface discovery
- [ ] Framebuffer logo displays on RNode screen over BLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)