### PR TITLE
Transport: decouple attached-interface targeting from receiving-interface skip

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -3582,17 +3582,31 @@ object Transport {
         val targetInterface = packet.attachedInterface
 
         for (iface in interfaces) {
-            if (!iface.canSend ||
-                !iface.online ||
-                iface.hash.contentEquals(receivingInterface.hash) ||
-                isLocalClientInterface(iface)
-            ) {
+            if (!iface.canSend || !iface.online || isLocalClientInterface(iface)) {
                 continue
             }
 
-            // Targeted emission: skip all interfaces except the attached one.
-            if (targetInterface != null && !iface.hash.contentEquals(targetInterface.hash)) {
-                continue
+            if (targetInterface != null) {
+                // Targeted emission (path response): emit ONLY on the attached
+                // interface, ignoring the receiving-interface skip. The skip
+                // rule exists to prevent broadcast announce loops; it doesn't
+                // apply when the caller has explicitly asked us to reply on a
+                // specific interface, and applying it here would silently
+                // drop the packet when targetInterface == receivingInterface
+                // (the common case for path_request handling where
+                // originalInterface is null and the fallback resolves to
+                // receivingInterface).
+                if (!iface.hash.contentEquals(targetInterface.hash)) {
+                    continue
+                }
+            } else {
+                // Broadcast retransmit: skip the interface we received on to
+                // avoid re-emitting an announce back to its source (Python
+                // loop-prevention via packet hashlist is the real guard;
+                // this is a cheap local optimization).
+                if (iface.hash.contentEquals(receivingInterface.hash)) {
+                    continue
+                }
             }
 
             if (AnnounceFilter.shouldForward(iface.mode, isLocal, sourceMode)) {


### PR DESCRIPTION
## Summary

Fixes a silent path-response drop in `queueAnnounceRetransmit` that Greptile flagged during its review of [#36](https://github.com/torlando-tech/reticulum-kt/pull/36). The bug landed in #34 along with the targeted-path-response change; #36's review made it visible against a combined diff that's no longer in scope on #36 now that the earlier PRs have merged. Fixing here against main.

## The bug

`processPathRequest` calls:

```kotlin
cachedPacket.attachedInterface = receivingInterface

queueAnnounceRetransmit(
    destinationHash,
    cachedPacket,
    originalInterface ?: receivingInterface,  // ← becomes the "skip" arg inside
)
```

When `originalInterface` is `null` — reachable when the interface that received the original announce is deregistered before a later path request arrives — the third argument falls back to `receivingInterface`. Inside `queueAnnounceRetransmit`, the emission loop has two filters:

```kotlin
for (iface in interfaces) {
    if (iface.hash.contentEquals(receivingInterface.hash)) continue       // skip-on-receiving
    if (targetInterface != null && !iface.hash.contentEquals(targetInterface.hash)) continue  // target-restrict
    // emit
}
```

With both `receivingInterface` and `targetInterface` resolving to the same interface, no `iface` passes both conditions. The path response is silently dropped.

## The fix

Separate the two semantics:

- **Targeted emission** (path response via `attachedInterface`): emit only on that interface, ignoring the receiving-interface skip. The skip is a broadcast-loop prevention measure; it doesn't apply to a reply explicitly aimed at a specific peer.
- **Broadcast retransmit** (no `attachedInterface`): skip the receiving interface as before.

Code diff is small (one `if/else` split with intent-documenting comments).

## Verification

- `./gradlew :rns-core:test :rns-test:test` — all 355 tests pass.
- Behavioral conformance suite in reticulum-conformance (`tests/behavioral/test_*.py`) continues to pass against the fixed Transport on `--impl=kotlin`. The stale-PATH_RESPONSE scenario specifically exercises the receiving-interface + attachedInterface interaction.

## Why this hasn't been hit by existing tests

The bug triggers only when `originalInterface` is `null`. In normal operation that requires an interface to be registered, cache an announce, then deregister before a peer requests the path for that destination. None of the byte-level nor behavioral conformance tests currently exercise interface churn between announce-cache and path-request; a targeted regression test would be a good follow-up (along the lines of "register iface, inject announce, detach iface, re-register a new iface, inject path request, assert response emitted on the new iface").

Fixes the P1 finding on #36.