### PR TITLE
Publish all maven-publish modules from jitpack.yml

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk17
 install:
-  - ./gradlew clean :rns-core:publishToMavenLocal :rns-interfaces:publishToMavenLocal :rns-android:publishToMavenLocal -x test
+  - ./gradlew clean publishToMavenLocal -x test


### PR DESCRIPTION
## Summary
- Replace enumerated module list (`:rns-core:publishToMavenLocal :rns-interfaces:publishToMavenLocal :rns-android:publishToMavenLocal`) with unscoped `publishToMavenLocal`.
- Gradle runs `publishToMavenLocal` on every subproject with the `maven-publish` plugin applied, so all 4 publishable modules (rns-core, rns-interfaces, rns-test, rns-android) ship on tag.

## Why
PR #26 added `maven-publish` to `rns-test` but didn't update this file. v0.0.2 was tagged with the old enumerated install command, so rns-test didn't land on JitPack at that tag. Unscoped form removes this class of "forgot to update jitpack.yml" bug for future module additions.

## Test plan
- [x] `./gradlew clean publishToMavenLocal -x test` publishes rns-core, rns-interfaces, rns-test, rns-android locally
- [ ] After merge + tag v0.0.3: verify all 4 artifacts resolve at `jitpack.io/com/github/torlando-tech/reticulum-kt/<module>/v0.0.3/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)