### PR TITLE
Fix channel proof callback deadlock and add pipe conformance coverage

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -71,6 +71,11 @@ jobs:
         working-directory: reticulum-conformance
         env:
           PYTHON_RNS_PATH: ${{ github.workspace }}/Reticulum
+        # NOTE: this runs the canonical `integration/test_channel_window_pipe.py`
+        # from the external `reticulum-conformance` repo. The in-tree copy at
+        # `python-bridge/conformance/test_channel_window.py` is a development
+        # scratch copy used when iterating locally; the external file is the
+        # source of truth. Keep the two in sync when changing either.
         run: |
           python3 -m pytest integration/test_channel_window_pipe.py \
             --peer-cmd "java -cp \"$KOTLIN_PIPE_PEER_CLASSPATH\" network.reticulum.cli.PipePeerKt" \

--- a/python-bridge/bridge_server.py
+++ b/python-bridge/bridge_server.py
@@ -52,8 +52,18 @@ import hashlib
 sys.path.insert(0, os.path.join(rns_path, 'RNS', 'vendor'))
 import umsgpack
 
-# Import LXMF stamper (used for stamp generation/validation)
+# Import LXMF stamper (used for stamp generation/validation). This transitively
+# imports `RNS`, which writes log output to stdout by default — the same
+# stdout the bridge uses for its JSON protocol. Any later RNS.log() call
+# (e.g. Identity.remember_ratchet hitting an AttributeError on Transport.owner
+# before a Reticulum() instance exists) will corrupt the next JSON response
+# and fail the Kotlin test's parseToJsonElement() call. Redirect RNS logs to
+# stderr (via a callback) so stdout stays clean.
 import LXMF.LXStamper as LXStamper
+import RNS as _rns_for_logsetup  # noqa: E402
+_rns_for_logsetup.loglevel = _rns_for_logsetup.LOG_CRITICAL
+_rns_for_logsetup.logdest = _rns_for_logsetup.LOG_CALLBACK
+_rns_for_logsetup.logcall = lambda msg: sys.stderr.write(msg + "\n")
 
 # Import cryptography modules directly from the Cryptography directory
 # This bypasses RNS/__init__.py which would load all interfaces
@@ -3003,6 +3013,13 @@ def _get_full_rns():
 
     # Import real RNS fresh
     import RNS
+    # Re-apply log redirect: _get_full_rns() wipes all RNS* modules from
+    # sys.modules and re-imports, which resets the module-level log config set
+    # at bridge startup. Without this, any RNS.log() after the first
+    # _get_full_rns() call goes back to stdout and corrupts the JSON protocol.
+    RNS.loglevel = RNS.LOG_CRITICAL
+    RNS.logdest = RNS.LOG_CALLBACK
+    RNS.logcall = lambda msg: sys.stderr.write(msg + "\n")
     _rns_module = RNS
     return RNS
 

--- a/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
@@ -9,8 +9,6 @@ import network.reticulum.link.Link
 import network.reticulum.link.LinkConstants
 import network.reticulum.transport.Transport
 import network.reticulum.transport.TransportConstants
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 /**
  * Callbacks for packet receipt events.
@@ -44,10 +42,6 @@ class PacketReceipt internal constructor(
         // Proof lengths
         val EXPL_LENGTH = RnsConstants.FULL_HASH_BYTES + RnsConstants.SIGNATURE_SIZE
         val IMPL_LENGTH = RnsConstants.SIGNATURE_SIZE
-
-        private val callbackExecutor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
-            Thread(runnable, "PacketReceipt-callbacks").apply { isDaemon = true }
-        }
     }
 
     /** The full hash of the packet. */
