### PR TITLE
Fix Channel packet proof validation by setting packet.link

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -855,6 +855,12 @@ class Link private constructor(
                     mtu = link.mtu,
                 )
 
+            // Associate the packet with this Link so the receipt can
+            // validate proofs using the Link's signing keys.
+            // Without this, the receipt falls through to destination-based
+            // validation which doesn't match Link proofs.
+            packet.link = link
+
             // Use packet.send() so a PacketReceipt is created, enabling
             // delivery confirmation and timeout callbacks for Channel retry logic
             val receipt = packet.send()


### PR DESCRIPTION
## Summary
- `LinkChannelOutlet.send()` was not setting `packet.link` before calling `packet.send()`
- Without this, `PacketReceipt` has `link = null`, causing proof validation to use the wrong code path (`validateProof` instead of `validateLinkProof`)
- This caused **all Channel messages** to fail delivery with "Retry count exceeded, tearing down Link" when communicating with Python RNS

## One-line fix
```kotlin
packet.link = link  // Added before packet.send() in LinkChannelOutlet.send()
```

Every other Link send method already does this (`sendWithReceipt`, `sendResourceData`, `provePacket`, etc.).

## Verified
Full rnsh session lifecycle passes end-to-end against a real Python `rnsh -l` listener:
Link establishment → version handshake → ExecuteCommand → stdin/stdout streaming → exit

Fixes #15