### PR TITLE
Add JitPack publishing infrastructure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 allprojects {
     group = "com.github.torlando-tech.reticulum-kt"
-    version = "0.1.0"
+    version = System.getenv("VERSION")?.removePrefix("v") ?: "0.1.0-SNAPSHOT"
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 }
 
 allprojects {
-    group = "network.reticulum"
-    version = "0.1.0-SNAPSHOT"
+    group = "com.github.torlando-tech.reticulum-kt"
+    version = "0.1.0"
 }
 
 dependencies {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk17
+install:
+  - ./gradlew clean :rns-core:publishToMavenLocal :rns-interfaces:publishToMavenLocal :rns-android:publishToMavenLocal -x test

--- a/python-bridge/conformance/pipe_session.py
+++ b/python-bridge/conformance/pipe_session.py
@@ -120,6 +120,7 @@ class PipeSession:
         process = self.process
 
         class _StdioPipe(BaseInterface):
+            DEFAULT_IFAC_SIZE = 8
             FLAG = 0x7E
             ESC = 0x7D
             ESC_MASK = 0x20

--- a/python-bridge/pipe_peer.py
+++ b/python-bridge/pipe_peer.py
@@ -629,6 +629,7 @@ def _create_pipe_interface(RNS, pin, pout, name="StdioPipe"):
     class StreamPipeInterface(BaseInterface):
         """Interface that communicates via HDLC framing over binary streams."""
 
+        DEFAULT_IFAC_SIZE = 8
         FLAG = 0x7E
         ESC = 0x7D
         ESC_MASK = 0x20

--- a/rns-android/build.gradle.kts
+++ b/rns-android/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("kotlin-parcelize")
     id("com.google.devtools.ksp")
+    `maven-publish`
 }
 
 val coroutinesVersion: String by project
@@ -44,6 +45,18 @@ android {
     testOptions {
         unitTests.all {
             it.useJUnit()
+        }
+    }
+
+    publishing {
+        singleVariant("release") { withSourcesJar() }
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") { from(components["release"]) }
         }
     }
 }

--- a/rns-core/build.gradle.kts
+++ b/rns-core/build.gradle.kts
@@ -30,9 +30,8 @@ dependencies {
     // Compression - Apache Commons Compress for BZ2
     implementation("org.apache.commons:commons-compress:1.26.0")
 
-    // Logging
+    // Logging — SLF4J API only; consumers supply their own binding (Logback, Log4j2, etc.)
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
-    implementation("org.slf4j:slf4j-simple:2.0.9")
 
     // Testing
     testImplementation(kotlin("test"))
@@ -40,4 +39,5 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+    testRuntimeOnly("org.slf4j:slf4j-simple:2.0.9")
 }

--- a/rns-core/build.gradle.kts
+++ b/rns-core/build.gradle.kts
@@ -1,6 +1,15 @@
 plugins {
     kotlin("jvm")
     id("org.jetbrains.kotlinx.kover")
+    `maven-publish`
+}
+
+java { withSourcesJar() }
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") { from(components["java"]) }
+    }
 }
 
 val coroutinesVersion: String by project

--- a/rns-interfaces/build.gradle.kts
+++ b/rns-interfaces/build.gradle.kts
@@ -17,7 +17,7 @@ val junitVersion: String by project
 val kotestVersion: String by project
 
 dependencies {
-    implementation(project(":rns-core"))
+    api(project(":rns-core"))
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")

--- a/rns-interfaces/build.gradle.kts
+++ b/rns-interfaces/build.gradle.kts
@@ -1,6 +1,15 @@
 plugins {
     kotlin("jvm")
     id("org.jetbrains.kotlinx.kover")
+    `maven-publish`
+}
+
+java { withSourcesJar() }
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") { from(components["java"]) }
+    }
 }
 
 val coroutinesVersion: String by project


### PR DESCRIPTION
## Summary
- Adds `maven-publish` plugin to `rns-core`, `rns-interfaces`, and `rns-android` modules
- Creates `jitpack.yml` pinning JDK 17 for JitPack CI builds
- Sets group to `com.github.torlando-tech.reticulum-kt` and version to `0.1.0` for proper JitPack coordinate resolution

First step toward migrating Columba's submodule dependencies to Gradle-managed JitPack artifacts. After merge + tag, modules resolve as:
- `com.github.torlando-tech.reticulum-kt:rns-core:<tag>`
- `com.github.torlando-tech.reticulum-kt:rns-interfaces:<tag>`
- `com.github.torlando-tech.reticulum-kt:rns-android:<tag>`

## Test plan
- [x] `./gradlew :rns-core:publishToMavenLocal :rns-interfaces:publishToMavenLocal :rns-android:publishToMavenLocal -x test` succeeds
- [x] POM transitive deps (rns-android → rns-core, rns-interfaces) use correct group coordinates
- [x] Columba `:app:assembleDebug` still builds with composite `includeBuild()` path unchanged
- [ ] After merge + tag `0.1.0`: verify JitPack build at `https://jitpack.io/com/github/torlando-tech/reticulum-kt/0.1.0/build.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)