### PR TITLE
Transport: Python-parity for path replacement, targeted path responses, unconditional identity remember

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2285,6 +2285,13 @@ object Transport {
             // Set hop count from path table (Python line 2736)
             cachedPacket.hops = pathEntry.hops
 
+            // Target the response at the requesting interface only (Python line 2781:
+            // announce_table entry stores attached_interface = requesting_interface).
+            // queueAnnounceRetransmit below respects attachedInterface for targeted
+            // emission. Without this the response would be broadcast, inflating
+            // hop counts on unrelated peers that receive the stale cached announce.
+            cachedPacket.attachedInterface = receivingInterface
+
             // Roaming mode check: don't answer if path is on the same roaming-mode interface
             // Python line 2731-2732
             if (receivingInterface.mode == InterfaceMode.ROAMING &&
@@ -3106,6 +3113,29 @@ object Transport {
 
     // ===== Packet Type Handlers =====
 
+    /**
+     * Extract the 5-byte big-endian emission timestamp from a 10-byte random_blob.
+     *
+     * The random_blob layout is 5 bytes of random material + 5 bytes of emission time
+     * (seconds since epoch, big-endian). Matches Python Transport.py:2935-2936
+     * `timebase_from_random_blob`.
+     */
+    private fun timebaseFromRandomBlob(randomBlob: ByteArray): Long {
+        if (randomBlob.size < 10) return 0L
+        var value = 0L
+        for (i in 5..9) {
+            value = (value shl 8) or (randomBlob[i].toLong() and 0xFF)
+        }
+        return value
+    }
+
+    /**
+     * Take the max emission timestamp across a list of random_blobs. Matches Python
+     * Transport.py:2938-2945 `timebase_from_random_blobs`.
+     */
+    private fun timebaseFromRandomBlobs(randomBlobs: List<ByteArray>): Long =
+        randomBlobs.maxOfOrNull { timebaseFromRandomBlob(it) } ?: 0L
+
     private fun processAnnounce(
         packet: Packet,
         interfaceRef: InterfaceRef,
@@ -3120,6 +3150,25 @@ object Transport {
         val destHash = packet.destinationHash
         val identity = announceData.identity
         val appData = announceData.appData
+
+        // Store the identity and ratchet unconditionally on a valid announce,
+        // matching Python Identity.validate_announce (Identity.py:457,478). These
+        // must happen BEFORE the path-table should_add check because ratchet and
+        // identity recall are needed for decryption regardless of whether the
+        // announce also updates our routing path. The previous Kotlin placement
+        // inside the should_add branch meant a stricter replacement rule (e.g.,
+        // rejecting a re-announce that arrives within the same emission-second)
+        // would silently drop ratchet rotation.
+        Identity.remember(
+            packetHash = packet.packetHash,
+            destHash = destHash,
+            publicKey = identity.getPublicKey(),
+            appData = appData,
+        )
+        announceData.ratchet?.let { ratchet ->
+            network.reticulum.destination.Destination.setRatchetForDestination(destHash, ratchet)
+            Identity.rememberRatchet(destHash, ratchet)
+        }
 
         // Record incoming announce for frequency tracking
         interfaceRef.recordIncomingAnnounce()
@@ -3156,22 +3205,36 @@ object Transport {
                 destHash.copyOf()
             }
 
-        // Check if this announce should update the path table (Python:1604-1686)
+        // Check if this announce should update the path table (Python:1604-1686).
+        //
+        // Python requires two conditions for a same-or-better-hop replacement:
+        //   (a) random_blob has not been seen (replay protection), AND
+        //   (b) announce_emitted > max(emission_time stored in random_blobs)
+        // The Kotlin port previously checked only (a), which let stale announces
+        // (e.g., a path_response holding an old cached route) overwrite a fresh
+        // direct path if their random_blobs happened to differ. The worse-hop
+        // branch is similarly emission-time-aware in Python.
         val existingEntry = pathTable[destHash.toKey()]
         val shouldAdd =
             if (existingEntry != null) {
+                val announceEmitted = timebaseFromRandomBlob(announceData.randomHash)
+                val pathTimebase = timebaseFromRandomBlobs(existingEntry.randomBlobs)
+                val blobIsNew = !existingEntry.randomBlobs.any { it.contentEquals(announceData.randomHash) }
+
                 if (packet.hops <= existingEntry.hops) {
-                    // Better or equal path — update if we haven't seen this random blob
-                    !existingEntry.randomBlobs.any { it.contentEquals(announceData.randomHash) }
+                    // Equal or better hop count — accept only if blob is new AND the
+                    // announce is strictly more recent than any existing blob. Python
+                    // Transport.py:1620-1631.
+                    blobIsNew && announceEmitted > pathTimebase
                 } else {
-                    // Worse path — only update if existing is expired or unresponsive
+                    // Worse hop count — accept only under specific conditions (Python
+                    // Transport.py:1632-1681).
                     val now = System.currentTimeMillis()
-                    if (now >= existingEntry.expires) {
-                        !existingEntry.randomBlobs.any { it.contentEquals(announceData.randomHash) }
-                    } else if (isPathUnresponsive(destHash)) {
-                        true
-                    } else {
-                        false
+                    when {
+                        now >= existingEntry.expires -> blobIsNew
+                        announceEmitted > pathTimebase -> blobIsNew
+                        announceEmitted == pathTimebase && isPathUnresponsive(destHash) -> true
+                        else -> false
                     }
                 }
             } else {
@@ -3218,21 +3281,8 @@ object Transport {
             interface_ = interfaceRef,
         )
 
-        // Store the identity for later recall
-        Identity.remember(
-            packetHash = packet.packetHash,
-            destHash = destHash,
-            publicKey = identity.getPublicKey(),
-            appData = appData,
-        )
-
-        // Store ratchet if present in announce
-        val ratchet = announceData.ratchet
-        if (ratchet != null) {
-            network.reticulum.destination.Destination
-                .setRatchetForDestination(destHash, ratchet)
-            Identity.rememberRatchet(destHash, ratchet)
-        }
+        // Identity and ratchet are already stored above (before the should_add
+        // branch), matching Python's validate_announce.
 
         log("Learned path to ${destHash.toHexString()} via ${interfaceRef.name} (${packet.hops} hops)")
 
@@ -3506,8 +3556,15 @@ object Transport {
         // Spawned local client interfaces have OUT=False in Python (LocalInterface.py:417),
         // so they are excluded from announce retransmission. Local clients receive announces
         // through retransmitAnnounceToLocalClients() instead.
+        //
+        // If the packet has an attachedInterface set, this is a targeted emission
+        // (e.g., a path response replying to a specific requester). Restrict to that
+        // interface only, matching Python's `attached_interface` semantics in
+        // Transport.py:2781 where path-response announces carry the requesting
+        // interface as their attached_interface.
         val isLocal = destinations.any { it.hash.contentEquals(destinationHash) }
         val sourceMode = nextHopInterface(destinationHash)?.mode
+        val targetInterface = packet.attachedInterface
 
         for (iface in interfaces) {
             if (!iface.canSend ||
@@ -3515,6 +3572,11 @@ object Transport {
                 iface.hash.contentEquals(receivingInterface.hash) ||
                 isLocalClientInterface(iface)
             ) {
+                continue
+            }
+
+            // Targeted emission: skip all interfaces except the attached one.
+            if (targetInterface != null && !iface.hash.contentEquals(targetInterface.hash)) {
                 continue
             }
 

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2518,6 +2518,17 @@ object Transport {
         interfaceRef.rStatSnr?.let { packet.snr = it }
         interfaceRef.rStatQ?.let { packet.q = it }
 
+        // Log wire-side hops before the +1 increment for diagnostics.
+        // Pairs with the TX PACKET log in transmit() so hop progression
+        // across the mesh can be reconstructed from logs alone.
+        if (packet.packetType == PacketType.ANNOUNCE) {
+            log(
+                "RX ANNOUNCE: dest=${packet.destinationHash.toHexString()} " +
+                    "wire_hops=${packet.hops} iface=${interfaceRef.name} " +
+                    "ctx=${packet.context}",
+            )
+        }
+
         // Increment hop count (Python Transport.py:1319)
         packet.hops++
 
@@ -3237,9 +3248,15 @@ object Transport {
 
         retransmitAnnounceToLocalClients(packet, interfaceRef)
 
-        // Retransmit if transport is enabled OR announce came from a local client
+        // Retransmit if transport is enabled OR announce came from a local client.
+        // PATH_RESPONSE is excluded to match Python Transport.py:1741 — path responses
+        // are targeted replies to a specific requester and must not be rebroadcast as
+        // fresh announces, which would inflate hop counts and flood the mesh.
         val fromLocal = fromLocalClient(interfaceRef)
-        if ((transportEnabled || fromLocal) && packet.hops < TransportConstants.PATHFINDER_M) {
+        if ((transportEnabled || fromLocal) &&
+            packet.context != PacketContext.PATH_RESPONSE &&
+            packet.hops < TransportConstants.PATHFINDER_M
+        ) {
             queueAnnounceRetransmit(destHash, packet, interfaceRef, fromLocalClient = fromLocal)
         }
     }

--- a/rns-test/src/test/kotlin/network/reticulum/integration/AnnounceForwardingIntegrationTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/AnnounceForwardingIntegrationTest.kt
@@ -194,9 +194,14 @@ class AnnounceForwardingIntegrationTest {
         for (raw in packets) {
             val parsed = Packet.unpack(raw)
             if (parsed != null && parsed.packetType == PacketType.ANNOUNCE) {
-                // The hop count should match what Transport processed
-                // (incremented by 1 from inbound processing, then preserved in forwarding)
-                assertTrue(parsed.hops >= 0, "Hop count should be non-negative: ${parsed.hops}")
+                // The injected announce arrived on ExternalInterface with wire_hops=0
+                // (it was never sent over a real network, just handed to Transport).
+                // processInbound does one +1, and retransmitAnnounceToLocalClients
+                // preserves that value. So the local client must see hops=1.
+                // If this assertion starts failing with hops=2 or higher, the forward
+                // path is double-counting (the exact bug class we'd want to catch).
+                assertEquals(1, parsed.hops,
+                    "Forwarded announce should have hops=1 after one +1 at inbound")
                 println("  [Test] Hop count preserved: ${parsed.hops}")
                 return
             }


### PR DESCRIPTION
## Summary

Three Python-parity fixes surfaced while investigating a Columba hop-inflation report where two phones, both direct clients of a transport hub, observed each other at 4 hops via cached `PATH_RESPONSE` announces instead of 2 hops via fresh direct announces. The diagnostic RX logging in #33 let us localize the cause to path-table replacement behavior, which in turn surfaced a related ratchet-rotation latent bug. All three fixes land together because they compound: #3 only matters once #1 is strict enough to reject a re-announce.

### 1. Path-table replacement now checks emission time

Python `Transport.py:1620-1681` requires **both** conditions for an equal-or-better-hop replacement:

- `random_blob not in random_blobs` (replay protection), **and**
- `announce_emitted > path_timebase` (newer than anything we've seen)

The Kotlin port checked only the first. In practice this let stale `PATH_RESPONSE`-sourced announces (carrying a novel random_blob because they came from the cached announce, not the original) overwrite fresh direct paths. The worse-hop branch is similarly emission-time-aware in Python.

Adds two helpers:

- `timebaseFromRandomBlob(bytes)` — decodes the 5-byte big-endian emission timestamp from a 10-byte random_blob.
- `timebaseFromRandomBlobs(list)` — returns the max emission time across a list.

### 2. Path responses are targeted at the requesting interface

Python `Transport.py:2781` stores `attached_interface = requesting_interface` in the announce_table for path responses. When the queue drains, that field restricts emission to a single interface.

Kotlin previously routed cached path-response announces through `queueAnnounceRetransmit`, which broadcasts to every interface except the receiving one. That floods the mesh with a cached announce that should have been a targeted reply, and the stale `wire_hops = pathEntry.hops` value propagates outward — every downstream receiver +1s it and learns an inflated path.

Fix: `cachedPacket.attachedInterface = receivingInterface` before queueing, and teach `queueAnnounceRetransmit` to respect `packet.attachedInterface` by restricting emission to that single interface when set.

### 3. `Identity.remember` and ratchet storage are now unconditional on valid announces

Python stores both in `Identity.validate_announce` (Identity.py:457, 478), **before** Transport's path-learning. The Kotlin port had both inside the `shouldAdd` branch of `processAnnounce`. Under the old lenient replacement rule this rarely mattered in practice (equal-hop announces with novel random_blobs always passed should_add), but the stricter rule from #1 legitimately rejects re-announces that arrive within the same emission-second, which would silently drop ratchet rotation.

Moved both up to run immediately after `validateAnnounce()` succeeds, matching Python's ordering.

## Verification

- `./gradlew :rns-core:test :rns-test:test` — all 355 tests pass, including the Python-interop `RatchetRotationE2ETest` which specifically depends on fix #3 once fix #1 is live.
- Built and installed against the two-phones-via-one-hub Columba setup; monitoring the path-replacement behavior to confirm the stale-`PATH_RESPONSE` inflation cycle terminates.

## Risk

All three changes tighten behavior to match Python rather than loosening it. The main regression surface is:

- **Rate of legitimate path updates drops slightly** under the new replacement rule — two valid announces emitted within the same second will keep the first and reject the second. This is already Python's behavior and matters mainly for high-frequency re-announce scenarios. For normal mesh operation (seconds-to-minutes between announces) this is invisible.
- **Path-response queries now only answer the requester** — if a hidden consumer somewhere was relying on the accidental broadcast behavior to discover paths it didn't explicitly request, it would stop receiving them. No such consumer exists in the public codebase that I could find.

## Test plan

- [x] `./gradlew :rns-core:test :rns-test:test` all pass locally
- [x] `RatchetRotationE2ETest` specifically passes (regression test for fix #3)
- [x] Published to `mavenLocal` as `0.0.6-hops-diag2` and consumed by Columba build
- [ ] Two-phones-via-one-hub end-to-end: confirm stale `ctx=PATH_RESPONSE wire_hops=4` entries no longer appear for the peer phone's hash once a direct `wire_hops=1` announce has been seen
- [ ] Confirm path responses on phone A's `hl` interface are no longer replicated to phone A's `Auto` interface (targeted behavior observable only if phone has multiple interfaces)

Builds on #33.