### PR TITLE
Fire destination link-established callback after status=ACTIVE

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,11 +78,23 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run rns-test tests
+      - name: Run rns-test tests with aggregated coverage
         env:
           PYTHON_RNS_PATH: /tmp/Reticulum
           PYTHON_LXMF_PATH: /tmp/LXMF
-        run: ./gradlew :rns-test:test
+        # Root-level koverXmlReport aggregates execution data across rns-core,
+        # rns-interfaces, and rns-test. `-x :rns-core:test -x :rns-interfaces:test`
+        # keeps the coverage job fast by not re-running unit tests already
+        # covered in the unit-tests job — codecov merges both uploads.
+        run: ./gradlew :rns-test:test koverXmlReport -x :rns-core:test -x :rns-interfaces:test
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: build/reports/kover/report.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test reports
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,10 @@ allprojects {
 dependencies {
     kover(project(":rns-core"))
     kover(project(":rns-interfaces"))
+    // Aggregate rns-test execution data so coverage of rns-core classes that
+    // can only be reached via two-node / interop tests (e.g. Link.rttPacket
+    // owner-callback flow) is counted in the root koverXmlReport.
+    kover(project(":rns-test"))
 }
 
 subprojects {

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -1880,13 +1880,27 @@ class Link private constructor(
             log("Link RTT measured: ${rtt}ms")
             updateKeepalive()
 
-            // Notify callback
+            // Notify the Link-level callback (set via link.setLinkEstablishedCallback).
             callbacks.linkEstablished?.let { callback ->
                 thread(isDaemon = true) {
                     try {
                         callback(this)
                     } catch (e: Exception) {
                         log("Error in link established callback: ${e.message}")
+                    }
+                }
+            }
+
+            // Notify the owning Destination's link-established callback. Python RNS fires
+            // this from rtt_packet() once status == ACTIVE (RNS/Link.py line 550–551);
+            // firing it earlier (e.g. on LINKREQUEST) leaves link.status == HANDSHAKE, and
+            // any link.send() from the callback silently fails.
+            owner?.let { ownerDest ->
+                thread(isDaemon = true) {
+                    try {
+                        ownerDest.invokeLinkEstablished(this)
+                    } catch (e: Exception) {
+                        log("Error in destination link established callback: ${e.message}")
                     }
                 }
             }

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -1842,6 +1842,10 @@ class Link private constructor(
      * Process RTT measurement packet.
      */
     private fun rttPacket(packet: Packet) {
+        // Guard against duplicate/replayed LRRTT packets. Matches the peer-side
+        // validateProof() check on HANDSHAKE and prevents double-firing the
+        // link-established callbacks or re-measuring rtt/activatedAt.
+        if (status != LinkConstants.HANDSHAKE) return
         try {
             val measuredRtt = System.currentTimeMillis() - requestTime
             val plaintext = decrypt(packet.data) ?: return

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -287,6 +287,7 @@ class Link private constructor(
     val hash: ByteArray get() = linkId
 
     // State
+    @Volatile
     var status: Int = LinkConstants.PENDING
         private set
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -4100,12 +4100,15 @@ object Transport {
                         return
                     }
 
-                    // Validate and create the incoming link
+                    // Validate and create the incoming link. The destination's
+                    // link-established callback is invoked from Link.rttPacket() once the
+                    // link reaches ACTIVE state, matching Python RNS (RNS/Link.py
+                    // rtt_packet). Invoking it here would fire while status is still
+                    // HANDSHAKE — at which point link.send() silently fails and any
+                    // caller-side signalling is dropped.
                     val link = Link.validateRequest(destination, packet.data, packet)
                     if (link != null) {
                         log("Link request for ${destination.hexHash} accepted: ${link.linkId.toHexString()}")
-                        // Invoke the destination's link established callback
-                        destination.invokeLinkEstablished(link)
                     } else {
                         log("Link request for ${destination.hexHash} rejected (validation failed)")
                     }

--- a/rns-test/build.gradle.kts
+++ b/rns-test/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 val coroutinesVersion: String by project

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkLifecycleTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkLifecycleTest.kt
@@ -13,8 +13,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -173,5 +176,70 @@ class LinkLifecycleTest {
         val responderLink = Link.validateRequest(destination, requestData, packet)
         assertNotNull(responderLink)
         assertTrue(!responderLink.initiator, "Validated link should not be initiator")
+    }
+
+    @Test
+    @DisplayName("Destination link-established callback does NOT fire during LINKREQUEST handling")
+    @Timeout(5)
+    fun `destination link established callback does not fire during linkrequest`() {
+        // Regression test: Transport's LINKREQUEST handler previously invoked
+        // destination.invokeLinkEstablished() immediately after Link.validateRequest()
+        // succeeded — while link.status was still HANDSHAKE. Any link.send() from
+        // inside that callback would then silently fail because sendWithReceipt
+        // rejects non-ACTIVE links. Python RNS only fires the owner callback from
+        // rtt_packet() after status = ACTIVE (RNS/Link.py line 550–551), and the
+        // Kotlin port now matches by invoking from Link.rttPacket().
+        val identity = Identity.create()
+        val destination = Destination.create(
+            identity = identity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lifecycle",
+            aspects = arrayOf("test", "callback-timing")
+        )
+        destination.acceptLinkRequests = true
+        Transport.registerDestination(destination)
+
+        val callbackInvocations = AtomicInteger(0)
+        val statusAtCallback = AtomicReference<Int?>(null)
+        destination.setLinkEstablishedCallback { link ->
+            callbackInvocations.incrementAndGet()
+            if (link is Link) {
+                statusAtCallback.set(link.status)
+            }
+        }
+
+        val crypto = defaultCryptoProvider()
+        val initiatorX25519 = crypto.generateX25519KeyPair()
+        val initiatorEd25519 = crypto.generateEd25519KeyPair()
+        val requestData = initiatorX25519.publicKey + initiatorEd25519.publicKey
+
+        val packet = Packet.createRaw(
+            destinationHash = destination.hash,
+            data = requestData,
+            packetType = PacketType.LINKREQUEST,
+            destinationType = DestinationType.SINGLE
+        )
+        packet.pack()
+
+        val link = Link.validateRequest(destination, requestData, packet)
+        assertNotNull(link, "validateRequest should create a link")
+        assertEquals(
+            LinkConstants.HANDSHAKE, link.status,
+            "Link should be in HANDSHAKE state immediately after validateRequest"
+        )
+
+        // Give any daemon-thread callback a chance to race; it should never fire
+        // because nothing has transitioned the link to ACTIVE yet.
+        Thread.sleep(100)
+
+        assertEquals(
+            0, callbackInvocations.get(),
+            "Destination link-established callback must not fire while link is in HANDSHAKE"
+        )
+        assertNull(
+            statusAtCallback.get(),
+            "No callback should have observed a status yet"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Matches Python RNS semantics: invoke the owning destination's `link_established` callback from `Link.rttPacket()` after `status = ACTIVE`, not from `Transport.processIncomingPacket` during LINKREQUEST validation.
- Before this fix, the callback fired while `link.status == HANDSHAKE`, and any `link.send(...)` from within the callback silently failed because `sendWithReceipt` rejects non-ACTIVE links.

## Background
Found while debugging inbound LXST voice calls from Python Sideband to a Kotlin server. The server-side inbound-call handler sends `STATUS_AVAILABLE` from the destination's link-established callback. In Python RNS this is the normal pattern (see `RNS/Link.py` line 550-551, where the owner callback fires from `rtt_packet` once status becomes ACTIVE). In reticulum-kt the same pattern failed silently: the packet was dropped, and the Python initiator tore down the link after its 5-second identify timeout with `reason=INITIATOR_CLOSED`.

## Changes
- `Transport.kt`: remove premature `destination.invokeLinkEstablished(link)` call from the LINKREQUEST handler. Add a comment pointing at `Link.rttPacket()` for where it now fires.
- `Link.kt`: after `status = ACTIVE` in `rttPacket()`, invoke `owner?.invokeLinkEstablished(this)` on a daemon thread (same pattern as the Link-level callback, matches Python's `threading.Thread(target=..., daemon=True)`).

## Verification
- `./gradlew :rns-core:test :rns-test:test --tests "*Link*" --tests "*Transport*"` — PASS
- End-to-end verified by running the parent Columba app against Python Sideband: inbound calls now connect with bidirectional audio. Before this fix the server received the LINKREQUEST, fired the callback against a HANDSHAKE link, `link.send()` returned false, and Sideband closed the link 5s later.

## Test plan
- [x] Unit tests pass locally (`:rns-core:test`, `:rns-test:test` Link/Transport subset)
- [x] Manual interop: Python Sideband → Kotlin server inbound call, bidirectional audio confirmed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)