### PR TITLE
Add conformance coverage for channel proof window recovery

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -48,14 +48,30 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build conformance bridge
+      - name: Build conformance bridge and Kotlin pipe peer runtime artifacts
         working-directory: reticulum-kt
-        run: ./gradlew :conformance-bridge:shadowJar
+        run: ./gradlew :conformance-bridge:shadowJar :rns-core:jar :rns-interfaces:jar :rns-cli:classes
 
-      - name: Run conformance tests
+      - name: Resolve Kotlin pipe peer classpath
+        working-directory: reticulum-kt
+        run: |
+          echo 'KOTLIN_PIPE_PEER_CLASSPATH<<EOF' >> "$GITHUB_ENV"
+          ./gradlew -q :rns-cli:printPipePeerRuntimeClasspath | perl -pe 's/\e\][^\a]*\a//g' >> "$GITHUB_ENV"
+          echo 'EOF' >> "$GITHUB_ENV"
+
+      - name: Run bridge conformance tests
         working-directory: reticulum-conformance
         env:
           CONFORMANCE_BRIDGE_CMD: java -jar ${{ github.workspace }}/reticulum-kt/conformance-bridge/build/libs/ConformanceBridge.jar
           PYTHON_RNS_PATH: ${{ github.workspace }}/Reticulum
           PYTHON_LXMF_PATH: ${{ github.workspace }}/LXMF
         run: python3 -m pytest tests/ --impl=kotlin -v --tb=short
+
+      - name: Run pipe integration conformance tests
+        working-directory: reticulum-conformance
+        env:
+          PYTHON_RNS_PATH: ${{ github.workspace }}/Reticulum
+        run: |
+          python3 -m pytest integration/test_channel_window_pipe.py \
+            --peer-cmd "java -cp \"$KOTLIN_PIPE_PEER_CLASSPATH\" network.reticulum.cli.PipePeerKt" \
+            -v --tb=short

--- a/python-bridge/conformance/pipe_session.py
+++ b/python-bridge/conformance/pipe_session.py
@@ -352,6 +352,18 @@ class PipeSession:
         """Wait for the target to report sending data on a link."""
         return self.wait_for_message("link_sent", timeout=timeout)
 
+    def wait_for_channel_sent(self, timeout=15):
+        """Wait for the target to report sending channel data."""
+        return self.wait_for_message("channel_sent", timeout=timeout)
+
+    def wait_for_channel_data(self, timeout=15):
+        """Wait for the target to report receiving channel data."""
+        return self.wait_for_message("channel_data", timeout=timeout)
+
+    def wait_for_error(self, timeout=15):
+        """Wait for the target to report an error."""
+        return self.wait_for_message("error", timeout=timeout)
+
     # ─── Python-side Link Data Receiving ──────────────────────────────
 
     def setup_python_link_callbacks(self, link):

