### PR TITLE
Publish rns-test for downstream test-infra reuse

### DIFF
--- a/rns-test/build.gradle.kts
+++ b/rns-test/build.gradle.kts
@@ -2,6 +2,15 @@ plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
     id("org.jetbrains.kotlinx.kover")
+    `maven-publish`
+}
+
+java { withSourcesJar() }
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") { from(components["java"]) }
+    }
 }
 
 val coroutinesVersion: String by project
@@ -11,7 +20,7 @@ val serializationVersion: String by project
 
 dependencies {
     api(project(":rns-core"))
-    implementation(project(":rns-interfaces"))
+    api(project(":rns-interfaces"))
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")


### PR DESCRIPTION
## Summary
- Adds `maven-publish` to `rns-test` so the shared Python-bridge test infrastructure can be consumed by downstream Kotlin libraries (LXMF-kt, and any future library that needs interop tests against the Python Reticulum reference impl).
- Changes `rns-interfaces` from `implementation` to `api` — `RnsLiveTestBase` declares `protected var kotlinTcpClient: TCPClientInterface?`, an rns-interfaces type, so consumers need it on their compile classpath. Same scope-correction we applied to `rns-interfaces → rns-core` earlier.

## Why
LXMF-kt's interop test suite (20 files) uses `RnsLiveTestBase`, `PythonBridgeInfrastructure`, and similar helpers from rns-test. Currently it consumes them via composite `includeBuild("reticulum-kt")`. Migrating LXMF-kt to JitPack requires rns-test to be a real published artifact — otherwise those tests lose their base class.

Follow-up: after merge, tag `v0.0.2`; then LXMF-kt can switch its `testImplementation("network.reticulum:rns-test")` to `testImplementation("com.github.torlando-tech.reticulum-kt:rns-test:v0.0.2")`.

## Test plan
- [x] `./gradlew :rns-test:publishToMavenLocal` succeeds
- [x] Published POM lists `rns-core` and `rns-interfaces` at `<scope>compile</scope>`, `junit-jupiter-api` and `kotest-assertions-core` at `<scope>compile</scope>` (preserves api scoping)
- [ ] After merge + tag: JitPack resolves `com.github.torlando-tech.reticulum-kt:rns-test:v0.0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)