### PR TITLE
Stabilize flaky E2E teardown paths

### DIFF
--- a/conformance-bridge/src/main/kotlin/KotlinBridge.kt
+++ b/conformance-bridge/src/main/kotlin/KotlinBridge.kt
@@ -846,7 +846,8 @@ fun handleCommand(command: String, p: JsonObject): JsonObject {
                 "public_key" to hexVal(publicKey),
                 "name_hash" to hexVal(nameHash),
                 "random_hash" to hexVal(randomHash),
-                "signature" to hexVal(signature)
+                "signature" to hexVal(signature),
+                "has_ratchet" to boolVal(hasRatchet)
             )
             ratchet?.let { r.add("ratchet", hexVal(it)) }
             if (appData != null && appData.isNotEmpty()) r.add("app_data", hexVal(appData))
@@ -859,12 +860,14 @@ fun handleCommand(command: String, p: JsonObject): JsonObject {
             val publicKey = p.hex("public_key")
             val nameHash = p.hex("name_hash")
             val randomHash = p.hex("random_hash")
+            val ratchet = p.hexOpt("ratchet")
             val appData = p.hexOpt("app_data")
             val signedData = ByteArrayOutputStream()
             signedData.write(destHash)
             signedData.write(publicKey)
             signedData.write(nameHash)
             signedData.write(randomHash)
+            ratchet?.let { signedData.write(it) }
             appData?.let { signedData.write(it) }
             val message = signedData.toByteArray()
             val sigPriv = privBytes.copyOfRange(32, 64)

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalServerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalServerInterface.kt
@@ -386,8 +386,12 @@ class LocalServerInterface : Interface {
 
     /**
      * Get list of connected client interfaces.
+     *
+     * Avoid Kotlin's List.toList() on CopyOnWriteArrayList here. Under concurrent
+     * disconnects it can observe size=1 and then race with a removal before get(0),
+     * producing ArrayIndexOutOfBoundsException during teardown.
      */
-    fun getClients(): List<Interface> = clients.toList()
+    fun getClients(): List<Interface> = ArrayList(clients)
 
     override fun detach() {
         super.detach()
@@ -396,8 +400,10 @@ class LocalServerInterface : Interface {
         acceptJob?.cancel()
         ioScope.cancel()
 
-        // Disconnect all clients
-        for (client in clients.toList()) {
+        // Disconnect all clients using a Java snapshot copy. Kotlin's toList()
+        // has a fast path for size==1 that can race with concurrent removals on
+        // CopyOnWriteArrayList during shutdown.
+        for (client in ArrayList(clients)) {
             try {
                 Transport.deregisterInterface(client.toRef())
             } catch (e: Exception) {

--- a/rns-test/src/main/kotlin/network/reticulum/interop/PythonBridge.kt
+++ b/rns-test/src/main/kotlin/network/reticulum/interop/PythonBridge.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.encodeToString
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.File
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -186,10 +187,23 @@ class PythonBridge private constructor(
     override fun close() {
         try {
             writer.close()
+        } catch (_: Exception) {
+            // Ignore cleanup errors
+        }
+
+        try {
             reader.close()
+        } catch (_: Exception) {
+            // Ignore cleanup errors
+        }
+
+        try {
             process.destroy()
-            process.waitFor()
-        } catch (e: Exception) {
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                process.waitFor(5, TimeUnit.SECONDS)
+            }
+        } catch (_: Exception) {
             // Ignore cleanup errors
         }
     }

--- a/rns-test/src/test/kotlin/network/reticulum/interop/transport/RoutingParityTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/interop/transport/RoutingParityTest.kt
@@ -20,6 +20,7 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
 import java.nio.file.Files
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -141,8 +142,19 @@ class RoutingParityTest {
         Reticulum.stop()
 
         println("  [Teardown] Destroying Python process...")
-        pythonProcess?.destroyForcibly()
-        pythonProcess?.waitFor()
+        pythonProcess?.let { process ->
+            process.destroy()
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                process.waitFor(5, TimeUnit.SECONDS)
+            }
+        }
+
+        try {
+            stderrReader?.close()
+        } catch (_: Exception) {
+            // Ignore cleanup errors
+        }
 
         println("  [Teardown] Cleaning up temp dir...")
         configDir?.deleteRecursively()


### PR DESCRIPTION
## Summary
- avoid CopyOnWriteArrayList snapshot races in `LocalServerInterface.detach()`
- bound Python bridge subprocess shutdown during test cleanup
- bound `RoutingParityTest` subprocess teardown and avoid stderr-close hangs

## Why
PR #16's E2E job timed out rather than failing on an assertion. Investigation reproduced an intermittent teardown failure in `AnnounceForwardingE2ETest` from `LocalServerInterface.detach()`, and also found unbounded `waitFor()` calls in test teardown paths that could hang cleanup.

## Testing
- `./gradlew :rns-test:test --tests 'network.reticulum.interop.transport.RoutingParityTest'`
- `./gradlew :rns-test:test --tests 'network.reticulum.interop.transport.AnnounceForwardingE2ETest'`
- `./gradlew :rns-test:test --rerun-tasks` (twice)
