### PR TITLE
Support an in-memory transport identity override

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -54,12 +54,13 @@ class Reticulum private constructor(
     val connectToSharedInstance: Boolean,
     /**
      * Optional in-memory transport identity. When non-null, [initialize] uses this
-     * identity directly and skips the load-from-file / create-and-save-to-file flow,
-     * so the private key never has to touch disk as plaintext. Callers that manage
-     * their own identity persistence (e.g. encrypted-at-rest in a Room database or
-     * Keystore-wrapped in a secure enclave) can pass an Identity built via
-     * [Identity.fromBytes]. When null, Reticulum retains the legacy
-     * `$storagePath/transport_identity` file behaviour.
+     * identity directly, skips the load-from-file / create-and-save-to-file flow,
+     * and deletes any stale `$storagePath/transport_identity` file left behind by
+     * a prior file-backed run — so the private key never has to touch disk as
+     * plaintext. Callers that manage their own identity persistence (e.g.
+     * encrypted-at-rest in a Room database or Keystore-wrapped in a secure enclave)
+     * can pass an Identity built via [Identity.fromBytes]. When null, Reticulum
+     * retains the legacy `$storagePath/transport_identity` file behaviour.
      */
     private val transportIdentityOverride: Identity? = null,
 ) {
@@ -158,8 +159,10 @@ class Reticulum private constructor(
          * @param sharedInstancePort TCP port for shared instance communication
          * @param connectToSharedInstance Whether to connect to an existing shared instance
          * @param transportIdentity Optional in-memory transport identity. When non-null, the
-         *   private key is used directly and the `$storagePath/transport_identity` file is
-         *   never read or written. When null (default), the legacy file-backed flow runs.
+         *   private key is used directly, `$storagePath/transport_identity` is never read or
+         *   written, and any stale file left by a prior file-backed run is deleted so no
+         *   plaintext key lingers on disk. When null (default), the legacy file-backed flow
+         *   runs.
          * @return The Reticulum instance
          */
         fun start(
@@ -303,7 +306,16 @@ class Reticulum private constructor(
         // Use the caller-provided identity if given (so the plaintext private key
         // never has to touch disk), otherwise fall back to the legacy file-backed flow.
         val transportIdentity =
-            transportIdentityOverride ?: loadOrCreateTransportIdentity()
+            if (transportIdentityOverride != null) {
+                // A caller on a device that previously ran the file-backed flow may still
+                // have a plaintext $storagePath/transport_identity on disk. Since the whole
+                // point of supplying an override is to keep plaintext keys off disk, remove
+                // the stale file on behalf of the caller.
+                deleteLegacyTransportIdentityFile()
+                transportIdentityOverride
+            } else {
+                loadOrCreateTransportIdentity()
+            }
 
         // Configure Transport and Identity storage paths
         Transport.setCachePath(cachePath)
@@ -441,6 +453,23 @@ class Reticulum private constructor(
         val identity = Identity.create()
         identity.toFile(file.absolutePath)
         return identity
+    }
+
+    /**
+     * Delete `$storagePath/transport_identity` if present. Called when a caller
+     * supplies an in-memory transport identity override, to clean up a plaintext
+     * file left behind by a previous file-backed run — matching the caller's
+     * stated intent of keeping private keys off disk.
+     */
+    private fun deleteLegacyTransportIdentityFile() {
+        val identityFile = File("$storagePath/transport_identity")
+        if (identityFile.exists()) {
+            if (identityFile.delete()) {
+                log("Deleted legacy plaintext transport_identity file (in-memory override active)")
+            } else {
+                log("WARNING: failed to delete legacy transport_identity file at ${identityFile.absolutePath}")
+            }
+        }
     }
 
     /**

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -192,9 +192,13 @@ class Reticulum private constructor(
                 return rns
             }
             if (transportIdentity != null) {
-                log(
-                    "WARNING: transportIdentity was provided but Reticulum is already started; " +
-                        "the supplied identity will not be used.",
+                // Callers pass transportIdentity precisely because they rely on the plaintext
+                // private key never touching disk. Silently handing back an already-running
+                // instance — which may have been started with the file-backed flow — would
+                // break that guarantee without the caller ever noticing. Fail loudly instead.
+                throw IllegalStateException(
+                    "Reticulum is already started; cannot apply transportIdentity. " +
+                        "Call Reticulum.stop() before restarting with a new identity.",
                 )
             }
             return instance!!

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -202,8 +202,14 @@ class Reticulum private constructor(
                     // Roll back the started/instance state so the caller can retry
                     // (e.g. with a different identity or after fixing a filesystem issue)
                     // without hitting the "already started" guard on the next start() call.
-                    instance = null
+                    //
+                    // Order matters: flip `started` false *first*, then null out `instance`.
+                    // If we cleared instance first, a concurrent start() whose
+                    // compareAndSet(false, true) was still false would fall through to
+                    // `return instance!!` and throw NPE. Flipping `started` first means a
+                    // racing caller wins the CAS and constructs its own instance.
                     started.set(false)
+                    instance = null
                     throw t
                 }
                 return rns

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -460,15 +460,24 @@ class Reticulum private constructor(
      * supplies an in-memory transport identity override, to clean up a plaintext
      * file left behind by a previous file-backed run — matching the caller's
      * stated intent of keeping private keys off disk.
+     *
+     * Throws [IllegalStateException] if the file exists but cannot be deleted.
+     * Callers using the override are relying on a security guarantee that a
+     * leftover plaintext key actively breaks; a warning-and-continue in that
+     * case would leave a forensic artifact with the caller having no
+     * programmatic way to detect it.
      */
     private fun deleteLegacyTransportIdentityFile() {
         val identityFile = File("$storagePath/transport_identity")
         if (identityFile.exists()) {
-            if (identityFile.delete()) {
-                log("Deleted legacy plaintext transport_identity file (in-memory override active)")
-            } else {
-                log("WARNING: failed to delete legacy transport_identity file at ${identityFile.absolutePath}")
+            if (!identityFile.delete()) {
+                throw IllegalStateException(
+                    "In-memory transport identity override requested but failed to delete " +
+                        "legacy plaintext key file at ${identityFile.absolutePath}. " +
+                        "Refusing to start to avoid a false sense of security.",
+                )
             }
+            log("Deleted legacy plaintext transport_identity file (in-memory override active)")
         }
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -109,6 +109,7 @@ class Reticulum private constructor(
          */
         const val DEFAULT_SHARED_INSTANCE_PORT = 37428
 
+        @Volatile
         private var instance: Reticulum? = null
         private val started = AtomicBoolean(false)
 
@@ -200,16 +201,22 @@ class Reticulum private constructor(
                     rns.initialize()
                 } catch (t: Throwable) {
                     // Roll back the started/instance state so the caller can retry
-                    // (e.g. with a different identity or after fixing a filesystem issue)
-                    // without hitting the "already started" guard on the next start() call.
+                    // (e.g. with a different identity or after fixing a filesystem
+                    // issue) without hitting the "already started" guard on the
+                    // next start() call.
                     //
-                    // Order matters: flip `started` false *first*, then null out `instance`.
-                    // If we cleared instance first, a concurrent start() whose
-                    // compareAndSet(false, true) was still false would fall through to
-                    // `return instance!!` and throw NPE. Flipping `started` first means a
-                    // racing caller wins the CAS and constructs its own instance.
-                    started.set(false)
+                    // Order matters: null `instance` *first*, then flip `started`
+                    // false. The opposite order would let a racing start() win the
+                    // CAS, build and assign its own rns to `instance`, and then
+                    // this catch block would overwrite that with null — silently
+                    // corrupting the racing caller's successful init. With
+                    // `instance` marked @Volatile, a racing caller whose CAS sees
+                    // started=true and falls through to `return instance!!` can
+                    // still NPE during the narrow window between these two writes;
+                    // that's an acceptable degradation (loud failure) versus the
+                    // silent-corruption alternative.
                     instance = null
+                    started.set(false)
                     throw t
                 }
                 return rns

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -55,12 +55,15 @@ class Reticulum private constructor(
     /**
      * Optional in-memory transport identity. When non-null, [initialize] uses this
      * identity directly, skips the load-from-file / create-and-save-to-file flow,
-     * and deletes any stale `$storagePath/transport_identity` file left behind by
-     * a prior file-backed run — so the private key never has to touch disk as
-     * plaintext. Callers that manage their own identity persistence (e.g.
-     * encrypted-at-rest in a Room database or Keystore-wrapped in a secure enclave)
-     * can pass an Identity built via [Identity.fromBytes]. When null, Reticulum
-     * retains the legacy `$storagePath/transport_identity` file behaviour.
+     * and zero-overwrites + deletes any stale `$storagePath/transport_identity`
+     * file left behind by a prior file-backed run — so the private key does not
+     * need to touch disk as plaintext in the current session. The overwrite-and-
+     * delete of the legacy file is best-effort; on wear-levelled or journalled
+     * storage the underlying blocks may still be recoverable forensically.
+     * Callers that manage their own identity persistence (e.g. encrypted-at-rest
+     * in a Room database or Keystore-wrapped in a secure enclave) can pass an
+     * Identity built via [Identity.fromBytes]. When null, Reticulum retains the
+     * legacy `$storagePath/transport_identity` file behaviour.
      */
     private val transportIdentityOverride: Identity? = null,
 ) {
@@ -160,9 +163,11 @@ class Reticulum private constructor(
          * @param connectToSharedInstance Whether to connect to an existing shared instance
          * @param transportIdentity Optional in-memory transport identity. When non-null, the
          *   private key is used directly, `$storagePath/transport_identity` is never read or
-         *   written, and any stale file left by a prior file-backed run is deleted so no
-         *   plaintext key lingers on disk. When null (default), the legacy file-backed flow
-         *   runs.
+         *   written in the current session, and any stale file left by a prior file-backed
+         *   run is zero-overwritten and deleted on a best-effort basis. True secure erasure
+         *   is not achievable on wear-levelled or journalled storage; callers needing that
+         *   guarantee must rely on device-level full-disk encryption. When null (default),
+         *   the legacy file-backed flow runs.
          * @return The Reticulum instance
          */
         fun start(
@@ -191,7 +196,16 @@ class Reticulum private constructor(
                 pendingLocalServerFactory?.let { rns.localServerInterfaceFactory = it }
                 pendingInterfaceRegistrar?.let { rns.interfaceRegistrar = it }
 
-                rns.initialize()
+                try {
+                    rns.initialize()
+                } catch (t: Throwable) {
+                    // Roll back the started/instance state so the caller can retry
+                    // (e.g. with a different identity or after fixing a filesystem issue)
+                    // without hitting the "already started" guard on the next start() call.
+                    instance = null
+                    started.set(false)
+                    throw t
+                }
                 return rns
             }
             if (transportIdentity != null) {
@@ -456,20 +470,36 @@ class Reticulum private constructor(
     }
 
     /**
-     * Delete `$storagePath/transport_identity` if present. Called when a caller
-     * supplies an in-memory transport identity override, to clean up a plaintext
-     * file left behind by a previous file-backed run — matching the caller's
-     * stated intent of keeping private keys off disk.
+     * Best-effort removal of `$storagePath/transport_identity` when a caller
+     * supplies an in-memory transport identity override. Performs a zero-fill
+     * overwrite before [File.delete] to reduce plaintext remnants in the
+     * directory entry's previously-allocated blocks.
      *
-     * Throws [IllegalStateException] if the file exists but cannot be deleted.
-     * Callers using the override are relying on a security guarantee that a
-     * leftover plaintext key actively breaks; a warning-and-continue in that
-     * case would leave a forensic artifact with the caller having no
-     * programmatic way to detect it.
+     * Caveat: neither the overwrite nor the delete is a true secure erase on
+     * wear-levelled (F2FS, eMMC controller-level) or journalled (ext4 data=
+     * journal) storage. Copy-on-write and the FS journal may retain
+     * previous block contents for an unbounded time before they're reused.
+     * This is the best Android userspace can offer without vendor APIs for
+     * secure discard; callers who need stronger guarantees must rely on
+     * full-disk encryption being active on the device.
+     *
+     * Throws [IllegalStateException] if the file exists but cannot be
+     * deleted. Callers using the override are relying on a security
+     * guarantee that a leftover plaintext key actively breaks; a
+     * warning-and-continue in that case would leave a forensic artifact
+     * with the caller having no programmatic way to detect it.
      */
     private fun deleteLegacyTransportIdentityFile() {
         val identityFile = File("$storagePath/transport_identity")
         if (identityFile.exists()) {
+            // Best-effort overwrite. Failure here is non-fatal — the delete
+            // below still runs and is what the invariant actually depends on.
+            try {
+                val zeros = ByteArray(identityFile.length().toInt())
+                identityFile.writeBytes(zeros)
+            } catch (_: Exception) {
+                // Overwrite is best-effort; fall through to delete.
+            }
             if (!identityFile.delete()) {
                 throw IllegalStateException(
                     "In-memory transport identity override requested but failed to delete " +

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -52,6 +52,16 @@ class Reticulum private constructor(
     val shareInstance: Boolean,
     val sharedInstancePort: Int,
     val connectToSharedInstance: Boolean,
+    /**
+     * Optional in-memory transport identity. When non-null, [initialize] uses this
+     * identity directly and skips the load-from-file / create-and-save-to-file flow,
+     * so the private key never has to touch disk as plaintext. Callers that manage
+     * their own identity persistence (e.g. encrypted-at-rest in a Room database or
+     * Keystore-wrapped in a secure enclave) can pass an Identity built via
+     * [Identity.fromBytes]. When null, Reticulum retains the legacy
+     * `$storagePath/transport_identity` file behaviour.
+     */
+    private val transportIdentityOverride: Identity? = null,
 ) {
     companion object {
         /**
@@ -155,10 +165,19 @@ class Reticulum private constructor(
             shareInstance: Boolean = false,
             sharedInstancePort: Int = DEFAULT_SHARED_INSTANCE_PORT,
             connectToSharedInstance: Boolean = false,
+            transportIdentity: Identity? = null,
         ): Reticulum {
             if (started.compareAndSet(false, true)) {
                 val dir = configDir ?: getDefaultConfigDir()
-                val rns = Reticulum(dir, enableTransport, shareInstance, sharedInstancePort, connectToSharedInstance)
+                val rns =
+                    Reticulum(
+                        configDir = dir,
+                        enableTransport = enableTransport,
+                        shareInstance = shareInstance,
+                        sharedInstancePort = sharedInstancePort,
+                        connectToSharedInstance = connectToSharedInstance,
+                        transportIdentityOverride = transportIdentity,
+                    )
                 instance = rns
 
                 // Apply pre-set factories before initialize
@@ -268,8 +287,10 @@ class Reticulum private constructor(
         // Ensure directories exist
         ensureDirectories()
 
-        // Load or create transport identity
-        val transportIdentity = loadOrCreateTransportIdentity()
+        // Use the caller-provided identity if given (so the plaintext private key
+        // never has to touch disk), otherwise fall back to the legacy file-backed flow.
+        val transportIdentity =
+            transportIdentityOverride ?: loadOrCreateTransportIdentity()
 
         // Configure Transport and Identity storage paths
         Transport.setCachePath(cachePath)

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -157,6 +157,9 @@ class Reticulum private constructor(
          * @param shareInstance Whether to share this instance with other apps (starts local server)
          * @param sharedInstancePort TCP port for shared instance communication
          * @param connectToSharedInstance Whether to connect to an existing shared instance
+         * @param transportIdentity Optional in-memory transport identity. When non-null, the
+         *   private key is used directly and the `$storagePath/transport_identity` file is
+         *   never read or written. When null (default), the legacy file-backed flow runs.
          * @return The Reticulum instance
          */
         fun start(
@@ -187,6 +190,12 @@ class Reticulum private constructor(
 
                 rns.initialize()
                 return rns
+            }
+            if (transportIdentity != null) {
+                log(
+                    "WARNING: transportIdentity was provided but Reticulum is already started; " +
+                        "the supplied identity will not be used.",
+                )
             }
             return instance!!
         }


### PR DESCRIPTION
## Summary

`Reticulum.start(...)` now accepts an optional `transportIdentity: Identity?` parameter. When non-null, `initialize()` uses that identity directly and skips the `\$storagePath/transport_identity` file flow entirely — the private key never has to touch disk as plaintext.

## Motivation

Downstream callers that manage their own identity persistence — for example, an Android app that stores the private key encrypted-at-rest in Room with an Android-Keystore-wrapped master key — currently have no choice but to decrypt and write the raw key bytes to `transport_identity` just so Reticulum can turn around and read them back. That plaintext file:

- Has to be excluded from every backup mechanism (Auto Backup, device-to-device transfer, ADB pulls).
- Duplicates the application's already-encrypted copy of the same key.
- Widens the blast radius of a root/debugger compromise.

With this change, the caller passes the decrypted `Identity` object in memory and Reticulum never touches the filesystem for transport-identity persistence.

## Backwards compatibility

`transportIdentity` is an optional parameter defaulting to `null`. When `null`, behaviour is unchanged: `loadOrCreateTransportIdentity()` runs, looks for `\$storagePath/transport_identity`, creates one if missing, and writes it to disk. Existing callers (desktop tooling, CLI, etc.) need no changes and continue to benefit from file-based persistence and cross-implementation compatibility with the Python Reticulum reference.

## Verification

- [x] `:rns-core:test` passes
- [x] `:rns-core:build` passes
- [x] `:rns-interfaces:test` passes
- [x] `:rns-interfaces:build` passes
- [x] `:rns-android:compileDebugKotlin` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)