### PR TITLE
Avoid channel proof callback deadlock

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
@@ -9,7 +9,8 @@ import network.reticulum.link.Link
 import network.reticulum.link.LinkConstants
 import network.reticulum.transport.Transport
 import network.reticulum.transport.TransportConstants
-import kotlin.concurrent.thread
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * Callbacks for packet receipt events.
@@ -43,6 +44,10 @@ class PacketReceipt internal constructor(
         // Proof lengths
         val EXPL_LENGTH = RnsConstants.FULL_HASH_BYTES + RnsConstants.SIGNATURE_SIZE
         val IMPL_LENGTH = RnsConstants.SIGNATURE_SIZE
+
+        private val callbackExecutor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "PacketReceipt-callbacks").apply { isDaemon = true }
+        }
     }
 
     /** The full hash of the packet. */
@@ -156,15 +161,8 @@ class PacketReceipt internal constructor(
 
             concludedAt = System.currentTimeMillis()
 
-            // Fire timeout callback in separate thread
             callbacks.timeout?.let { callback ->
-                thread(isDaemon = true) {
-                    try {
-                        callback(this)
-                    } catch (e: Exception) {
-                        // Log error but don't propagate
-                    }
-                }
+                submitCallback("timeout", callback)
             }
             return true
         }
@@ -206,15 +204,22 @@ class PacketReceipt internal constructor(
         this.link = link
     }
 
+    private fun submitCallback(
+        callbackType: String,
+        callback: (PacketReceipt) -> Unit,
+    ) {
+        callbackExecutor.execute {
+            try {
+                callback(this)
+            } catch (e: Exception) {
+                System.err.println("[PacketReceipt] Error in $callbackType callback for ${hash.toHexString()}: ${e.message}")
+            }
+        }
+    }
+
     private fun fireDeliveryCallbackAsync() {
         callbacks.delivery?.let { callback ->
-            thread(isDaemon = true) {
-                try {
-                    callback(this)
-                } catch (_: Exception) {
-                    // Log error but don't propagate
-                }
-            }
+            submitCallback("delivery", callback)
         }
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
@@ -206,6 +206,18 @@ class PacketReceipt internal constructor(
         this.link = link
     }
 
+    private fun fireDeliveryCallbackAsync() {
+        callbacks.delivery?.let { callback ->
+            thread(isDaemon = true) {
+                try {
+                    callback(this)
+                } catch (_: Exception) {
+                    // Log error but don't propagate
+                }
+            }
+        }
+    }
+
     /**
      * Validate a proof packet.
      *
@@ -253,15 +265,7 @@ class PacketReceipt internal constructor(
                 proved = true
                 concludedAt = System.currentTimeMillis()
                 this.proofPacket = proofPacket
-
-                // Fire delivery callback
-                callbacks.delivery?.let { callback ->
-                    try {
-                        callback(this)
-                    } catch (e: Exception) {
-                        // Log error but don't propagate
-                    }
-                }
+                fireDeliveryCallbackAsync()
             }
 
             return proofValid
@@ -303,15 +307,7 @@ class PacketReceipt internal constructor(
                     proved = true
                     concludedAt = System.currentTimeMillis()
                     this.proofPacket = proofPacket
-
-                    // Fire delivery callback
-                    callbacks.delivery?.let { callback ->
-                        try {
-                            callback(this)
-                        } catch (e: Exception) {
-                            // Log error but don't propagate
-                        }
-                    }
+                    fireDeliveryCallbackAsync()
                 }
 
                 return proofValid
@@ -329,15 +325,7 @@ class PacketReceipt internal constructor(
                     proved = true
                     concludedAt = System.currentTimeMillis()
                     this.proofPacket = proofPacket
-
-                    // Fire delivery callback
-                    callbacks.delivery?.let { callback ->
-                        try {
-                            callback(this)
-                        } catch (e: Exception) {
-                            // Log error but don't propagate
-                        }
-                    }
+                    fireDeliveryCallbackAsync()
                 }
 
                 return proofValid


### PR DESCRIPTION
## Summary
- fix a lock-order deadlock between channel sending and inbound proof handling
- make `PacketReceipt` delivery callbacks fire asynchronously instead of inline on the proof-processing thread

## Root cause
The new external conformance test for channel window recovery exposed a deadlock in live pipe-peer operation.

Lock order before this change:
1. outbound channel send held `Channel.lock` and called `Transport.outbound()`
2. inbound proof handling held `Transport.jobsLock`
3. proof validation fired the packet delivery callback inline
4. that callback re-entered channel delivery handling and tried to acquire `Channel.lock`

At the same time, the sender thread was still waiting to acquire `Transport.jobsLock` for the next channel send.

That produced a lock inversion:
- sender thread: `Channel.lock -> Transport.jobsLock`
- inbound proof thread: `Transport.jobsLock -> Channel.lock`

## User-visible effect
- first channel packet could be delivered
- returned proof arrived
- sender window never reopened for subsequent sends
- live channel tests stalled after `channel-one`

## Fix
Delivery callbacks now run asynchronously, matching the same general approach already used for timeout callbacks. This breaks the lock cycle while preserving proof validation state updates.

## Validation
- `PYTHON_RNS_PATH=$HOME/repos/Reticulum python3 -m pytest integration/test_channel_window_pipe.py --peer-cmd "java -cp $CP network.reticulum.cli.PipePeerKt" -q`
- `PYTHON_RNS_PATH=$HOME/repos/Reticulum PYTHON_LXMF_PATH=$HOME/repos/LXMF ./gradlew :rns-test:test --tests 'network.reticulum.interop.channel.ChannelE2ETest.channel send receives delivery proof' --rerun-tasks`

## Stack
This PR stacks on #20, which adds the external conformance coverage and CI wiring that exposed this bug.
