### PR TITLE
Fix ratchet E2E bridge stdout corruption

### DIFF
--- a/python-bridge/bridge_server.py
+++ b/python-bridge/bridge_server.py
@@ -3510,8 +3510,10 @@ def cmd_destination_encrypt_debug(params):
         # stdout if it does not, which corrupts this bridge's JSON protocol.
         # Install a temporary shared-instance owner stub so ratchet persistence
         # is skipped while still populating the in-memory ratchet cache.
-        restore_owner = not hasattr(RNS.Transport, "owner") or RNS.Transport.owner is None
-        if restore_owner:
+        _sentinel = object()
+        original_owner = getattr(RNS.Transport, "owner", _sentinel)
+        needs_stub = original_owner is _sentinel or original_owner is None
+        if needs_stub:
             class _BridgeSharedInstanceOwner:
                 is_connected_to_shared_instance = True
             RNS.Transport.owner = _BridgeSharedInstanceOwner()
@@ -3519,8 +3521,12 @@ def cmd_destination_encrypt_debug(params):
         try:
             RNS.Identity._remember_ratchet(dest_hash, ratchet_public)
         finally:
-            if restore_owner:
-                delattr(RNS.Transport, "owner")
+            if needs_stub:
+                if original_owner is _sentinel:
+                    delattr(RNS.Transport, "owner")
+                else:
+                    # Was explicitly None; restore that rather than deleting.
+                    RNS.Transport.owner = original_owner
 
     # Create destination
     dest = RNS.Destination(

--- a/python-bridge/bridge_server.py
+++ b/python-bridge/bridge_server.py
@@ -3504,7 +3504,23 @@ def cmd_destination_encrypt_debug(params):
 
     # Optionally remember ratchet
     if ratchet_public and len(ratchet_public) == 32:
-        RNS.Identity._remember_ratchet(dest_hash, ratchet_public)
+        # Some bridge-only commands import full RNS without starting a
+        # Reticulum instance. Upstream RNS Identity._remember_ratchet()
+        # assumes RNS.Transport.owner exists and will log AttributeError to
+        # stdout if it does not, which corrupts this bridge's JSON protocol.
+        # Install a temporary shared-instance owner stub so ratchet persistence
+        # is skipped while still populating the in-memory ratchet cache.
+        restore_owner = not hasattr(RNS.Transport, "owner") or RNS.Transport.owner is None
+        if restore_owner:
+            class _BridgeSharedInstanceOwner:
+                is_connected_to_shared_instance = True
+            RNS.Transport.owner = _BridgeSharedInstanceOwner()
+
+        try:
+            RNS.Identity._remember_ratchet(dest_hash, ratchet_public)
+        finally:
+            if restore_owner:
+                delattr(RNS.Transport, "owner")
 
     # Create destination
     dest = RNS.Destination(


### PR DESCRIPTION
## Summary
- avoid calling Python RNS ratchet persistence paths without a `Transport.owner` stub in bridge-only commands
- prevent upstream RNS log lines from corrupting the JSON bridge protocol used by `rns-test`
- keep ratchet data in memory for `destination_encrypt_debug` while intentionally skipping persistence when no Reticulum instance is running

## Root cause
`RatchetLifecycleTest` uses `python-bridge/bridge_server.py` command `destination_encrypt_debug`, which imports full Python RNS but does not start a Reticulum instance. Upstream `RNS.Identity._remember_ratchet()` assumes `RNS.Transport.owner` exists and logs an `AttributeError` to stdout if it does not. Since the bridge protocol also uses stdout for JSON responses, those log lines break Kotlin JSON parsing and cascade into 6 E2E failures.

## Fix
Install a temporary `RNS.Transport.owner` stub with `is_connected_to_shared_instance = True` around `_remember_ratchet()`. That preserves the in-memory ratchet cache needed by the test while skipping persistence paths that require a live Reticulum instance.

## Verification
- `PYTHON_RNS_PATH=/tmp/Reticulum PYTHON_LXMF_PATH=/tmp/LXMF ./gradlew :rns-test:test --tests "*RatchetLifecycleTest*"`
- `PYTHON_RNS_PATH=/tmp/Reticulum PYTHON_LXMF_PATH=/tmp/LXMF ./gradlew :rns-test:test --tests "*Ratchet*"`

I also attempted the full `:rns-test:test` run locally, but it exceeded the local harness timeout before completion.