--- a/python-bridge/conformance/test_channel_window.py
+++ b/python-bridge/conformance/test_channel_window.py
@@ -1,0 +1,137 @@
+"""
+Channel conformance tests focused on proof-driven send window recovery.
+
+These tests validate a subtle but important requirement:
+- the peer must not only deliver initial channel packets
+- it must also accept the returned proofs and reopen the channel send window
+
+A broken implementation can still get the first one or two channel packets to the
+remote side while failing to validate their proofs locally. In that case, the
+send window never reopens and the next channel send stalls or the link later
+tears down.
+"""
+import threading
+import time
+import pytest
+from pipe_session import PipeSession
+
+
+@pytest.fixture(scope="module")
+def session(peer_cmd, rns_path):
+    """Session where the target accepts a link and serves channel messages."""
+    s = PipeSession(peer_cmd, rns_path)
+    s.start(peer_action="channel_serve")
+    ready = s.wait_for_ready()
+    assert ready is not None
+    yield s
+    s.stop()
+
+
+@pytest.fixture(scope="module")
+def target_dest(session):
+    """Wait for target announce and confirm Python learned the path."""
+    announced = session.wait_for_announced(timeout=15)
+    assert announced is not None, "Target should announce its destination"
+
+    dest_hash = announced["destination_hash"]
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if session.python_has_path(dest_hash):
+            break
+        time.sleep(0.2)
+
+    assert session.python_has_path(dest_hash), \
+        f"Python should learn path to target destination {dest_hash}"
+
+    return announced
+
+
+class BridgeMessageFactory:
+    @staticmethod
+    def make(RNS):
+        class BridgeMessage(RNS.Channel.MessageBase):
+            MSGTYPE = 0x0101
+
+            def __init__(self, data=b""):
+                self.data = data
+
+            def pack(self):
+                return self.data
+
+            def unpack(self, raw):
+                self.data = raw
+
+        return BridgeMessage
+
+
+class TestChannelSendWindow:
+    """Target should reopen the channel send window after receiving proofs."""
+
+    @pytest.fixture(scope="class")
+    def active_link(self, session, target_dest):
+        dest_hash = target_dest["destination_hash"]
+        RNS = session.RNS
+        dest_bytes = bytes.fromhex(dest_hash)
+        identity = RNS.Identity.recall(dest_bytes)
+        assert identity is not None, "Should have identity from announce"
+
+        dest = RNS.Destination(
+            identity,
+            RNS.Destination.OUT,
+            RNS.Destination.SINGLE,
+            "pipetest",
+            "routing",
+        )
+
+        link = RNS.Link(dest)
+
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if link.status == RNS.Link.ACTIVE:
+                break
+            time.sleep(0.1)
+
+        assert link.status == RNS.Link.ACTIVE, \
+            f"Link should become ACTIVE, got status {link.status}"
+
+        msg = session.wait_for_link_established(timeout=15)
+        assert msg is not None, "Target should report link_established"
+
+        yield link
+
+        if link.status == RNS.Link.ACTIVE:
+            link.teardown()
+            time.sleep(0.5)
+
+    def test_target_reopens_channel_window_after_proofs(self, session, active_link):
+        RNS = session.RNS
+        BridgeMessage = BridgeMessageFactory.make(RNS)
+        channel = active_link.get_channel()
+        channel.register_message_type(BridgeMessage)
+
+        received = []
+        cond = threading.Condition()
+
+        def on_channel_message(message):
+            if isinstance(message, BridgeMessage):
+                with cond:
+                    received.append(bytes(message.data))
+                    cond.notify_all()
+                return True
+            return False
+
+        channel.add_message_handler(on_channel_message)
+
+        expected = [b"channel-one", b"channel-two", b"channel-three"]
+        deadline = time.time() + 15
+        with cond:
+            while time.time() < deadline and len(received) < len(expected):
+                cond.wait(timeout=min(deadline - time.time(), 0.5))
+
+        assert received[:3] == expected, \
+            f"Expected proof-gated channel sequence {expected}, got {received}"
+        assert active_link.status == RNS.Link.ACTIVE, "Link should remain active after channel proof exchange"
+        assert session.wait_for_error(timeout=1.5) is None, \
+            "Target should not report a stalled channel send"
+        assert session.wait_for_link_closed(timeout=1.5) is None, \
+            "Target should not tear the link down during the channel sequence"

--- a/python-bridge/pipe_peer.py
+++ b/python-bridge/pipe_peer.py
@@ -11,10 +11,11 @@ Protocol:
 
 The script accepts commands via environment variables:
   PIPE_PEER_ACTION: What to do after startup
-    "announce"     - Create a destination and announce it
-    "listen"       - Just listen and report what arrives
-    "link_listen"  - Create a destination, announce it, and accept incoming links
-    "transport"    - Enable transport mode and forward
+    "announce"      - Create a destination and announce it
+    "listen"        - Just listen and report what arrives
+    "link_listen"   - Create a destination, announce it, and accept incoming links
+    "channel_serve" - Accept a link and send a proof-dependent channel sequence
+    "transport"     - Enable transport mode and forward
 
   PIPE_PEER_APP_NAME: App name for destination (default: "pipetest")
   PIPE_PEER_ASPECTS: Comma-separated aspects (default: "routing")
