### PR TITLE
Delete legacy file-backed state after migrating to Room

### DIFF
--- a/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
@@ -63,6 +63,18 @@ class FileMigrator(
      * Remove legacy file-backed state that is now mirrored in Room.
      * Best-effort: each delete is isolated so a single failure doesn't abort
      * the rest. Safe to run when the files are already gone.
+     *
+     * Note on `ratchets/`: `migrateRatchets()` intentionally skips `.out`
+     * files, but those are just transient atomic-write staging (see
+     * `Identity.persistRatchet()` — it writes to `$hash.out`, then renames
+     * to `$hash`). A stranded `.out` file means a write was interrupted and
+     * the data is not authoritative; safe to delete alongside the real
+     * ratchet files that Room now owns.
+     *
+     * Note on `discovery/`: the migrator only touches
+     * `discovery/interfaces/`, so we scope the delete there rather than
+     * nuking the whole `discovery/` tree — future subdirectories should
+     * not be silently wiped.
      */
     private fun deleteLegacySourceFiles() {
         val storageFiles = listOf(
@@ -75,10 +87,9 @@ class FileMigrator(
         for (name in storageFiles) {
             runCatching { File(storagePath, name).delete() }
         }
-        // Directory contents: the stores own these now.
         runCatching { File(cachePath, "announces").deleteRecursively() }
         runCatching { File(storagePath, "ratchets").deleteRecursively() }
-        runCatching { File(storagePath, "discovery").deleteRecursively() }
+        runCatching { File(storagePath, "discovery/interfaces").deleteRecursively() }
     }
 
     private fun migratePathTable() {

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
@@ -25,7 +25,15 @@ class FileMigrator(
 ) {
     fun migrateIfNeeded() {
         val marker = File(storagePath, ".room_migrated")
-        if (marker.exists()) return
+        if (marker.exists()) {
+            // Migration already ran. Earlier versions of this migrator left the
+            // source files on disk afterward, which accumulated forever and kept
+            // sensitive routing state (known destinations, ratchets, announces)
+            // in plaintext outside the Room DB. Idempotent cleanup on every
+            // launch so upgraders eventually converge on Room-only storage.
+            deleteLegacySourceFiles()
+            return
+        }
 
         Log.i(TAG, "Starting file-to-Room migration...")
         val start = System.currentTimeMillis()
@@ -40,11 +48,37 @@ class FileMigrator(
             migrateDiscovery()
 
             marker.createNewFile()
+            // Room is authoritative for every entity we just imported — delete
+            // the source files so they don't drift out of sync and don't leak
+            // sensitive routing state via backup archives or forensic access.
+            deleteLegacySourceFiles()
             Log.i(TAG, "Migration completed in ${System.currentTimeMillis() - start}ms")
         } catch (e: Exception) {
             Log.e(TAG, "Migration failed: ${e.message}", e)
             // Don't create marker — will retry next launch
         }
+    }
+
+    /**
+     * Remove legacy file-backed state that is now mirrored in Room.
+     * Best-effort: each delete is isolated so a single failure doesn't abort
+     * the rest. Safe to run when the files are already gone.
+     */
+    private fun deleteLegacySourceFiles() {
+        val storageFiles = listOf(
+            "destination_table",
+            "packet_hashlist",
+            "known_destinations",
+            "known_destinations.tmp",
+            "tunnels"
+        )
+        for (name in storageFiles) {
+            runCatching { File(storagePath, name).delete() }
+        }
+        // Directory contents: the stores own these now.
+        runCatching { File(cachePath, "announces").deleteRecursively() }
+        runCatching { File(storagePath, "ratchets").deleteRecursively() }
+        runCatching { File(storagePath, "discovery").deleteRecursively() }
     }
 
     private fun migratePathTable() {


### PR DESCRIPTION
## Summary

`FileMigrator` imports `destination_table`, `packet_hashlist`, `known_destinations`, `tunnels`, `announces/`, `ratchets/`, and `discovery/interfaces/` into Room on first launch, then creates a `.room_migrated` marker and short-circuits on subsequent runs. The source files are never deleted, so they accumulate forever even though the Room stores own the authoritative copy.

## Why it matters

1. **State drift** — known destinations / ratchets on disk are frozen snapshots from the migration moment. Anything that still reads them (forensic tools, third-party backup restore) sees stale data and can get confused.
2. **Sensitive state outside the DB** — routing data (public keys, ratchets, announce payloads) stays in plaintext outside Room. Downstream Android consumers have had to blanket-exclude the Reticulum configDir from Auto Backup to avoid uploading these files, which forces users to manually re-establish every contact relationship after a phone swap.

## Changes

After a successful migration, delete the source files. Also run the cleanup for upgraders whose `.room_migrated` marker already exists, so existing installs converge on Room-only storage without a marker version bump.

The cleanup runs **before** `Reticulum.start()` (same call site as the migration), so there's no race with Transport writing — the stores are wired up but not yet running. Each delete is wrapped in `runCatching { ... }` so a failure on one file doesn't abort the rest.

## Verification

- [x] `:rns-android:assembleDebug`
- [x] `:rns-android:testDebugUnitTest`
- [ ] Manual: install on a device with pre-migration files, verify deletion on next boot, verify Room still has the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)