### PR TITLE
Move Destination ratchet persistence behind a pluggable store

### DIFF
--- a/rns-android/schemas/network.reticulum.android.db.ReticulumDatabase/3.json
+++ b/rns-android/schemas/network.reticulum.android.db.ReticulumDatabase/3.json
@@ -1,0 +1,564 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "a209e55d8d07f4eda8df3e57c580c820",
+    "entities": [
+      {
+        "tableName": "paths",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dest_hash` BLOB NOT NULL, `next_hop` BLOB NOT NULL, `hops` INTEGER NOT NULL, `expires` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `interface_hash` BLOB NOT NULL, `announce_hash` BLOB NOT NULL, `state` INTEGER NOT NULL, `failure_count` INTEGER NOT NULL, `random_blobs` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`dest_hash`))",
+        "fields": [
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextHop",
+            "columnName": "next_hop",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expires",
+            "columnName": "expires",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interfaceHash",
+            "columnName": "interface_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "announceHash",
+            "columnName": "announce_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failure_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "randomBlobs",
+            "columnName": "random_blobs",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dest_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_paths_expires",
+            "unique": false,
+            "columnNames": [
+              "expires"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_paths_expires` ON `${TABLE_NAME}` (`expires`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "packet_hashes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hash` BLOB NOT NULL, `generation` INTEGER NOT NULL, PRIMARY KEY(`hash`))",
+        "fields": [
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_packet_hashes_generation",
+            "unique": false,
+            "columnNames": [
+              "generation"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_hashes_generation` ON `${TABLE_NAME}` (`generation`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "known_destinations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dest_hash` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, `packet_hash` BLOB NOT NULL, `public_key` BLOB NOT NULL, `app_data` BLOB, PRIMARY KEY(`dest_hash`))",
+        "fields": [
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetHash",
+            "columnName": "packet_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appData",
+            "columnName": "app_data",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dest_hash"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tunnels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tunnel_id` BLOB NOT NULL, `interface_hash` BLOB, `expires` INTEGER NOT NULL, PRIMARY KEY(`tunnel_id`))",
+        "fields": [
+          {
+            "fieldPath": "tunnelId",
+            "columnName": "tunnel_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interfaceHash",
+            "columnName": "interface_hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "expires",
+            "columnName": "expires",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tunnel_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tunnel_paths",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tunnel_id` BLOB NOT NULL, `dest_hash` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, `received_from` BLOB NOT NULL, `hops` INTEGER NOT NULL, `expires` INTEGER NOT NULL, `packet_hash` BLOB NOT NULL, PRIMARY KEY(`tunnel_id`, `dest_hash`), FOREIGN KEY(`tunnel_id`) REFERENCES `tunnels`(`tunnel_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "tunnelId",
+            "columnName": "tunnel_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedFrom",
+            "columnName": "received_from",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expires",
+            "columnName": "expires",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetHash",
+            "columnName": "packet_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tunnel_id",
+            "dest_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tunnel_paths_tunnel_id",
+            "unique": false,
+            "columnNames": [
+              "tunnel_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tunnel_paths_tunnel_id` ON `${TABLE_NAME}` (`tunnel_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tunnels",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tunnel_id"
+            ],
+            "referencedColumns": [
+              "tunnel_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "announce_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packet_hash` BLOB NOT NULL, `raw` BLOB NOT NULL, `interface_name` TEXT NOT NULL, PRIMARY KEY(`packet_hash`))",
+        "fields": [
+          {
+            "fieldPath": "packetHash",
+            "columnName": "packet_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raw",
+            "columnName": "raw",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interfaceName",
+            "columnName": "interface_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packet_hash"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "identity_ratchets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dest_hash` BLOB NOT NULL, `ratchet` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`dest_hash`))",
+        "fields": [
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratchet",
+            "columnName": "ratchet",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dest_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_identity_ratchets_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_identity_ratchets_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "discovered_interfaces",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`discovery_hash` BLOB NOT NULL, `type` TEXT NOT NULL, `transport` INTEGER NOT NULL, `name` TEXT NOT NULL, `received` INTEGER NOT NULL, `stamp_value` INTEGER NOT NULL, `transport_id` TEXT NOT NULL, `network_id` TEXT NOT NULL, `hops` INTEGER NOT NULL, `latitude` REAL, `longitude` REAL, `height` REAL, `reachable_on` TEXT, `port` INTEGER, `frequency` INTEGER, `bandwidth` INTEGER, `spreading_factor` INTEGER, `coding_rate` INTEGER, `modulation` TEXT, `channel` INTEGER, `ifac_netname` TEXT, `ifac_netkey` TEXT, `discovered` INTEGER NOT NULL, `last_heard` INTEGER NOT NULL, `heard_count` INTEGER NOT NULL, PRIMARY KEY(`discovery_hash`))",
+        "fields": [
+          {
+            "fieldPath": "discoveryHash",
+            "columnName": "discovery_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transport",
+            "columnName": "transport",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received",
+            "columnName": "received",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stampValue",
+            "columnName": "stamp_value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkId",
+            "columnName": "network_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reachableOn",
+            "columnName": "reachable_on",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "frequency",
+            "columnName": "frequency",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bandwidth",
+            "columnName": "bandwidth",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spreadingFactor",
+            "columnName": "spreading_factor",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "codingRate",
+            "columnName": "coding_rate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modulation",
+            "columnName": "modulation",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ifacNetname",
+            "columnName": "ifac_netname",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ifacNetkey",
+            "columnName": "ifac_netkey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "discovered",
+            "columnName": "discovered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeard",
+            "columnName": "last_heard",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "heardCount",
+            "columnName": "heard_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "discovery_hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovered_interfaces_last_heard",
+            "unique": false,
+            "columnNames": [
+              "last_heard"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_interfaces_last_heard` ON `${TABLE_NAME}` (`last_heard`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "destination_ratchets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dest_hash` BLOB NOT NULL, `data` BLOB NOT NULL, PRIMARY KEY(`dest_hash`))",
+        "fields": [
+          {
+            "fieldPath": "destHash",
+            "columnName": "dest_hash",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "dest_hash"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a209e55d8d07f4eda8df3e57c580c820')"
+    ]
+  }
+}

--- a/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
@@ -268,6 +268,7 @@ class ReticulumService : LifecycleService() {
         network.reticulum.transport.Transport.tunnelStore = null
         network.reticulum.transport.Transport.announceStore = null
         network.reticulum.transport.Transport.discoveryStore = null
+        network.reticulum.transport.Transport.destinationRatchetStore = null
         network.reticulum.identity.Identity.identityStore = null
 
         database?.close()
@@ -311,7 +312,8 @@ class ReticulumService : LifecycleService() {
                 network.reticulum.android.db.ReticulumDatabase::class.java,
                 "reticulum.db"
             ).addMigrations(
-                network.reticulum.android.db.ReticulumDatabase.MIGRATION_1_2
+                network.reticulum.android.db.ReticulumDatabase.MIGRATION_1_2,
+                network.reticulum.android.db.ReticulumDatabase.MIGRATION_2_3,
             ).build()
             database = db
 
@@ -332,6 +334,8 @@ class ReticulumService : LifecycleService() {
                 network.reticulum.android.db.store.RoomDiscoveryStore(db.discoveredInterfaceDao(), executor)
             network.reticulum.identity.Identity.identityStore =
                 network.reticulum.android.db.store.RoomIdentityStore(db.knownDestinationDao(), db.identityRatchetDao(), executor)
+            network.reticulum.transport.Transport.destinationRatchetStore =
+                network.reticulum.android.db.store.RoomDestinationRatchetStore(db.destinationRatchetDao(), executor)
 
             Log.i(TAG, "Room database initialized with persistent stores")
 
@@ -340,7 +344,10 @@ class ReticulumService : LifecycleService() {
             kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
                 // Migrate existing file-based data to Room (one-time, idempotent)
                 network.reticulum.android.db.FileMigrator(
-                    db, "$configDir/storage", "$configDir/cache"
+                    db = db,
+                    storagePath = "$configDir/storage",
+                    cachePath = "$configDir/cache",
+                    lxmfRatchetsPath = "$configDir/lxmf/ratchets",
                 ).migrateIfNeeded()
 
                 // Configure Transport for coroutine-based job loop on Android

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
@@ -2,6 +2,7 @@ package network.reticulum.android.db
 
 import android.util.Log
 import network.reticulum.android.db.entity.AnnounceCacheEntity
+import network.reticulum.android.db.entity.DestinationRatchetEntity
 import network.reticulum.android.db.entity.DiscoveredInterfaceEntity
 import network.reticulum.android.db.entity.IdentityRatchetEntity
 import network.reticulum.android.db.entity.KnownDestinationEntity
@@ -21,16 +22,26 @@ import java.io.File
 class FileMigrator(
     private val db: ReticulumDatabase,
     private val storagePath: String,
-    private val cachePath: String
+    private val cachePath: String,
+    /**
+     * Optional LXMF ratchet directory. When LXMF-kt is in the dependency tree
+     * it writes per-destination ratchet private keys under
+     * `$configDir/lxmf/ratchets/<hash>` (Kotlin) or `<hash>.ratchets` (Python
+     * reference layout). Pass `$configDir/lxmf/ratchets` here and FileMigrator
+     * will import those into the destination_ratchets Room table and scrub the
+     * files. Leave null for bare rns-core deployments.
+     */
+    private val lxmfRatchetsPath: String? = null,
 ) {
     fun migrateIfNeeded() {
         val marker = File(storagePath, ".room_migrated")
         if (marker.exists()) {
-            // Migration already ran. Earlier versions of this migrator left the
-            // source files on disk afterward, which accumulated forever and kept
-            // sensitive routing state (known destinations, ratchets, announces)
-            // in plaintext outside the Room DB. Idempotent cleanup on every
-            // launch so upgraders eventually converge on Room-only storage.
+            // Full migration already ran, but earlier versions of this migrator
+            // didn't know about the LXMF destination-ratchet files (they were
+            // added later) and left legacy source files on disk forever.
+            // Re-import ratchets and run the scrub on every launch — upsert
+            // is idempotent, so repeated runs are safe.
+            migrateDestinationRatchets()
             deleteLegacySourceFiles()
             return
         }
@@ -45,6 +56,7 @@ class FileMigrator(
             migrateTunnels()
             migrateAnnounceCache()
             migrateRatchets()
+            migrateDestinationRatchets()
             migrateDiscovery()
 
             // storagePath is no longer eagerly created by Reticulum.initialize(),
@@ -93,6 +105,52 @@ class FileMigrator(
         runCatching { File(cachePath, "announces").deleteRecursively() }
         runCatching { File(storagePath, "ratchets").deleteRecursively() }
         runCatching { File(storagePath, "discovery/interfaces").deleteRecursively() }
+        // LXMF per-destination ratchets — only present when LXMF-kt is in use.
+        // Both filename flavours (Kotlin's `<hash>`, Python's `<hash>.ratchets`)
+        // landed under the same directory.
+        lxmfRatchetsPath?.let { runCatching { File(it).deleteRecursively() } }
+    }
+
+    /**
+     * Import LXMF per-destination inbound ratchets into Room.
+     *
+     * The on-disk blob (`{signature, ratchets}` msgpack) is stored opaquely —
+     * `Destination.reloadRatchets` unpacks it and verifies the signature when
+     * the router re-registers the destination. This keeps the migration
+     * signature-agnostic, so it still works when the destination's identity
+     * isn't materialized at migration time.
+     *
+     * Accepts both `<hash>` (LXMF-kt layout) and `<hash>.ratchets` (Python
+     * LXMF reference layout); strips the suffix when parsing the hash.
+     */
+    private fun migrateDestinationRatchets() {
+        val dir = lxmfRatchetsPath?.let { File(it) } ?: return
+        if (!dir.exists() || !dir.isDirectory) return
+        try {
+            var count = 0
+            for (file in dir.listFiles() ?: emptyArray()) {
+                if (!file.isFile) continue
+                if (file.name.endsWith(".tmp")) continue
+                val hashName = file.name.removeSuffix(".ratchets")
+                val destHash =
+                    try {
+                        hexToBytes(hashName)
+                    } catch (_: Exception) {
+                        continue
+                    }
+                try {
+                    db.destinationRatchetDao().upsert(
+                        DestinationRatchetEntity(destHash = destHash, data = file.readBytes()),
+                    )
+                    count++
+                } catch (_: Exception) {
+                    // Skip a single bad file, continue with the rest.
+                }
+            }
+            Log.i(TAG, "Migrated $count destination ratchets")
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to migrate destination ratchets: ${e.message}")
+        }
     }
 
     private fun migratePathTable() {

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/FileMigrator.kt
@@ -128,6 +128,7 @@ class FileMigrator(
         if (!dir.exists() || !dir.isDirectory) return
         try {
             var count = 0
+            var skipped = 0
             for (file in dir.listFiles() ?: emptyArray()) {
                 if (!file.isFile) continue
                 if (file.name.endsWith(".tmp")) continue
@@ -135,7 +136,12 @@ class FileMigrator(
                 val destHash =
                     try {
                         hexToBytes(hashName)
-                    } catch (_: Exception) {
+                    } catch (e: Exception) {
+                        // deleteLegacySourceFiles will erase this file afterwards, so
+                        // log loudly — the operator gets no other chance to catch an
+                        // unparseable filename before it's gone.
+                        Log.w(TAG, "Skipping non-hex ratchet filename ${file.name}: ${e.message}")
+                        skipped++
                         continue
                     }
                 try {
@@ -143,11 +149,23 @@ class FileMigrator(
                         DestinationRatchetEntity(destHash = destHash, data = file.readBytes()),
                     )
                     count++
-                } catch (_: Exception) {
-                    // Skip a single bad file, continue with the rest.
+                } catch (e: Exception) {
+                    // Same reasoning as above — file is about to be deleted. If this
+                    // was a transient SQLite error the destination loses ratchet
+                    // history until the next rotation, so surface it clearly.
+                    Log.w(
+                        TAG,
+                        "Failed to import ratchet file ${file.name} for destination " +
+                            "${hashName.take(8)}... into Room: ${e.message}",
+                    )
+                    skipped++
                 }
             }
-            Log.i(TAG, "Migrated $count destination ratchets")
+            if (skipped > 0) {
+                Log.w(TAG, "Migrated $count destination ratchets, skipped $skipped")
+            } else {
+                Log.i(TAG, "Migrated $count destination ratchets")
+            }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to migrate destination ratchets: ${e.message}")
         }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/ReticulumDatabase.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/ReticulumDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import network.reticulum.android.db.dao.AnnounceCacheDao
+import network.reticulum.android.db.dao.DestinationRatchetDao
 import network.reticulum.android.db.dao.DiscoveredInterfaceDao
 import network.reticulum.android.db.dao.IdentityRatchetDao
 import network.reticulum.android.db.dao.KnownDestinationDao
@@ -13,6 +14,7 @@ import network.reticulum.android.db.dao.PathDao
 import network.reticulum.android.db.dao.TunnelDao
 import network.reticulum.android.db.dao.TunnelPathDao
 import network.reticulum.android.db.entity.AnnounceCacheEntity
+import network.reticulum.android.db.entity.DestinationRatchetEntity
 import network.reticulum.android.db.entity.DiscoveredInterfaceEntity
 import network.reticulum.android.db.entity.IdentityRatchetEntity
 import network.reticulum.android.db.entity.KnownDestinationEntity
@@ -31,8 +33,9 @@ import network.reticulum.android.db.entity.TunnelPathEntity
         AnnounceCacheEntity::class,
         IdentityRatchetEntity::class,
         DiscoveredInterfaceEntity::class,
+        DestinationRatchetEntity::class,
     ],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 abstract class ReticulumDatabase : RoomDatabase() {
@@ -44,12 +47,25 @@ abstract class ReticulumDatabase : RoomDatabase() {
     abstract fun announceCacheDao(): AnnounceCacheDao
     abstract fun identityRatchetDao(): IdentityRatchetDao
     abstract fun discoveredInterfaceDao(): DiscoveredInterfaceDao
+    abstract fun destinationRatchetDao(): DestinationRatchetDao
 
     companion object {
         /** Migration 1→2: Add random_blobs column to paths table. */
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE paths ADD COLUMN random_blobs TEXT NOT NULL DEFAULT ''")
+            }
+        }
+
+        /** Migration 2→3: Add destination_ratchets table. */
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS destination_ratchets (" +
+                        "dest_hash BLOB NOT NULL, " +
+                        "data BLOB NOT NULL, " +
+                        "PRIMARY KEY(dest_hash))"
+                )
             }
         }
     }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/dao/DestinationRatchetDao.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/dao/DestinationRatchetDao.kt
@@ -1,0 +1,18 @@
+package network.reticulum.android.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import network.reticulum.android.db.entity.DestinationRatchetEntity
+
+@Dao
+interface DestinationRatchetDao {
+    @Upsert
+    fun upsert(entity: DestinationRatchetEntity)
+
+    @Query("SELECT * FROM destination_ratchets WHERE dest_hash = :destHash")
+    fun getByHash(destHash: ByteArray): DestinationRatchetEntity?
+
+    @Query("DELETE FROM destination_ratchets WHERE dest_hash = :destHash")
+    fun deleteByHash(destHash: ByteArray)
+}

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/entity/DestinationRatchetEntity.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/entity/DestinationRatchetEntity.kt
@@ -1,0 +1,29 @@
+package network.reticulum.android.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Per-inbound-destination ratchet state.
+ *
+ * The blob is the signed msgpack envelope `Destination.persistRatchets` produces:
+ * `{signature: bytes, ratchets: bytes}`. The store treats it opaquely; unpacking,
+ * signature verification, and rotation all live in `Destination`.
+ */
+@Entity(tableName = "destination_ratchets")
+data class DestinationRatchetEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "dest_hash", typeAffinity = ColumnInfo.BLOB)
+    val destHash: ByteArray,
+    @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
+    val data: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DestinationRatchetEntity) return false
+        return destHash.contentEquals(other.destHash) && data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int = destHash.contentHashCode()
+}

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomDestinationRatchetStore.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomDestinationRatchetStore.kt
@@ -1,0 +1,32 @@
+package network.reticulum.android.db.store
+
+import network.reticulum.android.db.dao.DestinationRatchetDao
+import network.reticulum.android.db.entity.DestinationRatchetEntity
+import network.reticulum.storage.DestinationRatchetStore
+import java.util.concurrent.ExecutorService
+
+/**
+ * Room-backed `DestinationRatchetStore`. Reads synchronously (called from
+ * `Destination.enableRatchets` on router startup) and writes through the
+ * injected executor so the caller's ratchet-rotation path doesn't block
+ * on disk.
+ */
+class RoomDestinationRatchetStore(
+    private val dao: DestinationRatchetDao,
+    private val writeExecutor: ExecutorService,
+) : DestinationRatchetStore {
+    override fun save(
+        destHash: ByteArray,
+        data: ByteArray,
+    ) {
+        writeExecutor.execute {
+            dao.upsert(DestinationRatchetEntity(destHash = destHash, data = data))
+        }
+    }
+
+    override fun load(destHash: ByteArray): ByteArray? = dao.getByHash(destHash)?.data
+
+    override fun delete(destHash: ByteArray) {
+        writeExecutor.execute { dao.deleteByHash(destHash) }
+    }
+}

--- a/rns-core/src/main/kotlin/network/reticulum/destination/Destination.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/destination/Destination.kt
@@ -1100,9 +1100,12 @@ class Destination private constructor(
                     // Try decryption with current in-memory ratchets
                     var plaintext = tryDecryptWithRatchets(id, ciphertext)
 
-                    // If failed and we have a ratchets file, reload and retry
-                    // (matches Python: reload from disk on failure)
-                    if (plaintext == null && ratchetsPath != null) {
+                    // If failed and we have persistent ratchet storage (file OR store),
+                    // reload and retry (matches Python: reload from disk on failure).
+                    if (plaintext == null &&
+                        (ratchetsPath != null ||
+                            network.reticulum.transport.Transport.destinationRatchetStore != null)
+                    ) {
                         try {
                             println("Decryption with ratchets failed on $this, reloading ratchets from storage and retrying")
                             reloadRatchets()

--- a/rns-core/src/main/kotlin/network/reticulum/destination/Destination.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/destination/Destination.kt
@@ -407,7 +407,6 @@ class Destination private constructor(
      * @throws java.io.IOException if file write fails
      */
     private fun persistRatchets() {
-        val path = ratchetsPath ?: throw IllegalStateException("No ratchets path set")
         val id = identity ?: throw IllegalStateException("Cannot persist ratchets without identity")
         require(id.hasPrivateKey) { "Cannot persist ratchets without private key" }
 
@@ -437,7 +436,16 @@ class Destination private constructor(
                 outerPacker.writePayload(packedRatchets)
                 val fileData = outerPacker.toByteArray()
 
-                // Write to temporary file first
+                // Prefer the pluggable store (Room on Android) so private ratchet keys
+                // don't touch the filesystem. Fall back to file-based persistence when
+                // no store is wired (bare rns-core, tests, etc.).
+                val store = network.reticulum.transport.Transport.destinationRatchetStore
+                if (store != null) {
+                    store.save(hash, fileData)
+                    return@withLock
+                }
+
+                val path = ratchetsPath ?: throw IllegalStateException("No ratchets path set")
                 val file = File(path)
                 val tempFile = File("$path.tmp")
 
@@ -470,18 +478,22 @@ class Destination private constructor(
      * @throws java.io.IOException if file read or verification fails
      */
     private fun reloadRatchets(): Boolean {
-        val path = ratchetsPath ?: throw IllegalStateException("No ratchets path set")
         val id = identity ?: throw IllegalStateException("Cannot reload ratchets without identity")
 
-        val file = File(path)
-        if (!file.exists()) {
+        // Prefer the pluggable store (Room on Android). Fall back to reading the file
+        // on disk when no store is wired.
+        val store = network.reticulum.transport.Transport.destinationRatchetStore
+        val storedBytes = store?.load(hash)
+
+        val file: File? = if (storedBytes == null && ratchetsPath != null) File(ratchetsPath!!) else null
+        if (storedBytes == null && (file == null || !file.exists())) {
             return false
         }
 
         ratchetFileLock.withLock {
             fun loadAttempt() {
-                // Read file
-                val fileData = file.readBytes()
+                // Read from store if present, otherwise from disk
+                val fileData = storedBytes ?: file!!.readBytes()
 
                 // Unpack outer msgpack dict: {"signature": bytes, "ratchets": bytes}
                 // Matches Python: umsgpack.unpackb(ratchets_file.read())

--- a/rns-core/src/main/kotlin/network/reticulum/storage/DestinationRatchetStore.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/storage/DestinationRatchetStore.kt
@@ -1,0 +1,29 @@
+package network.reticulum.storage
+
+/**
+ * Persistent storage for a destination's inbound ratchet state.
+ *
+ * Stores the signed msgpack blob (`{signature, ratchets}`) that
+ * `Destination.persistRatchets` produces, keyed by destination hash.
+ * Implementations keep the bytes opaque — serialization, signing, and
+ * signature verification all live in `Destination`.
+ *
+ * Implementations must be thread-safe. `save`/`delete` are called from
+ * whichever thread rotates ratchets (typically the destination's own
+ * message-handling scope); `load` is called on `Destination.enableRatchets`
+ * which runs on the caller's thread at router startup.
+ */
+interface DestinationRatchetStore {
+    /**
+     * Persist the signed ratchet blob for [destHash].
+     * The caller passes the already-packed and signed bytes; the store
+     * should not try to interpret them.
+     */
+    fun save(destHash: ByteArray, data: ByteArray)
+
+    /** Load the signed ratchet blob for [destHash], or null if none. */
+    fun load(destHash: ByteArray): ByteArray?
+
+    /** Remove the entry for [destHash]. No-op if not present. */
+    fun delete(destHash: ByteArray)
+}

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -545,6 +545,9 @@ object Transport {
     /** Persistent discovery storage. When null, falls back to file-based persistence. */
     var discoveryStore: network.reticulum.storage.DiscoveryStore? = null
 
+    /** Persistent per-destination inbound ratchet storage. When null, falls back to file-based persistence. */
+    var destinationRatchetStore: network.reticulum.storage.DestinationRatchetStore? = null
+
     // ===== Memory Management =====
 
     /**


### PR DESCRIPTION
## Summary

`Destination.persistRatchets` writes X25519 private keys for inbound forward secrecy. Python LXMF and LXMF-kt both hand it a path under `\$configDir/lxmf/ratchets/<hash>` (Python appends `.ratchets`). On Android, any backup archive that includes `files/reticulum/` picks up those private keys — undermining forward secrecy for any past messages to the affected identity, and forcing downstream consumers to blanket-exclude the directory from Auto Backup.

This PR extracts the ratchet persistence behind a new `DestinationRatchetStore` interface, mirroring the existing `PathStore` / `AnnounceStore` / `IdentityStore` pattern. rns-android gets a Room-backed implementation and a file-to-DB migration.

## Why this was the missing piece

The earlier PR #30 moved RNS routing state (paths, announces, known destinations, identity ratchets, etc.) into Room, so downstream users could drop their backup exclusion. In verification I caught that `files/reticulum/lxmf/ratchets/<hash>` still contained raw X25519 private keys — same security-sensitive material the on-disk identity files used to hold. This closes that gap.

## Changes

**rns-core:**
- New `storage/DestinationRatchetStore.kt` interface (opaque BLOB save/load/delete keyed by destination hash).
- `Transport.destinationRatchetStore: DestinationRatchetStore? = null` — same pattern as the other store statics.
- `Destination.persistRatchets` / `reloadRatchets` prefer the store when set, fall back to file I/O when not. `ratchetsPath` still required for fallback.

**rns-android:**
- `DestinationRatchetEntity` / `DestinationRatchetDao` (single opaque `data` BLOB per destHash).
- `RoomDestinationRatchetStore` — executor-backed write-through, synchronous reads.
- `ReticulumDatabase` bumps to v3 with `MIGRATION_2_3` adding the `destination_ratchets` table.
- `ReticulumService.onCreate` wires the store up alongside the others and passes `\$configDir/lxmf/ratchets` to `FileMigrator`.
- `FileMigrator`:
  - New `migrateDestinationRatchets()` imports both LXMF-kt (`<hash>`) and Python LXMF reference (`<hash>.ratchets`) filename flavours from the LXMF ratchets directory.
  - The migration also runs on launches where `.room_migrated` already exists, so upgraders from #30 don't lose ratchet state to the scrub.
  - `deleteLegacySourceFiles()` now recursively deletes the LXMF ratchet directory too.

**No change to LXMF-kt or consumers.** LXMF-kt still calls `destination.enableRatchets(path)`; the path just becomes dormant on Android where the store handles it.

## Verification

- [x] `:rns-core:assemble`
- [x] `:rns-android:assembleDebug`
- [x] `:rns-core:test`
- [x] `:rns-android:testDebugUnitTest`
- [ ] Manual: on a Columba install that already has `files/reticulum/lxmf/ratchets/*`, verify post-boot the directory is empty and the app still decrypts inbound messages (which would fail if ratchets were lost rather than migrated).

## Security note

Upsert migration uses the destination hash as the key. The msgpack blob is stored opaque — signature verification happens in `Destination.reloadRatchets` when the destination re-registers, so a malformed or tampered blob would fail verification there rather than at migration time. Keeping the signature check in `Destination` means the store doesn't need to know about identity keys or signing context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)