### PR TITLE
Improve native RNode recovery and response handling

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -2727,18 +2727,36 @@ class Link private constructor(
             return
         }
 
-        // Get the resource data
-        val packedResponse = resource.data
-        if (packedResponse == null) {
+        val responseData = resource.data
+        if (responseData == null) {
             log("Response resource has no data")
             return
         }
 
         try {
+            // Python special-case: file responses are sent as raw resource data with metadata,
+            // not as msgpack [request_id, response_data].
+            if (resource.hasMetadata) {
+                val requestId = resource.requestId
+                if (requestId == null) {
+                    log("Response resource has metadata but no request ID")
+                    return
+                }
+
+                handleResponse(
+                    requestId,
+                    responseData,
+                    resource.totalSize,
+                    resource.size,
+                    metadata = resource.metadataBytes,
+                )
+                return
+            }
+
             // Unpack response: [request_id, response_data]
             val unpacker =
                 org.msgpack.core.MessagePack
-                    .newDefaultUnpacker(packedResponse)
+                    .newDefaultUnpacker(responseData)
             val arraySize = unpacker.unpackArrayHeader()
             if (arraySize != 2) {
                 log("Invalid response format: expected 2 elements, got $arraySize")
@@ -2753,7 +2771,7 @@ class Link private constructor(
             val responseValue = unpacker.unpackValue()
             unpacker.close()
 
-            val responseData: ByteArray? =
+            val unpackedResponseData: ByteArray? =
                 when {
                     responseValue.isNilValue -> null
                     responseValue.isBinaryValue -> responseValue.asBinaryValue().asByteArray()
@@ -2770,7 +2788,7 @@ class Link private constructor(
                 }
 
             // Pass to handleResponse
-            handleResponse(requestId, responseData, packedResponse.size, resource.totalSize)
+            handleResponse(requestId, unpackedResponseData, responseData.size, resource.totalSize)
         } catch (e: Exception) {
             log("Error processing response resource: ${e.message}")
         }

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -1224,6 +1224,12 @@ class Resource private constructor(
         get() = assembledData
 
     /**
+     * Get extracted metadata bytes, if present.
+     */
+    val metadataBytes: ByteArray?
+        get() = metadata
+
+    /**
      * Get transfer progress (0.0 to 1.0).
      */
     val progress: Float

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -44,6 +44,7 @@ class RNodeInterface(
     private val spreadingFactor: Int,
     private val codingRate: Int,
     private val flowControl: Boolean = true,
+    private val activityKeepaliveMs: Long? = null,
     private val parentScope: CoroutineScope? = null,
     /** Optional 512-byte framebuffer image to display on the RNode screen after init. */
     val displayImageData: ByteArray? = null,
@@ -58,6 +59,7 @@ class RNodeInterface(
         private const val DETECT_TIMEOUT_MS = 5_000L
         private const val VALIDATE_TIMEOUT_MS = 2_000L
         private const val READ_TIMEOUT_MS = 1_250L
+        private const val CONFIG_DELAY_MS = 150L
         private const val FB_BYTES_PER_LINE = 8
 
         // Signal quality computation constants (matching Python RNodeInterface)
@@ -141,6 +143,7 @@ class RNodeInterface(
 
     // Flow control
     @Volatile private var interfaceReady: Boolean = false
+    @Volatile private var lastWriteMs: Long = System.currentTimeMillis()
     private val packetQueue = CopyOnWriteArrayList<ByteArray>()
     private val txLock = Any()
 
@@ -267,13 +270,19 @@ class RNodeInterface(
         writeRaw(cmd)
     }
 
-    private fun initRadio() {
+    private suspend fun initRadio() {
         sendFrequency()
+        delay(CONFIG_DELAY_MS)
         sendBandwidth()
+        delay(CONFIG_DELAY_MS)
         sendTxPower()
+        delay(CONFIG_DELAY_MS)
         sendSpreadingFactor()
+        delay(CONFIG_DELAY_MS)
         sendCodingRate()
+        delay(CONFIG_DELAY_MS)
         sendRadioState(KISS.RADIO_STATE_ON)
+        delay(CONFIG_DELAY_MS)
     }
 
     private fun sendFrequency() {
@@ -324,6 +333,7 @@ class RNodeInterface(
         try {
             outputStream.write(data)
             outputStream.flush()
+            lastWriteMs = System.currentTimeMillis()
         } catch (e: IOException) {
             log("Write error: ${e.message}")
             throw e
@@ -347,6 +357,14 @@ class RNodeInterface(
         }
         if (rSf != null && spreadingFactor != rSf) {
             log("Spreading factor mismatch: configured=$spreadingFactor, reported=$rSf")
+            valid = false
+        }
+        if (rCr != null && codingRate != rCr) {
+            log("Coding rate mismatch: configured=$codingRate, reported=$rCr")
+            valid = false
+        }
+        if (rState != null && rState != (KISS.RADIO_STATE_ON.toInt() and 0xFF)) {
+            log("Radio state not ON: reported=$rState")
             valid = false
         }
 
@@ -404,9 +422,24 @@ class RNodeInterface(
 
         try {
             while (ioScope.isActive && !detached.get()) {
-                val bytesRead = withContext(Dispatchers.IO) {
-                    inputStream.read(buf)
-                }
+                val bytesRead =
+                    try {
+                        withContext(Dispatchers.IO) {
+                            inputStream.read(buf)
+                        }
+                    } catch (_: java.net.SocketTimeoutException) {
+                        val timeSinceLast = System.currentTimeMillis() - lastReadMs
+                        if (dataBuffer.size() > 0 && timeSinceLast > READ_TIMEOUT_MS) {
+                            log("Read timeout in command ${command.toInt() and 0xFF}")
+                            dataBuffer.reset()
+                            commandBuffer.reset()
+                            inFrame = false
+                            command = KISS.CMD_UNKNOWN
+                            escape = false
+                        }
+                        handleIdleMaintenance()
+                        continue
+                    }
 
                 if (bytesRead <= 0) {
                     // Check for idle timeout
@@ -419,7 +452,11 @@ class RNodeInterface(
                         command = KISS.CMD_UNKNOWN
                         escape = false
                     }
-                    if (bytesRead == -1) break
+                    if (bytesRead == -1) {
+                        log("Read loop reached EOF - remote closed connection")
+                        break
+                    }
+                    handleIdleMaintenance()
                     delay(10)
                     continue
                 }
@@ -681,6 +718,9 @@ class RNodeInterface(
             }
         }
 
+        if (online.get()) {
+            log("Read loop exiting - marking interface offline")
+        }
         online.set(false)
     }
 
@@ -733,6 +773,7 @@ class RNodeInterface(
         try {
             outputStream.write(frame)
             outputStream.flush()
+            lastWriteMs = System.currentTimeMillis()
             txBytes.addAndGet(data.size.toLong())
         } catch (e: IOException) {
             log("TX error: ${e.message}")
@@ -747,6 +788,16 @@ class RNodeInterface(
             processOutgoing(data)
         } else {
             interfaceReady = true
+        }
+    }
+
+    private fun handleIdleMaintenance() {
+        val keepaliveAfterMs = activityKeepaliveMs
+        if (keepaliveAfterMs != null && online.get()) {
+            val timeSinceLastWrite = System.currentTimeMillis() - lastWriteMs
+            if (timeSinceLastWrite >= keepaliveAfterMs) {
+                detect()
+            }
         }
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -45,6 +45,8 @@ class RNodeInterface(
     private val codingRate: Int,
     private val flowControl: Boolean = true,
     private val activityKeepaliveMs: Long? = null,
+    private val framebufferLineDelayMs: Long = 0L,
+    private val framebufferEnableDelayMs: Long = 0L,
     private val parentScope: CoroutineScope? = null,
     /** Optional 512-byte framebuffer image to display on the RNode screen after init. */
     val displayImageData: ByteArray? = null,
@@ -210,6 +212,9 @@ class RNodeInterface(
             if (displayImageData != null) {
                 try {
                     displayImage(displayImageData!!)
+                    if (framebufferEnableDelayMs > 0) {
+                        delay(framebufferEnableDelayMs)
+                    }
                     enableExternalFramebuffer()
                     log("Displayed logo on RNode screen")
                 } catch (e: Exception) {
@@ -226,14 +231,13 @@ class RNodeInterface(
     /** Enable external framebuffer control on the RNode display. */
     private fun enableExternalFramebuffer() {
         val cmd = byteArrayOf(KISS.FEND, KISS.CMD_FB_EXT, 0x01, KISS.FEND)
-        outputStream.write(cmd)
-        outputStream.flush()
+        writeRaw(cmd)
     }
 
     /** Write a 64x64 monochrome bitmap (512 bytes) to the RNode display,
-     *  one line at a time. BLE pacing is handled by the OutputStream's
-     *  latch-per-write synchronization — no artificial delay needed. */
-    private fun displayImage(imageData: ByteArray) {
+     *  one line at a time. Optional pacing can be applied to match Python's
+     *  framebuffer write timing for transports that need it. */
+    private suspend fun displayImage(imageData: ByteArray) {
         require(imageData.size == FB_BYTES_PER_LINE * 64) {
             "displayImage expects ${FB_BYTES_PER_LINE * 64} bytes (64x64 monochrome), got ${imageData.size}"
         }
@@ -242,6 +246,9 @@ class RNodeInterface(
             val lineStart = line * FB_BYTES_PER_LINE
             val lineData = imageData.copyOfRange(lineStart, lineStart + FB_BYTES_PER_LINE)
             writeFramebuffer(line, lineData)
+            if (framebufferLineDelayMs > 0) {
+                delay(framebufferLineDelayMs)
+            }
         }
     }
 
@@ -250,8 +257,7 @@ class RNodeInterface(
         val data = byteArrayOf(line.toByte()) + lineData
         val escaped = KISS.escape(data)
         val cmd = byteArrayOf(KISS.FEND, KISS.CMD_FB_WRITE) + escaped + byteArrayOf(KISS.FEND)
-        outputStream.write(cmd)
-        outputStream.flush()
+        writeRaw(cmd)
     }
 
     // -- KISS command helpers (matching Python's detect/setFrequency/etc.) --

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -689,8 +689,9 @@ class RNodeInterface(
                         }
                     } else if (command == KISS.CMD_RESET) {
                         if (byte == 0xF8) {
-                            if (online.get()) {
-                                log("Device reset detected while online")
+                            if ((platform == (KISS.PLATFORM_ESP32.toInt() and 0xFF)) && online.get()) {
+                                log("Device reset detected while online, reinitialising device")
+                                throw IOException("ESP32 reset")
                             }
                         }
                     } else if (command == KISS.CMD_READY) {

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/rnode/RNodeInterfaceTcpKeepaliveTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/rnode/RNodeInterfaceTcpKeepaliveTest.kt
@@ -1,0 +1,104 @@
+package network.reticulum.interfaces.rnode
+
+import network.reticulum.interfaces.framing.KISS
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+class RNodeInterfaceTcpKeepaliveTest {
+
+    @Test
+    fun `idle TCP interface sends detect keepalive when online`() {
+        val output = ByteArrayOutputStream()
+        val iface = createInterface(output, activityKeepaliveMs = 3_500L)
+
+        iface.online.set(true)
+        setLastWriteMs(iface, System.currentTimeMillis() - 4_000L)
+
+        invokeHandleIdleMaintenance(iface)
+
+        assertArrayEquals(expectedDetectFrames(), output.toByteArray())
+    }
+
+    @Test
+    fun `idle maintenance does not send keepalive when offline`() {
+        val output = ByteArrayOutputStream()
+        val iface = createInterface(output, activityKeepaliveMs = 3_500L)
+
+        iface.online.set(false)
+        setLastWriteMs(iface, System.currentTimeMillis() - 4_000L)
+
+        invokeHandleIdleMaintenance(iface)
+
+        assertEquals(0, output.size())
+    }
+
+    @Test
+    fun `idle maintenance does not send keepalive before threshold`() {
+        val output = ByteArrayOutputStream()
+        val iface = createInterface(output, activityKeepaliveMs = 3_500L)
+
+        iface.online.set(true)
+        setLastWriteMs(iface, System.currentTimeMillis() - 1_000L)
+
+        invokeHandleIdleMaintenance(iface)
+
+        assertEquals(0, output.size())
+    }
+
+    private fun createInterface(
+        output: ByteArrayOutputStream,
+        activityKeepaliveMs: Long?,
+    ): RNodeInterface =
+        RNodeInterface(
+            name = "TestRNode",
+            inputStream = ByteArrayInputStream(byteArrayOf()),
+            outputStream = output,
+            frequency = 915_000_000L,
+            bandwidth = 125_000L,
+            txPower = 7,
+            spreadingFactor = 7,
+            codingRate = 5,
+            flowControl = false,
+            activityKeepaliveMs = activityKeepaliveMs,
+            parentScope = null,
+            displayImageData = null,
+        )
+
+    private fun invokeHandleIdleMaintenance(iface: RNodeInterface) {
+        val method = iface.javaClass.getDeclaredMethod("handleIdleMaintenance")
+        method.isAccessible = true
+        method.invoke(iface)
+    }
+
+    private fun setLastWriteMs(
+        iface: RNodeInterface,
+        value: Long,
+    ) {
+        val field = iface.javaClass.getDeclaredField("lastWriteMs")
+        field.isAccessible = true
+        field.setLong(iface, value)
+    }
+
+    private fun expectedDetectFrames(): ByteArray =
+        byteArrayOf(
+            KISS.FEND,
+            KISS.CMD_DETECT,
+            KISS.DETECT_REQ,
+            KISS.FEND,
+            KISS.FEND,
+            KISS.CMD_FW_VERSION,
+            0x00,
+            KISS.FEND,
+            KISS.FEND,
+            KISS.CMD_PLATFORM,
+            0x00,
+            KISS.FEND,
+            KISS.FEND,
+            KISS.CMD_MCU,
+            0x00,
+            KISS.FEND,
+        )
+}


### PR DESCRIPTION
## Summary
This PR upstreams the remaining `reticulum-kt` changes that the Columba native migration has been using locally.

Included changes:
- keep TCP RNode interfaces alive with Python-style activity keepalives
- match Python-style TCP framebuffer pacing
- handle resource-backed request responses correctly (e.g. NomadNet file responses with metadata)
- treat ESP32 `CMD_RESET 0xF8` while online as fatal so higher-level recovery can reopen the transport

## Why
These fixes were validated during real-device migration testing in Columba and are needed to avoid keeping the parent repo pinned to local-only submodule commits.

## Validation
- `./gradlew :rns-interfaces:test :rns-core:test`

## Notes
The ESP32 reset behavior mirrors the Python implementation's expectation that an online reset should force reinitialisation/recovery rather than leaving the interface stuck offline.
