### PR TITLE
Transport: don't HEADER_2-wrap link DATA on multi-hop paths

### DIFF
--- a/conformance-bridge/src/main/kotlin/WireTcp.kt
+++ b/conformance-bridge/src/main/kotlin/WireTcp.kt
@@ -24,6 +24,7 @@
  * a server with a client.
  */
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import network.reticulum.Reticulum
@@ -34,10 +35,16 @@ import network.reticulum.identity.Identity
 import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.tcp.TCPServerInterface
 import network.reticulum.interfaces.toRef
+import network.reticulum.link.Link
+import network.reticulum.link.LinkConstants
 import network.reticulum.transport.Transport
 import java.io.File
 import java.net.ServerSocket
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Handle-indexed state.
@@ -55,6 +62,16 @@ private class WireInstance(
     val serverIface: TCPServerInterface? = null,
     val clientIface: TCPClientInterface? = null,
     val destinations: MutableList<Pair<Identity, Destination>> = mutableListOf(),
+    // Link bookkeeping — used by wire_listen / wire_link_* commands below.
+    val listeners: ConcurrentHashMap<String, Listener> = ConcurrentHashMap(),
+    val outLinks: ConcurrentHashMap<String, Link> = ConcurrentHashMap(),
+)
+
+/** Per-destination receive buffer for incoming link data. */
+private class Listener(
+    val destination: Destination,
+    val identity: Identity,
+    val recvBuffer: ConcurrentLinkedDeque<ByteArray> = ConcurrentLinkedDeque(),
 )
 
 private val wireInstances = mutableMapOf<String, WireInstance>()
@@ -255,6 +272,135 @@ fun handleWireCommand(command: String, p: JsonObject): JsonObject = when (comman
         } else {
             result("found" to boolVal(false))
         }