@@ -208,7 +202,7 @@ class PacketReceipt internal constructor(
         callbackType: String,
         callback: (PacketReceipt) -> Unit,
     ) {
-        callbackExecutor.execute {
+        Transport.submitReceiptCallback {
             try {
                 callback(this)
             } catch (e: Exception) {

--- a/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/packet/PacketReceipt.kt
@@ -9,7 +9,8 @@ import network.reticulum.link.Link
 import network.reticulum.link.LinkConstants
 import network.reticulum.transport.Transport
 import network.reticulum.transport.TransportConstants
-import kotlin.concurrent.thread
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * Callbacks for packet receipt events.
@@ -43,6 +44,10 @@ class PacketReceipt internal constructor(
         // Proof lengths
         val EXPL_LENGTH = RnsConstants.FULL_HASH_BYTES + RnsConstants.SIGNATURE_SIZE
         val IMPL_LENGTH = RnsConstants.SIGNATURE_SIZE
+
+        private val callbackExecutor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "PacketReceipt-callbacks").apply { isDaemon = true }
+        }
     }
 
     /** The full hash of the packet. */
@@ -156,15 +161,8 @@ class PacketReceipt internal constructor(
 
             concludedAt = System.currentTimeMillis()
 
-            // Fire timeout callback in separate thread
             callbacks.timeout?.let { callback ->
-                thread(isDaemon = true) {
-                    try {
-                        callback(this)
-                    } catch (e: Exception) {
-                        // Log error but don't propagate
-                    }
-                }
+                submitCallback("timeout", callback)
             }
             return true
         }
@@ -204,6 +202,25 @@ class PacketReceipt internal constructor(
      */
     internal fun setLink(link: Link) {
         this.link = link
+    }
+
+    private fun submitCallback(
+        callbackType: String,
+        callback: (PacketReceipt) -> Unit,
+    ) {
+        callbackExecutor.execute {
+            try {
+                callback(this)
+            } catch (e: Exception) {
+                System.err.println("[PacketReceipt] Error in $callbackType callback for ${hash.toHexString()}: ${e.message}")
+            }
+        }
+    }
+
+    private fun fireDeliveryCallbackAsync() {
+        callbacks.delivery?.let { callback ->
+            submitCallback("delivery", callback)
+        }
     }
 
     /**
@@ -253,15 +270,7 @@ class PacketReceipt internal constructor(
                 proved = true
                 concludedAt = System.currentTimeMillis()
                 this.proofPacket = proofPacket
-
-                // Fire delivery callback
-                callbacks.delivery?.let { callback ->
-                    try {
-                        callback(this)
-                    } catch (e: Exception) {
-                        // Log error but don't propagate
-                    }
-                }
+                fireDeliveryCallbackAsync()
             }
 
             return proofValid
@@ -303,15 +312,7 @@ class PacketReceipt internal constructor(
                     proved = true
                     concludedAt = System.currentTimeMillis()
                     this.proofPacket = proofPacket
-
-                    // Fire delivery callback
-                    callbacks.delivery?.let { callback ->
-                        try {
-                            callback(this)
-                        } catch (e: Exception) {
-                            // Log error but don't propagate
-                        }
-                    }
+                    fireDeliveryCallbackAsync()
                 }
 
                 return proofValid
@@ -329,15 +330,7 @@ class PacketReceipt internal constructor(
                     proved = true
                     concludedAt = System.currentTimeMillis()
                     this.proofPacket = proofPacket
-
-                    // Fire delivery callback
-                    callbacks.delivery?.let { callback ->
-                        try {
-                            callback(this)
-                        } catch (e: Exception) {
-                            // Log error but don't propagate
-                        }
-                    }
+                    fireDeliveryCallbackAsync()
                 }
 
                 return proofValid

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -139,7 +139,13 @@ object Transport {
      * are silently dropped rather than fired against torn-down state.
      */
     internal fun submitReceiptCallback(task: Runnable) {
-        receiptCallbackExecutor?.execute(task)
+        try {
+            receiptCallbackExecutor?.execute(task)
+        } catch (_: java.util.concurrent.RejectedExecutionException) {
+            // Transport is stopping; drop the callback silently. A racing stop()
+            // call can shutdownNow() the executor between our null-check and
+            // execute(), after which submissions throw.
+        }
     }
 
     // ===== State =====

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -129,6 +129,19 @@ fun interface ProofCallback {
  * - Handles announce propagation and path discovery
  */
 object Transport {
+    @Volatile
+    private var receiptCallbackExecutor: java.util.concurrent.ExecutorService? = null
+
+    /**
+     * Submit a packet-receipt callback for asynchronous execution on Transport's
+     * receipt-callback executor. The executor is owned by Transport so it can be
+     * drained and shut down cleanly on [stop]. If Transport is stopped, callbacks
+     * are silently dropped rather than fired against torn-down state.
+     */
+    internal fun submitReceiptCallback(task: Runnable) {
+        receiptCallbackExecutor?.execute(task)
+    }
+
     // ===== State =====
 
     /** Transport identity for this node. */
@@ -362,6 +375,11 @@ object Transport {
             return // Already started
         }
 
+        receiptCallbackExecutor =
+            java.util.concurrent.Executors.newSingleThreadExecutor { r ->
+                Thread(r, "PacketReceipt-callbacks").apply { isDaemon = true }
+            }
+
         identity = transportIdentity ?: Identity.create()
         transportEnabled = enableTransport
         startTime = System.currentTimeMillis()
@@ -479,6 +497,10 @@ object Transport {
         speedTx = 0
         lastTrafficSnapshot = Pair(0L, 0L)
         lastTrafficTime = 0L
+
+        // Drain and shut down the packet-receipt callback executor
+        receiptCallbackExecutor?.shutdownNow()
+        receiptCallbackExecutor = null
 
         log("Transport stopped")
     }

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -504,7 +504,8 @@ object Transport {
         lastTrafficSnapshot = Pair(0L, 0L)
         lastTrafficTime = 0L
 
-        // Drain and shut down the packet-receipt callback executor
+        // Cancel and shut down the packet-receipt callback executor; any
+        // callbacks that have been submitted but not yet started are dropped.
         receiptCallbackExecutor?.shutdownNow()
         receiptCallbackExecutor = null
 

--- a/rns-core/src/test/kotlin/network/reticulum/storage/PathStoreWriteThroughTest.kt
+++ b/rns-core/src/test/kotlin/network/reticulum/storage/PathStoreWriteThroughTest.kt
@@ -31,12 +31,15 @@ class PathStoreWriteThroughTest {
         store = InMemoryPathStore()
         tempDir = Files.createTempDirectory("rns-test").toFile()
         Transport.setStoragePath(tempDir.absolutePath)
+        // Clear global pathTable — other tests may have leaked entries.
+        Transport.pathTable.clear()
     }
 
     @AfterEach
     fun teardown() {
         Transport.pathStore = null
         Transport.announceStore = null
+        Transport.pathTable.clear()
         tempDir.deleteRecursively()
     }
 

--- a/rns-test/src/test/kotlin/network/reticulum/interop/channel/ChannelE2ETest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/interop/channel/ChannelE2ETest.kt
@@ -245,10 +245,10 @@ class ChannelE2ETest : RnsLiveTestBase() {
         val channel = link.getChannel()
         val messageCount = 5
 
-        // Send multiple K→P messages. The channel has a send window that may
-        // fill up if proof validation fails (known issue with link packet proofs),
-        // so we send as many as the window allows.
-        println("  [Test] Sending up to $messageCount channel messages K→P...")
+        // Send all K→P messages. With the proof callback deadlock fixed, the
+        // channel send window should reopen after each proof so every message
+        // in the loop is sendable.
+        println("  [Test] Sending $messageCount channel messages K→P...")
         var sentCount = 0
         for (i in 0 until messageCount) {
             val msg = TestMessage().apply { data = "Message $i from Kotlin".toByteArray() }
@@ -257,15 +257,19 @@ class ChannelE2ETest : RnsLiveTestBase() {
             while (!channel.isReadyToSend() && System.currentTimeMillis() < readyDeadline) {
                 Thread.sleep(50)
             }
-            if (!channel.isReadyToSend()) {
-                println("  [Test] Channel window full after $sentCount messages (proof pipeline issue)")
-                break
-            }
+            assertTrue(
+                channel.isReadyToSend(),
+                "Channel window should reopen after each proof — stalled after $sentCount messages",
+            )
             channel.send(msg)
             sentCount++
         }
 
-        assertTrue(sentCount > 0, "Should send at least one channel message")
+        assertEquals(
+            messageCount,
+            sentCount,
+            "After deadlock fix, all $messageCount channel messages should be sendable",
+        )
 
         // Wait for Python to receive sent messages
         val deadline = System.currentTimeMillis() + 15_000

--- a/rns-test/src/test/kotlin/network/reticulum/interop/channel/ChannelE2ETest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/interop/channel/ChannelE2ETest.kt
@@ -265,11 +265,7 @@ class ChannelE2ETest : RnsLiveTestBase() {
             sentCount++
         }
 
-        assertEquals(
-            messageCount,
-            sentCount,
-            "After deadlock fix, all $messageCount channel messages should be sendable",
-        )
+        // sentCount == messageCount is guaranteed by the assertTrue inside the loop.
 
         // Wait for Python to receive sent messages
         val deadline = System.currentTimeMillis() + 15_000


### PR DESCRIPTION
## Summary
- bring the channel proof-validation regression work onto `main`
- add pipe-peer conformance coverage for channel send-window recovery
- fix the remaining channel proof callback deadlock that leaves the send window closed after the first proved message

## Background
`main` currently has a larger channel issue than the ratchet bridge failure alone:
- `rns-test` can hang in `ChannelE2ETest`
- conformance fails in `integration/test_channel_window_pipe.py` after only the first channel message is delivered

The symptom is that the first channel message is proved, but the sender never properly reopens the channel window for subsequent messages.

## Root cause
There are two pieces to the channel proof path:

1. **Channel packets must be associated with their `Link`** so proof validation uses the link signing key rather than destination identity validation.
2. **PacketReceipt delivery callbacks must not run inline in the proof-processing path**. Running them inline can deadlock/re-enter channel window bookkeeping, so the first message succeeds but later messages never progress.

This branch carries both the regression coverage and the callback fix needed to make channel window recovery reliable.

## Changes
- ensure channel packet proofs are validated in link context
- add channel proof-validation regression coverage in `rns-test`
- add pipe-peer conformance coverage for proof-gated channel window reopening
- run the pipe integration conformance test in CI
- make `PacketReceipt` delivery/timeout callbacks execute asynchronously instead of inline during proof handling

## Why this PR now
This is the missing follow-up for the current CI failures on `main`:
- **E2E timeout**: `ChannelE2ETest` hangs waiting for later channel messages/proofs to make progress
- **Conformance failure**: pipe integration receives only `channel-one` and never recovers the send window for `channel-two` / `channel-three`

## Verification
Locally:
- on current `main`, `PYTHON_RNS_PATH=/tmp/Reticulum PYTHON_LXMF_PATH=/tmp/LXMF timeout 120s ./gradlew :rns-test:test --tests "*ChannelE2ETest*"` times out
- with this branch applied, the same `ChannelE2ETest` run completes successfully in about 9s
- CI conformance coverage in this branch exercises the exact proof-gated channel window recovery path that was failing

## Notes
This PR is intentionally broader than a one-line fix because the regression tests and conformance coverage are part of the value: they lock in the behavior that was previously breaking on `main`.
