### PR TITLE
Drop Reticulum.ensureDirectories and dead identityPath

### DIFF
--- a/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
@@ -47,6 +47,9 @@ class FileMigrator(
             migrateRatchets()
             migrateDiscovery()
 
+            // storagePath is no longer eagerly created by Reticulum.initialize(),
+            // so make sure it exists before dropping the marker.
+            marker.parentFile?.mkdirs()
             marker.createNewFile()
             // Room is authoritative for every entity we just imported — delete
             // the source files so they don't drift out of sync and don't leak

--- a/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/Reticulum.kt
@@ -295,7 +295,6 @@ class Reticulum private constructor(
     // Storage paths
     val storagePath: String = "$configDir/storage"
     val cachePath: String = "$configDir/cache"
-    val identityPath: String = "$configDir/identities"
 
     // State
     private val interfaces = mutableListOf<Any>()
@@ -327,8 +326,10 @@ class Reticulum private constructor(
     private fun initialize() {
         log("Initializing Reticulum...")
 
-        // Ensure directories exist
-        ensureDirectories()
+        // Directory layout is lazily created at each write site (Transport, Identity,
+        // InterfaceDiscovery, Destination all mkdirs parents on demand) and on Android
+        // everything routes through Room stores anyway, so there's no reason to
+        // eagerly create empty subdirectories that may never be written to.
 
         // Use the caller-provided identity if given (so the plaintext private key
         // never has to touch disk), otherwise fall back to the legacy file-backed flow.
@@ -521,18 +522,6 @@ class Reticulum private constructor(
                 )
             }
             log("Deleted legacy plaintext transport_identity file (in-memory override active)")
-        }
-    }
-
-    /**
-     * Ensure required directories exist.
-     */
-    private fun ensureDirectories() {
-        listOf(configDir, storagePath, cachePath, identityPath).forEach { path ->
-            val dir = File(path)
-            if (!dir.exists()) {
-                dir.mkdirs()
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #30. Once FileMigrator wipes the legacy file tree, `files/reticulum/` on Android should be empty — but `Reticulum.ensureDirectories()` keeps re-creating `storage/`, `cache/`, `identities/` on every init even though most write sites have their own lazy `mkdirs()` and rns-android routes everything through Room stores.

## Changes

- **Delete `Reticulum.ensureDirectories()`.** Every writer already mkdirs on demand:
  - `Identity.saveKnownDestinations` (Identity.kt:560)
  - `Identity.persistRatchet` (815)
  - `Identity.saveToFile` (1302)
  - `Transport.cacheAnnouncePacket` (4898)
  - `Transport.saveTunnelTable` (5121)
  - `Transport.persistDataToStorage` (5300)
  - `Transport.savePersistedData` (1829)
  - `InterfaceDiscovery.discoveryDir` getter (47)
  - `Destination` (445)

- **Delete `identityPath`.** The property and the `ensureDirectories` loop were its only references in the tree — the last writer was removed in the in-memory-identity refactor.

- **Update `FileMigrator`.** The `.room_migrated` marker goes in `storagePath`, so mkdirs the parent before `createNewFile()`. Only meaningful impact is on fresh installs where nothing else writes there first.

## Motivation

On Columba + PR #30, `files/reticulum/` becomes truly empty of user state post-migration. Dropping phantom subdirectories is the final step before we can relax the Android Auto Backup exclusion downstream — an empty directory with nothing to leak is a different risk profile from "five subdirs of unknown content".

## Base branch

This PR targets `chore/filemigrator-cleanup-source-files` (PR #30) so the diff shows only the incremental change. It'll auto-retarget `main` after #30 merges.

## Verification

- [x] `:rns-core:assemble`
- [x] `:rns-android:assembleDebug`
- [x] `:rns-core:test`
- [x] `:rns-android:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)