+    }
+
+    "wire_listen" -> {
+        val handle = p.str("handle")
+        val appName = p.str("app_name")
+        val aspectsJson = p.get("aspects")?.asJsonArray
+        val aspects: Array<String> = aspectsJson?.map { it.asString }?.toTypedArray() ?: emptyArray()
+
+        val inst = wireInstances[handle]
+            ?: throw IllegalArgumentException("Unknown handle: $handle")
+
+        val identity = Identity.create()
+        val destination = Destination.create(
+            identity = identity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = appName,
+            aspects = aspects,
+        )
+
+        val listener = Listener(destination, identity)
+        // On link established, wire a packet callback into the listener's buffer.
+        destination.setLinkEstablishedCallback { linkObj ->
+            val link = linkObj as? Link ?: return@setLinkEstablishedCallback
+            link.setPacketCallback { data, _packet ->
+                listener.recvBuffer.add(data.copyOf())
+            }
+        }
+
+        // Announce so the sender peer can learn a path via the transport.
+        destination.announce()
+
+        inst.listeners[destination.hash.toHex()] = listener
+        // Keep strong refs so neither gets GC'd.
+        inst.destinations.add(identity to destination)
+
+        result(
+            "destination_hash" to hexVal(destination.hash),
+            "identity_hash" to hexVal(identity.hash),
+        )
+    }
+
+    "wire_link_open" -> {
+        val handle = p.str("handle")
+        val destHash = p.hex("destination_hash")
+        val appName = p.str("app_name")
+        val aspectsJson = p.get("aspects")?.asJsonArray
+        val aspects: Array<String> = aspectsJson?.map { it.asString }?.toTypedArray() ?: emptyArray()
+        val timeoutMs = p.get("timeout_ms")?.asInt ?: 10000
+
+        val inst = wireInstances[handle]
+            ?: throw IllegalArgumentException("Unknown handle: $handle")
+
+        val identity = Identity.recall(destHash)
+            ?: throw IllegalStateException(
+                "No identity known for ${destHash.toHex()}; " +
+                    "ensure an announce was received first.",
+            )
+
+        val outDest = Destination.create(
+            identity = identity,
+            direction = DestinationDirection.OUT,
+            type = DestinationType.SINGLE,
+            appName = appName,
+            aspects = aspects,
+        )
+
+        val latch = CountDownLatch(1)
+        val link = Link.create(
+            destination = outDest,
+            establishedCallback = { latch.countDown() },
+            closedCallback = { latch.countDown() },
+        )
+
+        if (!latch.await(timeoutMs.toLong(), TimeUnit.MILLISECONDS)) {
+            throw IllegalStateException(
+                "Link to ${destHash.toHex()} did not become active within ${timeoutMs}ms",
+            )
+        }
+        if (link.status != LinkConstants.ACTIVE) {
+            throw IllegalStateException(
+                "Link to ${destHash.toHex()} closed before becoming active (status=${link.status})",
+            )
+        }
+
+        val linkIdHex = link.linkId.toHex()
+        inst.outLinks[linkIdHex] = link
+        result("link_id" to JsonPrimitive(linkIdHex))
+    }
+
+    "wire_link_send" -> {
+        val handle = p.str("handle")
+        val linkIdHex = p.str("link_id")
+        val payload = p.hex("data")
+
+        val inst = wireInstances[handle]
+            ?: throw IllegalArgumentException("Unknown handle: $handle")
+
+        val link = inst.outLinks[linkIdHex]
+            ?: throw IllegalArgumentException("Unknown link_id: $linkIdHex")
+
+        val ok = link.send(payload)
+        result("sent" to boolVal(ok))
+    }
+
+    "wire_link_poll" -> {
+        val handle = p.str("handle")
+        val destHashHex = p.str("destination_hash")
+        val timeoutMs = p.get("timeout_ms")?.asInt ?: 5000
+
+        val inst = wireInstances[handle]
+            ?: throw IllegalArgumentException("Unknown handle: $handle")
+
+        val listener = inst.listeners[destHashHex]
+            ?: throw IllegalArgumentException(
+                "No listener registered for destination_hash=$destHashHex",
+            )
+
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline && listener.recvBuffer.isEmpty()) {
+            Thread.sleep(50)
+        }
+
+        val arr = JsonArray()
+        while (true) {
+            val item = listener.recvBuffer.pollFirst() ?: break
+            arr.add(item.toHex())
+        }
+        result("packets" to arr)
     }
 
     "wire_stop" -> {

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -1048,22 +1048,43 @@ object Transport {
     /**
      * Register a path entry for a link so that outbound packets use the correct interface.
      * This should be called when a link is established with the receiving interface hash.
+     *
+     * The `hops` parameter is accepted for diagnostic/logging purposes (callers pass the
+     * traversed hop count of the establishment packet), but the stored path entry always
+     * uses `hops = 1` so that [outbound] takes the direct-transmit branch.
+     *
+     * Rationale: Python RNS never adds link_id entries to its path_table. Link DATA
+     * packets are sent as HEADER_1 with destination_hash = linkId over the link's
+     * `attached_interface`. Intermediate transport nodes forward them by looking up
+     * `linkId` in their own [linkTable], not by HEADER_2 transport routing.
+     *
+     * Storing `hops = packet.hops` (> 1 for multi-hop establishment) would cause
+     * [outbound] to HEADER_2-wrap link DATA with `transport_id = linkId`, which no
+     * transport node's identity matches, so the intermediate drops the packet as
+     * "in transport for other transport instance" (see Python `Transport.py:1428`).
+     * Forcing `hops = 1` here keeps outgoing link DATA on the HEADER_1 path, where
+     * the transport's linkTable lookup does the forwarding the way Python does.
      */
     fun registerLinkPath(
         linkId: ByteArray,
         receivingInterfaceHash: ByteArray,
-        hops: Int = 1,
+        @Suppress("UNUSED_PARAMETER") hops: Int = 1,
     ) {
         val now = System.currentTimeMillis()
         val entry =
             PathEntry(
                 timestamp = now,
-                nextHop = linkId, // Use linkId as nextHop (will route to link)
-                hops = hops,
+                // Transport.outbound with hops <= 1 doesn't consult nextHop for the
+                // wire bytes (it transmits packet.raw as-is), so the exact value is
+                // only used for diagnostics. Keep it as linkId for symmetry.
+                nextHop = linkId,
+                // ALWAYS 1, even when the actual establishment was multi-hop. See
+                // rationale above.
+                hops = 1,
                 expires = now + TransportConstants.PATHFINDER_E,
                 randomBlobs = mutableListOf(),
                 receivingInterfaceHash = receivingInterfaceHash,
-                announcePacketHash = linkId, // Use linkId as placeholder
+                announcePacketHash = linkId,
             )
         pathTable[linkId.toKey()] = entry
         pathStore?.upsertPath(linkId, entry)

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -1051,19 +1051,24 @@ object Transport {
      *
      * The `hops` parameter is accepted for diagnostic/logging purposes (callers pass the
      * traversed hop count of the establishment packet), but the stored path entry always
-     * uses `hops = 1` so that [outbound] takes the direct-transmit branch.
+     * uses `hops = 1`.
      *
-     * Rationale: Python RNS never adds link_id entries to its path_table. Link DATA
-     * packets are sent as HEADER_1 with destination_hash = linkId over the link's
-     * `attached_interface`. Intermediate transport nodes forward them by looking up
-     * `linkId` in their own [linkTable], not by HEADER_2 transport routing.
-     *
-     * Storing `hops = packet.hops` (> 1 for multi-hop establishment) would cause
-     * [outbound] to HEADER_2-wrap link DATA with `transport_id = linkId`, which no
-     * transport node's identity matches, so the intermediate drops the packet as
+     * Link DATA packets must never be HEADER_2-wrapped: their `destination_hash` IS the
+     * `linkId`, which no transport node's identity matches. Any HEADER_2 wrap that uses
+     * `nextHop = linkId` as `transport_id` is dropped by the intermediate transport as
      * "in transport for other transport instance" (see Python `Transport.py:1428`).
-     * Forcing `hops = 1` here keeps outgoing link DATA on the HEADER_1 path, where
-     * the transport's linkTable lookup does the forwarding the way Python does.
+     *
+     * This is enforced by TWO checks — belt and suspenders:
+     *  1. `hops = 1` here, so [outbound] won't take the `hops > 1` HEADER_2 branch.
+     *  2. An `isLink` guard in [outbound] that also skips the shared-instance HEADER_2
+     *     wrap branch (`hops == 1 + isConnectedToSharedInstance`), which would
+     *     otherwise still re-wrap with `nextHop = linkId`.
+     *
+     * Net effect: link DATA always goes on the HEADER_1 path. Intermediate transports
+     * (both Python and Kotlin) forward link DATA by looking `linkId` up in their own
+     * [linkTable], which is populated during LINKREQUEST / LRPROOF traversal. Python
+     * RNS never adds link_id entries to its `path_table` at all — this is the closest
+     * Kotlin-side equivalent given the existing PathEntry-centric routing primitives.
      */
     fun registerLinkPath(
         linkId: ByteArray,
@@ -1074,12 +1079,11 @@ object Transport {
         val entry =
             PathEntry(
                 timestamp = now,
-                // Transport.outbound with hops <= 1 doesn't consult nextHop for the
-                // wire bytes (it transmits packet.raw as-is), so the exact value is
-                // only used for diagnostics. Keep it as linkId for symmetry.
+                // `nextHop` is not read by [outbound] on the paths link DATA takes
+                // (direct transmit uses `packet.raw`), but it's logged and persisted,
+                // so keep it as linkId for symmetry with the entry's key.
                 nextHop = linkId,
-                // ALWAYS 1, even when the actual establishment was multi-hop. See
-                // rationale above.
+                // Always 1 — see doc above for why.
                 hops = 1,
                 expires = now + TransportConstants.PATHFINDER_E,
                 randomBlobs = mutableListOf(),
@@ -2921,21 +2925,31 @@ object Transport {
                 //                                            a caller supplies one, we don't
                 //                                            double-wrap — identical to Python)
                 val isHeader1 = packet.headerType == HeaderType.HEADER_1
+                // Link DATA packets must never be HEADER_2-wrapped: their
+                // destination_hash IS the linkId, which no transport's
+                // identity matches, so any HEADER_2 wrap with `nextHop =
+                // linkId` as transport_id is dropped by the intermediate
+                // as "in transport for other transport instance".
+                // Intermediate transports (Python and Kotlin) forward link
+                // DATA by looking the linkId up in their own link_table —
+                // that lookup requires HEADER_1 so it actually runs.
+                val isLink = packet.destinationType == DestinationType.LINK
                 when {
-                    pathEntry.hops > 1 && isHeader1 -> {
+                    pathEntry.hops > 1 && isHeader1 && !isLink -> {
                         val transportRaw = insertIntoTransport(packet, pathEntry.nextHop)
                         transmit(outboundInterface, transportRaw)
                         sent = true
                     }
-                    pathEntry.hops == 1 && isConnectedToSharedInstance && isHeader1 -> {
+                    pathEntry.hops == 1 && isConnectedToSharedInstance && isHeader1 && !isLink -> {
                         // Python Transport.py:993-1011: a 1-hop destination behind a shared
                         // instance still needs transport wrapping so the instance forwards.
                         val transportRaw = insertIntoTransport(packet, pathEntry.nextHop)
                         transmit(outboundInterface, transportRaw)
                         sent = true
                     }
-                    pathEntry.hops <= 1 -> {
-                        // Direct transmission (hops==0 for self/local-client, hops==1 direct)
+                    pathEntry.hops <= 1 || isLink -> {
+                        // Direct transmission (hops==0 for self/local-client, hops==1 direct,
+                        // or any Link destination — see isLink comment above).
                         transmit(outboundInterface, packedData)
                         sent = true
                     }

--- a/rns-core/src/test/kotlin/network/reticulum/storage/PathStoreWriteThroughTest.kt
+++ b/rns-core/src/test/kotlin/network/reticulum/storage/PathStoreWriteThroughTest.kt
@@ -68,11 +68,15 @@ class PathStoreWriteThroughTest {
             val linkId = ByteArray(16) { it.toByte() }
             val interfaceHash = ByteArray(16) { 0xFF.toByte() }
 
+            // `hops = 2` is accepted for call-site compatibility but the
+            // stored entry always carries hops = 1 so that outbound link
+            // DATA packets don't get HEADER_2-wrapped with the linkId as
+            // transport_id. See Transport.registerLinkPath doc comment.
             Transport.registerLinkPath(linkId, interfaceHash, hops = 2)
 
             store.data.size shouldBe 1
             store.data[linkId.toKey()] shouldNotBe null
-            store.data[linkId.toKey()]!!.hops shouldBe 2
+            store.data[linkId.toKey()]!!.hops shouldBe 1
         }
 
         @Test


### PR DESCRIPTION
## Summary

Fixes a silent failure mode where multi-hop Link DATA packets are
dropped by intermediate transport nodes, observed in production as
LXMF DIRECT deliveries falling back to PROPAGATED even when the
direct route is fully reachable.

## Root cause

`Transport.registerLinkPath` stored the link's PathEntry with
`nextHop = linkId` and `hops = packet.hops`. When the link was
established across one or more transports — i.e. \`packet.hops > 1\` —
`Transport.outbound` took the multi-hop branch for later link DATA
packets, HEADER_2-wrapping them with `transport_id = linkId`. No
transport's own identity matches the linkId, so every intermediate
dropped the packet as "in transport for other transport instance"
(Python RNS's log phrase for the HEADER_2 `transport_id` mismatch
check).

Observed traversal (Columba→rnsd→Sideband):

```
[rnsd] Link request proof validated for transport via TCPInterface[...Columba...]
[rnsd] Ignored packet <...> in transport for other transport instance
[rnsd] Ignored packet <...> in transport for other transport instance
[rnsd] Ignored packet <...> in transport for other transport instance
```

Link handshake completes, link activates, then every DATA packet is
silently dropped.

## Fix

Force `hops = 1` in the stored PathEntry regardless of the actual
establishment hop count. That routes `Transport.outbound` into the
direct-transmit branch for link DATA, emitting HEADER_1 with
`destination_hash = linkId`.

This matches Python RNS's behavior: Python never adds link_id
entries to its `path_table` at all — link DATA packets are HEADER_1,
and intermediate transport nodes forward them by looking up the
destination_hash in their own `link_table` (populated during the
LINKREQUEST / LRPROOF traversal). reticulum-kt's `Transport.linkTable`
already handles the inbound-side lookup correctly; this fix lets
outbound stay HEADER_1 so that lookup actually runs.

## Conformance tests

This PR also adds `wire_listen`, `wire_link_open`, `wire_link_send`,
`wire_link_poll` to the `conformance-bridge` so the matching
reticulum-conformance PR's new 3-peer multi-hop link suite can drive
Kotlin peers as senders / receivers / transports. The suite is
parametrized across every (sender_impl, transport_impl,
receiver_impl) triple.

**Results with fix applied (parametrized --impl=kotlin run, 3 tests × 8 triples):**
- 16 pass, including `kotlin → reference → reference` (the exact Columba → rnsd → Sideband topology, across single-packet and 5-packet burst variants)
- 8 xfail: every variant where Kotlin is the receiver on multi-hop. Those fail due to a *separate* receive-side reliability bug (packet loss under burst), which is not addressed here. Follow-up issue to be filed.

## Coordination

Pairs with torlando-tech/reticulum-conformance#[pending] which adds
the test harness / test file. Same stacked-PR pattern as the
behavioral and wire-interop PRs: land this first (Kotlin bridge
needs the new wire_link_* commands) before merging the conformance
tests.

## Test plan

- [x] Local: `./gradlew :conformance-bridge:shadowJar` clean build
- [x] Local: `pytest tests/wire/test_link_multihop.py -v --impl=kotlin` -> 16 pass / 8 xfail / 0 fail
- [x] Local: Columba scenario stable across 3 back-to-back runs (9/9 test invocations pass)
- [ ] CI conformance job green
- [ ] Greptile review: 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)