@@ -54,6 +55,30 @@ def emit(msg):
 
 def bytes_to_hex(b):
     return b.hex() if b else ""
+
+
+_BridgeMessageClass = None
+
+
+def _get_bridge_message_class():
+    """Create a simple channel message type for interoperability tests."""
+    import RNS
+    global _BridgeMessageClass
+    if _BridgeMessageClass is None:
+        class BridgeMessage(RNS.Channel.MessageBase):
+            MSGTYPE = 0x0101
+
+            def __init__(self, data=b""):
+                self.data = data
+
+            def pack(self):
+                return self.data
+
+            def unpack(self, raw):
+                self.data = raw
+
+        _BridgeMessageClass = BridgeMessage
+    return _BridgeMessageClass
 
 
 def main():
@@ -200,6 +225,25 @@ def main():
             *aspects
         )
         destination.set_link_established_callback(_link_serve_established)
+        destination.announce()
+        emit({
+            "type": "announced",
+            "destination_hash": bytes_to_hex(destination.hash),
+            "identity_hash": bytes_to_hex(identity.hash),
+            "identity_public_key": bytes_to_hex(identity.get_public_key()),
+        })
+        _path_table_dumper(RNS)
+
+    elif action == "channel_serve":
+        identity = RNS.Identity()
+        destination = RNS.Destination(
+            identity,
+            RNS.Destination.IN,
+            RNS.Destination.SINGLE,
+            app_name,
+            *aspects
+        )
+        destination.set_link_established_callback(_channel_serve_established)
         destination.announce()
         emit({
             "type": "announced",
@@ -459,6 +503,67 @@ def _link_serve_established(link):
             emit({"type": "error", "message": f"Welcome send failed: {e}"})
 
     threading.Thread(target=send_welcome, daemon=True).start()
+
+
+def _setup_channel_peer(link, send_sequence=False):
+    """Register a simple channel type and optionally send a proof-gated sequence."""
+    BridgeMessage = _get_bridge_message_class()
+    channel = link.get_channel()
+    channel.register_message_type(BridgeMessage)
+
+    def on_channel_message(message):
+        if isinstance(message, BridgeMessage):
+            data = bytes(message.data)
+            emit({
+                "type": "channel_data",
+                "link_id": bytes_to_hex(link.link_id),
+                "data_hex": data.hex(),
+                "data_utf8": data.decode("utf-8", errors="replace"),
+            })
+            return True
+        return False
+
+    channel.add_message_handler(on_channel_message)
+
+    if not send_sequence:
+        return
+
+    def send_messages():
+        time.sleep(1.0)
+        for payload in (b"channel-one", b"channel-two", b"channel-three"):
+            deadline = time.time() + 5.0
+            while time.time() < deadline and link.status == link.ACTIVE and not channel.is_ready_to_send():
+                time.sleep(0.05)
+
+            if link.status != link.ACTIVE:
+                emit({"type": "error", "message": "Link became inactive before channel send"})
+                return
+
+            if not channel.is_ready_to_send():
+                emit({"type": "error", "message": "Channel never became ready for next send"})
+                return
+
+            try:
+                channel.send(BridgeMessage(payload))
+                emit({"type": "channel_sent", "link_id": bytes_to_hex(link.link_id), "data_hex": payload.hex()})
+            except Exception as e:
+                emit({"type": "error", "message": f"Channel send failed: {e}"})
+                return
+
+    threading.Thread(target=send_messages, daemon=True).start()
+
+
+def _channel_serve_established(link):
+    """Called when a link is established in channel_serve mode."""
+    link_id = link.link_id.hex() if link.link_id else ""
+    dest_hash = link.destination.hash.hex() if link.destination else ""
+    emit({
+        "type": "link_established",
+        "link_id": link_id,
+        "destination_hash": dest_hash,
+    })
+    link.set_link_closed_callback(_link_closed)
+    _setup_channel_peer(link, send_sequence=True)
 
 
 def _link_closed(link):

--- a/rns-cli/build.gradle.kts
+++ b/rns-cli/build.gradle.kts
@@ -40,6 +40,13 @@ tasks {
         exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
     }
 
+    register("printPipePeerRuntimeClasspath") {
+        dependsOn("classes")
+        doLast {
+            println(sourceSets.main.get().runtimeClasspath.asPath)
+        }
+    }
+
     // Pipe peer jar for conformance testing
     register<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("pipePeerJar") {
         archiveBaseName.set("kt-pipe-peer")

--- a/rns-cli/src/main/kotlin/network/reticulum/cli/PipePeer.kt
+++ b/rns-cli/src/main/kotlin/network/reticulum/cli/PipePeer.kt
@@ -2,6 +2,7 @@ package network.reticulum.cli
 
 import kotlinx.serialization.json.*
 import network.reticulum.Reticulum
+import network.reticulum.channel.MessageBase
 import network.reticulum.common.DestinationDirection
 import network.reticulum.common.DestinationType
 import network.reticulum.common.InterfaceMode
@@ -13,6 +14,7 @@ import network.reticulum.interfaces.local.LocalServerInterface
 import network.reticulum.interfaces.pipe.PipeInterface
 import network.reticulum.interfaces.toRef
 import network.reticulum.link.Link
+import network.reticulum.link.LinkConstants
 import network.reticulum.transport.AnnounceHandler
 import network.reticulum.transport.Transport
 import java.io.FileInputStream
@@ -27,7 +29,7 @@ import java.nio.file.Files
  *   stderr: JSON control/status messages (one per line)
  *
  * Environment variables:
- *   PIPE_PEER_ACTION:    announce | listen | link_listen | link_serve | transport
+ *   PIPE_PEER_ACTION:    announce | listen | link_listen | link_serve | channel_serve | transport
  *   PIPE_PEER_APP_NAME:  app name for destination (default: pipetest)
  *   PIPE_PEER_ASPECTS:   comma-separated aspects (default: routing)
  *   PIPE_PEER_TRANSPORT: true | false (default: false)
@@ -41,6 +43,83 @@ import java.nio.file.Files
 private fun fdPath(fd: Int): String = when {
     System.getProperty("os.name").startsWith("Mac", ignoreCase = true) -> "/dev/fd/$fd"
     else -> "/proc/self/fd/$fd"
+}
+
+private class BridgeChannelMessage : MessageBase() {
+    override val msgType: Int = 0x0101
+    var data: ByteArray = ByteArray(0)
+
+    override fun pack(): ByteArray = data
+
+    override fun unpack(raw: ByteArray) {
+        data = raw
+    }
+}
+
+private fun setupChannelPeer(link: Link, sendSequence: Boolean) {
+    val channel = link.getChannel()
+    channel.registerMessageType { BridgeChannelMessage() }
+    channel.addMessageHandler { message ->
+        if (message is BridgeChannelMessage) {
+            emit(buildJsonObject {
+                put("type", "channel_data")
+                put("link_id", link.linkId.toHexString())
+                put("data_hex", message.data.toHexString())
+                put("data_utf8", message.data.decodeToString())
+            })
+            true
+        } else {
+            false
+        }
+    }
+
+    if (!sendSequence) return
+
+    Thread {
+        Thread.sleep(1000)
+        val payloads = listOf("channel-one", "channel-two", "channel-three")
+        for (payload in payloads) {
+            val deadline = System.currentTimeMillis() + 5_000
+            while (System.currentTimeMillis() < deadline &&
+                link.status == LinkConstants.ACTIVE &&
+                !channel.isReadyToSend()
+            ) {
+                Thread.sleep(50)
+            }
+
+            if (link.status != LinkConstants.ACTIVE) {
+                emit(buildJsonObject {
+                    put("type", "error")
+                    put("message", "Link became inactive before channel send")
+                })
+                return@Thread
+            }
+
+            if (!channel.isReadyToSend()) {
+                emit(buildJsonObject {
+                    put("type", "error")
+                    put("message", "Channel never became ready for next send")
+                })
+                return@Thread
+            }
+
+            try {
+                val data = payload.toByteArray()
+                channel.send(BridgeChannelMessage().apply { this.data = data })
+                emit(buildJsonObject {
+                    put("type", "channel_sent")
+                    put("link_id", link.linkId.toHexString())
+                    put("data_hex", data.toHexString())
+                })
+            } catch (e: Exception) {
+                emit(buildJsonObject {
+                    put("type", "error")
+                    put("message", "Channel send failed: ${e.message}")
+                })
+                return@Thread
+            }
+        }
+    }.apply { isDaemon = true }.start()
 }
 
 fun main() {
@@ -273,6 +352,40 @@ fun main() {
                             })
                         }
                     }.apply { isDaemon = true }.start()
+                }
+                destination.announce()
+                emit(buildJsonObject {
+                    put("type", "announced")
+                    put("destination_hash", destination.hash.toHexString())
+                    put("identity_hash", identity.hash.toHexString())
+                    put("identity_public_key", identity.getPublicKey().toHexString())
+                })
+                pathTableDumper()
+            }
+            "channel_serve" -> {
+                val identity = Identity.create()
+                val destination = Destination.create(
+                    identity = identity,
+                    direction = DestinationDirection.IN,
+                    type = DestinationType.SINGLE,
+                    appName = appName,
+                    aspects = aspects
+                )
+                destination.setLinkEstablishedCallback { linkAny ->
+                    val link = linkAny as Link
+                    emit(buildJsonObject {
+                        put("type", "link_established")
+                        put("link_id", link.linkId.toHexString())
+                        put("destination_hash", destination.hash.toHexString())
+                    })
+                    link.setLinkClosedCallback { closedLink ->
+                        emit(buildJsonObject {
+                            put("type", "link_closed")
+                            put("link_id", closedLink.linkId.toHexString())
+                            put("destination_hash", destination.hash.toHexString())
+                        })
+                    }
+                    setupChannelPeer(link, sendSequence = true)
                 }
                 destination.announce()
                 emit(buildJsonObject {


### PR DESCRIPTION
## Summary
- add a conformance test for proof-driven channel send window recovery
- teach both pipe peers a `channel_serve` action that sends a 3-message channel sequence
- expose target-side `channel_sent` / `error` events to the conformance harness

## Why
A broken implementation can still deliver the first one or two channel packets while failing to validate the returned link proofs locally. When that happens, the sender's channel send window never reopens, so later channel sends stall or the link tears down.

The existing black-box channel checks did not catch that because they only asserted initial remote delivery.

## What the new test verifies
`python-bridge/conformance/test_channel_window.py`

The test:
1. establishes a link from the Python reference implementation to the target peer
2. creates a channel on the Python side
3. has the target send `channel-one`, `channel-two`, and `channel-three`
4. asserts the Python side receives all three messages in order
5. asserts the target does not emit an error or close the link during the sequence

This makes proof validation observable from the outside: the third send only happens if the target accepts returned proofs and reopens its channel send window.

## Validation
- `PYTHON_RNS_PATH=$HOME/repos/Reticulum python3 -m pytest python-bridge/conformance/test_channel_window.py --peer-cmd "python3 python-bridge/pipe_peer.py" -q`
- `./gradlew :rns-cli:compileKotlin`

## Notes
This PR is stacked on top of #19 because the conformance case is specifically intended to cover that channel proof-validation bug class for future implementations too.
