### PR TITLE
Transport: add announce hop diagnostics and fix two Python divergences

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2518,6 +2518,17 @@ object Transport {
         interfaceRef.rStatSnr?.let { packet.snr = it }
         interfaceRef.rStatQ?.let { packet.q = it }
 
+        // Log wire-side hops before the +1 increment for diagnostics.
+        // Pairs with the TX PACKET log in transmit() so hop progression
+        // across the mesh can be reconstructed from logs alone.
+        if (packet.packetType == PacketType.ANNOUNCE) {
+            log(
+                "RX ANNOUNCE: dest=${packet.destinationHash.toHexString()} " +
+                    "wire_hops=${packet.hops} iface=${interfaceRef.name} " +
+                    "ctx=${packet.context}",
+            )
+        }
+
         // Increment hop count (Python Transport.py:1319)
         packet.hops++
 
@@ -3237,9 +3248,15 @@ object Transport {
 
         retransmitAnnounceToLocalClients(packet, interfaceRef)
 
-        // Retransmit if transport is enabled OR announce came from a local client
+        // Retransmit if transport is enabled OR announce came from a local client.
+        // PATH_RESPONSE is excluded to match Python Transport.py:1741 — path responses
+        // are targeted replies to a specific requester and must not be rebroadcast as
+        // fresh announces, which would inflate hop counts and flood the mesh.
         val fromLocal = fromLocalClient(interfaceRef)
-        if ((transportEnabled || fromLocal) && packet.hops < TransportConstants.PATHFINDER_M) {
+        if ((transportEnabled || fromLocal) &&
+            packet.context != PacketContext.PATH_RESPONSE &&
+            packet.hops < TransportConstants.PATHFINDER_M
+        ) {
             queueAnnounceRetransmit(destHash, packet, interfaceRef, fromLocalClient = fromLocal)
         }
     }

--- a/rns-test/src/test/kotlin/network/reticulum/integration/AnnounceForwardingIntegrationTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/AnnounceForwardingIntegrationTest.kt
@@ -194,9 +194,14 @@ class AnnounceForwardingIntegrationTest {
         for (raw in packets) {
             val parsed = Packet.unpack(raw)
             if (parsed != null && parsed.packetType == PacketType.ANNOUNCE) {
-                // The hop count should match what Transport processed
-                // (incremented by 1 from inbound processing, then preserved in forwarding)
-                assertTrue(parsed.hops >= 0, "Hop count should be non-negative: ${parsed.hops}")
+                // The injected announce arrived on ExternalInterface with wire_hops=0
+                // (it was never sent over a real network, just handed to Transport).
+                // processInbound does one +1, and retransmitAnnounceToLocalClients
+                // preserves that value. So the local client must see hops=1.
+                // If this assertion starts failing with hops=2 or higher, the forward
+                // path is double-counting (the exact bug class we'd want to catch).
+                assertEquals(1, parsed.hops,
+                    "Forwarded announce should have hops=1 after one +1 at inbound")
                 println("  [Test] Hop count preserved: ${parsed.hops}")
                 return
             }


### PR DESCRIPTION
## Summary

Three small changes motivated by a Columba report where two phones, both direct TCP clients of a single transport node, observed each other at 4 hops in the path table instead of the expected 2. Static code review couldn't pinpoint a +2 bug in the Kotlin port — every per-hop step (outbound, inbound +1, retransmit with `packet.hops = packet.hops`, path-response cache replay) matches Python faithfully. These patches add the diagnostics we need to confirm where the inflation happens, plus fix two real divergences found during that review.

## Changes

### 1. Log wire-side hops on ANNOUNCE receive

Pairs with the existing `TX PACKET` log in `transmit()`. Before the canonical `packet.hops++` increment in `processInbound`, we now log:

```
RX ANNOUNCE: dest=<hash> wire_hops=<n> iface=<name> ctx=<ctx>
```

With TX and RX logs on both ends, hop progression across a multi-node path can be reconstructed from logcat alone — enough to tell "transport node X is forwarding with inflated hops" vs "Kotlin Transport is double-incrementing on receive".

### 2. Exclude `PATH_RESPONSE` from announce rebroadcast

Matches Python `Transport.py:1741`:

```python
if (RNS.Reticulum.transport_enabled() or Transport.from_local_client(packet)) and packet.context != RNS.Packet.PATH_RESPONSE:
    # Insert announce into announce table for retransmission
```

Kotlin's pre-existing condition omitted the `context != PATH_RESPONSE` half, so received path responses were being re-queued by `queueAnnounceRetransmit` like fresh announces. That's a spurious path-announce source that can propagate through the mesh with each node contributing +1 to the hop count downstream of the original requester.

### 3. Strengthen hop-count assertion

`AnnounceForwardingIntegrationTest.kt:199` previously asserted only `hops >= 0`, which passes regardless of whether the forward path double-counts, corrupts, or zeros the value. Changed to `assertEquals(1, hops)` so any regression that breaks the +1-per-hop invariant on a single forward fails the test. Verified the new assertion passes against a fresh build.

## Tracked, NOT addressed in this PR

Two other divergences from Python found during the same review. Filing separately after this diagnostic PR lands and we've confirmed whether either of them is related to the Columba hop-inflation report.

### A. Path-table replacement missing emission-time gate

`Transport.kt:3150-3168` vs Python `Transport.py:1620-1681`. Python accepts an equal-or-better-hop replacement only when *both* conditions hold:

- `random_blob not in existing random_blobs`
- `announce_emitted > path_timebase`

Kotlin checks only the first. Allows stale announces with novel random_blobs to overwrite current paths. Fix requires parsing `announceEmitted` from announce data and implementing a `timebase_from_random_blobs` helper (Python has the equivalent).

### B. Path responses broadcast rather than targeted

`Transport.kt:2317-2321` passes path-response cached announces through `queueAnnounceRetransmit`, which broadcasts to all interfaces except the receiving one. Python sends a single targeted packet to the requesting interface via `attached_interface = requesting_interface`. Kotlin's behavior floods path responses across the mesh, which is both a bandwidth issue and a plausible contributor to unexpected path updates on uninvolved peers.

## Test plan

- [x] `./gradlew :rns-core:test :rns-test:test` all pass locally
- [x] New `assertEquals(1, hops)` assertion in `forwarded announce preserves hop count` passes on this branch
- [ ] Integrate into Columba dev build and capture `RX ANNOUNCE` log lines from a two-phone-via-one-hub repro to confirm whether homelab or Kotlin Transport is responsible for the 4-hop inflation