### PR TITLE
Expose Interface.online as StateFlow for reactive observation

### DIFF
--- a/conformance-bridge/src/main/kotlin/BehavioralTransport.kt
+++ b/conformance-bridge/src/main/kotlin/BehavioralTransport.kt
@@ -45,7 +45,7 @@ class MockInterface(
     private val txQueue = ConcurrentLinkedDeque<ByteArray>()
 
     override fun start() {
-        online.set(true)
+        setOnline(true)
     }
 
     override fun processOutgoing(data: ByteArray) {

--- a/rns-interfaces/build.gradle.kts
+++ b/rns-interfaces/build.gradle.kts
@@ -19,8 +19,8 @@ val kotestVersion: String by project
 dependencies {
     api(project(":rns-core"))
 
-    // Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+    // Coroutines — `api` because Interface.online: StateFlow<Boolean> is a public API
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
     // Testing
     testImplementation(kotlin("test"))

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/Interface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/Interface.kt
@@ -1,5 +1,8 @@
 package network.reticulum.interfaces
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import network.reticulum.common.ByteArrayKey
 import network.reticulum.common.InterfaceMode
 import network.reticulum.common.RnsConstants
@@ -121,8 +124,37 @@ abstract class Interface(
     /** Total bytes transmitted. */
     val txBytes = AtomicLong(0)
 
-    /** Whether this interface is currently online. */
-    val online = AtomicBoolean(false)
+    private val _online = MutableStateFlow(false)
+
+    /**
+     * Whether this interface is currently online, exposed as a [StateFlow]
+     * so observers can react to transitions (e.g., UI state, handshake
+     * completion in [network.reticulum.interfaces.rnode.RNodeInterface]
+     * which flips to online several seconds after registration).
+     *
+     * Scalar reads use `online.value`; to observe, collect the flow.
+     *
+     * The exposed type is the read-only [StateFlow]; mutation happens
+     * through [setOnline] (the backing [MutableStateFlow] stays private).
+     */
+    val online: StateFlow<Boolean> = _online.asStateFlow()
+
+    /**
+     * Update the online state. Public so subclasses (and parents managing
+     * spawned peers) can flip the flag during their lifecycle.
+     *
+     * Public rather than protected because some subclass hierarchies —
+     * [network.reticulum.interfaces.nearby.NearbyInterface] tearing down
+     * its spawned [network.reticulum.interfaces.nearby.NearbyPeerInterface]
+     * peers, and the conformance bridge's `MockInterface` in a separate
+     * module — need cross-instance or cross-module write access that JVM
+     * protected semantics won't allow. External Columba-side consumers
+     * read via the [online] StateFlow; they have no incentive to call
+     * this, and doing so would fight with the owning subclass.
+     */
+    fun setOnline(value: Boolean) {
+        _online.value = value
+    }
 
     /** Whether this interface has been detached (shutdown). */
     val detached = AtomicBoolean(false)
@@ -209,7 +241,7 @@ abstract class Interface(
      * Implementations should deframe the data and call [processIncoming].
      */
     protected fun processIncoming(data: ByteArray) {
-        if (!online.get() || detached.get()) return
+        if (!online.value || detached.get()) return
 
         rxBytes.addAndGet(data.size.toLong())
         parentInterface?.rxBytes?.addAndGet(data.size.toLong())
@@ -226,7 +258,7 @@ abstract class Interface(
      * Stop and detach the interface.
      */
     open fun detach() {
-        online.set(false)
+        setOnline(false)
         detached.set(true)
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/InterfaceAdapter.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/InterfaceAdapter.kt
@@ -17,7 +17,7 @@ class InterfaceAdapter private constructor(
     override val hash: ByteArray = iface.getHash()
     override val canSend: Boolean = iface.canSend
     override val canReceive: Boolean = iface.canReceive
-    override val online: Boolean get() = iface.online.get()
+    override val online: Boolean get() = iface.online.value
     override val rxBytes: Long get() = iface.rxBytes.get()
     override val txBytes: Long get() = iface.txBytes.get()
     override val mode: InterfaceMode get() = iface.mode

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterface.kt
@@ -134,7 +134,7 @@ class AutoInterface(
             // Start peer management job
             startPeerManagementJob()
 
-            online.set(true)
+            setOnline(true)
             log("AutoInterface started on ${linkLocalAddresses.size} interface(s)")
         } catch (e: Exception) {
             log("Failed to start AutoInterface: ${e.message}")
@@ -147,7 +147,7 @@ class AutoInterface(
         if (!running.getAndSet(false)) return
 
         log("Detaching AutoInterface...")
-        online.set(false)
+        setOnline(false)
         detached.set(true)
 
         // Cancel all coroutines

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterfacePeer.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/auto/AutoInterfacePeer.kt
@@ -47,7 +47,7 @@ class AutoInterfacePeer(
             outboundSocket = DatagramSocket().apply {
                 reuseAddress = true
             }
-            online.set(true)
+            setOnline(true)
             log("Started peer connection to $targetAddress")
         } catch (e: Exception) {
             log("Failed to start peer connection: ${e.message}")
@@ -59,7 +59,7 @@ class AutoInterfacePeer(
         if (!running.getAndSet(false)) return
 
         log("Detaching peer connection to $targetAddress")
-        online.set(false)
+        setOnline(false)
         detached.set(true)
 
         try {
@@ -72,8 +72,8 @@ class AutoInterfacePeer(
 
     override fun processOutgoing(data: ByteArray) {
         val socket = outboundSocket
-        if (socket == null || !online.get() || detached.get()) {
-            log("Cannot send: socket=${socket != null}, online=${online.get()}, detached=${detached.get()}")
+        if (socket == null || !online.value || detached.get()) {
+            log("Cannot send: socket=${socket != null}, online=${online.value}, detached=${detached.get()}")
             return
         }
 
@@ -95,7 +95,7 @@ class AutoInterfacePeer(
      * This handles the inbound data flow.
      */
     fun handleIncomingData(data: ByteArray) {
-        if (!online.get() || detached.get()) return
+        if (!online.value || detached.get()) return
         processIncoming(data)
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -81,7 +81,7 @@ class BLEInterface(
      * disconnections, and periodic cleanup.
      */
     override fun start() {
-        online.set(true)
+        setOnline(true)
         log("start() called — launching BLE coroutines")
 
         // Start advertising (peripheral role)
@@ -228,7 +228,7 @@ class BLEInterface(
             val existingAddress = identityToAddress[identityHex]
             if (existingAddress != null && existingAddress != address) {
                 val existing = peers[identityHex]
-                if (existing != null && existing.online.get() && !existing.detached.get()) {
+                if (existing != null && existing.online.value && !existing.detached.get()) {
                     // Existing connection is healthy — keep it, reject new
                     log("Duplicate identity ${identityHex.take(8)}: keeping existing at ${existingAddress.takeLast(8)}, rejecting outgoing ${address.takeLast(8)}")
                     reconnectBackoff[address] = System.currentTimeMillis() + 30_000
@@ -331,7 +331,7 @@ class BLEInterface(
             val existingAddress = identityToAddress[identityHex]
             if (existingAddress != null && existingAddress != address) {
                 val existing = peers[identityHex]
-                if (existing != null && existing.online.get() && !existing.detached.get()) {
+                if (existing != null && existing.online.value && !existing.detached.get()) {
                     // Existing connection is healthy — keep it, reject incoming
                     log("Duplicate identity ${identityHex.take(8)}: keeping existing at ${existingAddress.takeLast(8)}, rejecting incoming ${address.takeLast(8)}")
                     reconnectBackoff[address] = System.currentTimeMillis() + 30_000
@@ -586,7 +586,7 @@ class BLEInterface(
      * Runs every 30 seconds.
      */
     private suspend fun periodicCleanup() {
-        while (online.get() && !detached.get()) {
+        while (online.value && !detached.get()) {
             delay(30_000)
             val now = System.currentTimeMillis()
 
@@ -609,7 +609,7 @@ class BLEInterface(
      * Flow: graceful disconnect -> grace period -> force teardown -> blacklist.
      */
     private suspend fun zombieDetectionLoop() {
-        while (online.get() && !detached.get()) {
+        while (online.value && !detached.get()) {
             delay(BLEConstants.ZOMBIE_CHECK_INTERVAL_MS)
             val now = System.currentTimeMillis()
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
@@ -85,7 +85,7 @@ class BLEPeerInterface(
      * Called by [BLEInterface] after spawning and registering with Transport.
      */
     fun startReceiving() {
-        online.set(true)
+        setOnline(true)
 
         receiveJob = scope.launch { receiveLoop() }
         keepaliveJob = scope.launch { keepaliveLoop() }
@@ -99,9 +99,9 @@ class BLEPeerInterface(
     private fun startRssiPolling() {
         if (!isOutgoing) return
         rssiJob = scope.launch {
-            while (online.get() && !detached.get()) {
+            while (online.value && !detached.get()) {
                 delay(10_000)
-                if (!online.get() || detached.get()) break
+                if (!online.value || detached.get()) break
                 try {
                     currentRssi = connection.readRemoteRssi()
                 } catch (_: Exception) {
@@ -118,7 +118,7 @@ class BLEPeerInterface(
     private suspend fun receiveLoop() {
         try {
             connection.receivedFragments.collect { fragment ->
-                if (!online.get() || detached.get()) return@collect
+                if (!online.value || detached.get()) return@collect
 
                 // Any traffic resets the zombie detection timer
                 lastTrafficReceived = System.currentTimeMillis()
@@ -160,7 +160,7 @@ class BLEPeerInterface(
      * so we bridge with runBlocking(Dispatchers.IO).
      */
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) return
+        if (!online.value || detached.get()) return
 
         try {
             val fragments = fragmenter.fragment(data)
@@ -188,10 +188,10 @@ class BLEPeerInterface(
      */
     private suspend fun keepaliveLoop() {
         try {
-            while (online.get() && !detached.get()) {
+            while (online.value && !detached.get()) {
                 delay(BLEConstants.KEEPALIVE_INTERVAL_MS)
 
-                if (!online.get() || detached.get()) break
+                if (!online.value || detached.get()) break
 
                 try {
                     connection.sendFragment(byteArrayOf(BLEConstants.KEEPALIVE_BYTE))
@@ -200,7 +200,7 @@ class BLEPeerInterface(
                     log("Keepalive failed, grace period...")
                     delay(BLEConstants.KEEPALIVE_INTERVAL_MS)
 
-                    if (!online.get() || detached.get()) break
+                    if (!online.value || detached.get()) break
 
                     try {
                         connection.sendFragment(byteArrayOf(BLEConstants.KEEPALIVE_BYTE))
@@ -252,7 +252,7 @@ class BLEPeerInterface(
 
     override fun detach() {
         if (detached.getAndSet(true)) return
-        online.set(false)
+        setOnline(false)
 
         // Cancel coroutines
         receiveJob?.cancel()

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/i2p/I2PInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/i2p/I2PInterface.kt
@@ -160,7 +160,7 @@ class I2PInterface(
         // We go online even before tunnels are up — the server socket is ready
         // Peers will connect once their tunnels establish
         if (!connectable && peers.isEmpty()) {
-            online.set(true)
+            setOnline(true)
         }
     }
 
@@ -201,7 +201,7 @@ class I2PInterface(
                     i2pController.setupServerTunnel(name, bindPort)
                 }
                 b32 = addr
-                online.set(true)
+                setOnline(true)
                 log("I2P endpoint ready: $addr.b32.i2p")
                 // Tunnel is up — wait until we're detached
                 while (!detached.get()) {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/i2p/I2PInterfacePeer.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/i2p/I2PInterfacePeer.kt
@@ -126,7 +126,7 @@ class I2PInterfacePeer(
         if (connectedSocket != null) {
             // Inbound connection — socket already connected
             socket = connectedSocket
-            online.set(true)
+            setOnline(true)
             neverConnected.set(false)
 
             configureSocket(socket!!)
@@ -178,7 +178,7 @@ class I2PInterfacePeer(
                 socket = streamConn.socket
                 configureSocket(streamConn.socket)
 
-                online.set(true)
+                setOnline(true)
                 neverConnected.set(false)
                 tunnelState = TUNNEL_STATE_ACTIVE
 
@@ -253,7 +253,7 @@ class I2PInterfacePeer(
         val buffer = ByteArray(4096)
 
         try {
-            while (ioScope.isActive && online.get() && !detached.get()) {
+            while (ioScope.isActive && online.value && !detached.get()) {
                 val bytesRead = withContext(Dispatchers.IO) {
                     input.read(buffer)
                 }
@@ -269,7 +269,7 @@ class I2PInterfacePeer(
                     }
                 } else if (bytesRead == -1) {
                     // Connection closed
-                    online.set(false)
+                    setOnline(false)
                     break
                 }
             }
@@ -277,7 +277,7 @@ class I2PInterfacePeer(
             // Normal shutdown
         } catch (e: IOException) {
             if (!detached.get()) {
-                online.set(false)
+                setOnline(false)
             }
         }
 
@@ -302,7 +302,7 @@ class I2PInterfacePeer(
      */
     private suspend fun readWatchdog(sock: Socket) {
         try {
-            while (ioScope.isActive && online.get() && !detached.get()) {
+            while (ioScope.isActive && online.value && !detached.get()) {
                 delay(1000)
 
                 val now = System.currentTimeMillis()
@@ -349,7 +349,7 @@ class I2PInterfacePeer(
     }
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) {
+        if (!online.value || detached.get()) {
             throw IllegalStateException("Interface is not online")
         }
 
@@ -388,14 +388,14 @@ class I2PInterfacePeer(
         if (isInitiator && !detached.get()) {
             log("Unrecoverable error, tearing down")
         }
-        online.set(false)
+        setOnline(false)
         closeSocket(socket)
         parentI2P.peerDisconnected(this)
     }
 
     override fun detach() {
         if (detached.getAndSet(true)) return
-        online.set(false)
+        setOnline(false)
 
         readJob?.cancel()
         watchdogJob?.cancel()

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalClientInterface.kt
@@ -194,7 +194,7 @@ class LocalClientInterface : Interface {
             // Unix sockets don't support TCP options, ignore
         }
 
-        online.set(true)
+        setOnline(true)
 
         readJob = ioScope.launch {
             readLoop()
@@ -214,7 +214,7 @@ class LocalClientInterface : Interface {
                 throw IllegalStateException("No socket path or TCP port configured")
             }
 
-            online.set(true)
+            setOnline(true)
             neverConnected.set(false)
 
             startWithSocket()
@@ -268,7 +268,7 @@ class LocalClientInterface : Interface {
         try {
             var attempts = 0
 
-            while (!online.get()) {
+            while (!online.value) {
                 attempts++
                 delay(RECONNECT_WAIT)
 
@@ -284,7 +284,7 @@ class LocalClientInterface : Interface {
                 }
             }
 
-            if (!neverConnected.get() && online.get()) {
+            if (!neverConnected.get() && online.value) {
                 log("Reconnected successfully")
             }
         } finally {
@@ -298,7 +298,7 @@ class LocalClientInterface : Interface {
         log("Read loop started")
 
         try {
-            while (online.get() && !detached.get()) {
+            while (online.value && !detached.get()) {
                 val sock = socket ?: break
                 // Blocking read wrapped in IO dispatcher
                 val bytesRead = withContext(Dispatchers.IO) {
@@ -312,7 +312,7 @@ class LocalClientInterface : Interface {
                 } else if (bytesRead == -1) {
                     // Connection closed
                     log("Connection closed by remote (read returned -1)")
-                    online.set(false)
+                    setOnline(false)
 
                     if (isSharedInstanceClient.get() && !detached.get()) {
                         log("Connection closed, attempting to reconnect...")
@@ -323,13 +323,13 @@ class LocalClientInterface : Interface {
                     break
                 }
             }
-            log("Read loop exited normally (online=${online.get()}, detached=${detached.get()})")
+            log("Read loop exited normally (online=${online.value}, detached=${detached.get()})")
         } catch (e: CancellationException) {
             // Normal cancellation, don't log as error
         } catch (e: IOException) {
             if (!detached.get()) {
                 log("IOException in read loop: ${e.message}")
-                online.set(false)
+                setOnline(false)
 
                 if (isSharedInstanceClient.get()) {
                     log("Connection error: ${e.message}, attempting to reconnect...")
@@ -349,8 +349,8 @@ class LocalClientInterface : Interface {
     }
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) {
-            log("processOutgoing called but interface not online (online=${online.get()}, detached=${detached.get()})")
+        if (!online.value || detached.get()) {
+            log("processOutgoing called but interface not online (online=${online.value}, detached=${detached.get()})")
             throw IllegalStateException("Interface is not online")
         }
 
@@ -371,7 +371,7 @@ class LocalClientInterface : Interface {
             parentInterface?.txBytes?.addAndGet(framedData.size.toLong())
 
         } catch (e: IOException) {
-            online.set(false)
+            setOnline(false)
 
             if (isSharedInstanceClient.get() && !detached.get()) {
                 log("Send error: ${e.message}, will reconnect...")
@@ -391,7 +391,7 @@ class LocalClientInterface : Interface {
 
     override fun detach() {
         if (detached.getAndSet(true)) return
-        online.set(false)
+        setOnline(false)
 
         // Cancel coroutines first
         readJob?.cancel()

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalServerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalServerInterface.kt
@@ -208,7 +208,7 @@ class LocalServerInterface : Interface {
                 throw IllegalStateException("No socket path or TCP port configured")
             }
 
-            online.set(true)
+            setOnline(true)
 
             acceptJob = ioScope.launch {
                 acceptLoop()
@@ -266,7 +266,7 @@ class LocalServerInterface : Interface {
     }
 
     private suspend fun acceptLoop() {
-        while (online.get() && !detached.get()) {
+        while (online.value && !detached.get()) {
             try {
                 // Blocking accept wrapped in IO dispatcher
                 val socket = withContext(Dispatchers.IO) {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyInterface.kt
@@ -78,12 +78,12 @@ class NearbyInterface(
                 // driver.start() suspends until advertising + discovery are confirmed.
                 // It throws on failure, so online stays false.
                 driver.start(localEndpointName, maxConnections)
-                online.set(true)
+                setOnline(true)
                 log("Advertising and discovery started (name=$localEndpointName)")
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
-                online.set(false)
+                setOnline(false)
                 log("Failed to start: ${e.message}")
             }
         }
@@ -106,13 +106,13 @@ class NearbyInterface(
 
     override fun detach() {
         if (detached.getAndSet(true)) return
-        online.set(false)
+        setOnline(false)
         log("Detaching — shutting down all peers and driver")
 
         // Tear down all peer interfaces directly (don't call peer.detach() which
         // would re-enter peerDisconnected and double-deregister from Transport)
         for ((_, peer) in peers) {
-            peer.online.set(false)
+            peer.setOnline(false)
             peer.detached.set(true)
             try {
                 Transport.deregisterInterface(peer.toRef())
@@ -153,7 +153,7 @@ class NearbyInterface(
     private suspend fun collectConnectedEndpoints() {
         try {
             driver.connectedEndpoints.collect { endpoint ->
-                if (!online.get() || detached.get()) return@collect
+                if (!online.value || detached.get()) return@collect
 
                 // Skip if already have a peer for this endpoint
                 if (peers.containsKey(endpoint.endpointId)) return@collect
@@ -195,7 +195,7 @@ class NearbyInterface(
     private suspend fun collectDataReceived() {
         try {
             driver.dataReceived.collect { received ->
-                if (!online.get() || detached.get()) return@collect
+                if (!online.value || detached.get()) return@collect
 
                 val peer = peers[received.endpointId]
                 if (peer != null) {
@@ -249,7 +249,7 @@ class NearbyInterface(
         }
 
         if (!peer.detached.get()) {
-            peer.online.set(false)
+            peer.setOnline(false)
             peer.detached.set(true)
         }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/nearby/NearbyPeerInterface.kt
@@ -36,7 +36,7 @@ class NearbyPeerInterface(
      * Send data to this specific endpoint.
      */
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) return
+        if (!online.value || detached.get()) return
 
         try {
             driver.send(endpointId, data)
@@ -52,17 +52,17 @@ class NearbyPeerInterface(
      * Called by [NearbyInterface] when data arrives from this endpoint.
      */
     fun deliverIncoming(data: ByteArray) {
-        if (!online.get() || detached.get()) return
+        if (!online.value || detached.get()) return
         processIncoming(data)
     }
 
     override fun start() {
-        online.set(true)
+        setOnline(true)
     }
 
     override fun detach() {
         if (detached.getAndSet(true)) return
-        online.set(false)
+        setOnline(false)
 
         try {
             driver.disconnect(endpointId)

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/pipe/PipeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/pipe/PipeInterface.kt
@@ -58,7 +58,7 @@ class PipeInterface(
     private var readThread: Thread? = null
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) return
+        if (!online.value || detached.get()) return
 
         val framed = HDLC.frame(data)
         synchronized(outputStream) {
@@ -66,7 +66,7 @@ class PipeInterface(
                 outputStream.write(framed)
                 outputStream.flush()
             } catch (_: IOException) {
-                online.set(false)
+                setOnline(false)
                 return
             }
         }
@@ -74,7 +74,7 @@ class PipeInterface(
     }
 
     override fun start() {
-        online.set(true)
+        setOnline(true)
         readThread = Thread(::readLoop).apply {
             isDaemon = true
             name = "PipeInterface[$name]-read"
@@ -85,7 +85,7 @@ class PipeInterface(
     private fun readLoop() {
         val buffer = ByteArray(MAX_CHUNK)
         try {
-            while (online.get() && !detached.get()) {
+            while (online.value && !detached.get()) {
                 val bytesRead = inputStream.read(buffer)
                 if (bytesRead == -1) break
                 hdlcDeframer.process(buffer.copyOf(bytesRead))
@@ -93,7 +93,7 @@ class PipeInterface(
         } catch (_: IOException) {
             // Stream closed — expected on shutdown
         }
-        online.set(false)
+        setOnline(false)
     }
 
     override fun detach() {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -727,8 +727,8 @@ class RNodeInterface(
 
         if (online.value) {
             log("Read loop exiting - marking interface offline")
+            setOnline(false)
         }
-        setOnline(false)
     }
 
     /**

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/rnode/RNodeInterface.kt
@@ -165,7 +165,7 @@ class RNodeInterface(
                 throw e
             } catch (e: Exception) {
                 log("Failed to configure RNode: ${e.message}")
-                online.set(false)
+                setOnline(false)
             }
         }
     }
@@ -206,7 +206,7 @@ class RNodeInterface(
         if (validateRadioState()) {
             interfaceReady = true
             delay(300)
-            online.set(true)
+            setOnline(true)
             log("RNode is configured and online")
 
             if (displayImageData != null) {
@@ -689,7 +689,7 @@ class RNodeInterface(
                         }
                     } else if (command == KISS.CMD_RESET) {
                         if (byte == 0xF8) {
-                            if ((platform == (KISS.PLATFORM_ESP32.toInt() and 0xFF)) && online.get()) {
+                            if ((platform == (KISS.PLATFORM_ESP32.toInt() and 0xFF)) && online.value) {
                                 log("Device reset detected while online, reinitialising device")
                                 throw IOException("ESP32 reset")
                             }
@@ -721,14 +721,14 @@ class RNodeInterface(
         } catch (e: IOException) {
             if (!detached.get()) {
                 log("Read loop error: ${e.message}")
-                online.set(false)
+                setOnline(false)
             }
         }
 
-        if (online.get()) {
+        if (online.value) {
             log("Read loop exiting - marking interface offline")
         }
-        online.set(false)
+        setOnline(false)
     }
 
     /**
@@ -753,10 +753,10 @@ class RNodeInterface(
     // -- TX path --
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) return
+        if (!online.value || detached.get()) return
 
         synchronized(txLock) {
-            if (!online.get()) return // re-check after acquiring lock
+            if (!online.value) return // re-check after acquiring lock
 
             if (interfaceReady) {
                 if (flowControl) {
@@ -784,7 +784,7 @@ class RNodeInterface(
             txBytes.addAndGet(data.size.toLong())
         } catch (e: IOException) {
             log("TX error: ${e.message}")
-            online.set(false)
+            setOnline(false)
         }
     }
 
@@ -800,7 +800,7 @@ class RNodeInterface(
 
     private fun handleIdleMaintenance() {
         val keepaliveAfterMs = activityKeepaliveMs
-        if (keepaliveAfterMs != null && online.get()) {
+        if (keepaliveAfterMs != null && online.value) {
             val timeSinceLastWrite = System.currentTimeMillis() - lastWriteMs
             if (timeSinceLastWrite >= keepaliveAfterMs) {
                 detect()

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/spp/SppInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/spp/SppInterface.kt
@@ -206,7 +206,7 @@ class SppInterface(
             outputStream = conn.outputStream
             remoteDeviceName = conn.remoteName
             remoteDeviceAddress = conn.remoteAddress
-            online.set(true)
+            setOnline(true)
             neverConnected.set(false)
 
             if (initial) {
@@ -230,7 +230,7 @@ class SppInterface(
     private suspend fun reconnect() {
         if (reconnecting.getAndSet(true)) return
 
-        while (!online.get() && !detached.get()) {
+        while (!online.value && !detached.get()) {
             val delayMs = backoff.nextDelay()
 
             if (delayMs == null) {
@@ -266,7 +266,7 @@ class SppInterface(
             val buffer = ByteArray(READ_BUFFER_SIZE)
 
             try {
-                while (isActive && online.get() && !detached.get()) {
+                while (isActive && online.value && !detached.get()) {
                     val bytesRead = withContext(Dispatchers.IO) {
                         stream.read(buffer)
                     }
@@ -280,7 +280,7 @@ class SppInterface(
                             debugLog("Read loop: EOF, connection closed by peer")
                             debugLog("  frames sent: ${framesSent.get()}, received: ${framesReceived.get()}")
                         }
-                        online.set(false)
+                        setOnline(false)
                         break
                     }
                 }
@@ -291,7 +291,7 @@ class SppInterface(
                     debugLog("Read loop: IOException - ${e.javaClass.name}: ${e.message}")
                 }
                 if (!detached.get()) {
-                    online.set(false)
+                    setOnline(false)
                 }
             }
 
@@ -305,7 +305,7 @@ class SppInterface(
     }
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) {
+        if (!online.value || detached.get()) {
             throw IllegalStateException("Interface is not online")
         }
 
@@ -350,7 +350,7 @@ class SppInterface(
         log("Bluetooth state changed - resetting reconnection backoff")
         backoff.reset()
 
-        if (!online.get() && !detached.get() && !reconnecting.get()) {
+        if (!online.value && !detached.get() && !reconnecting.get()) {
             ioScope.launch {
                 reconnect()
             }
@@ -372,7 +372,7 @@ class SppInterface(
         if (DEBUG) {
             debugLog("Teardown - frames sent: ${framesSent.get()}, received: ${framesReceived.get()}")
         }
-        online.set(false)
+        setOnline(false)
         closeConnection()
 
         if (!detached.get()) {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
@@ -192,7 +192,7 @@ class TCPClientInterface(
             val inputStream = sock.getInputStream()
 
             socket = sock
-            online.set(true)
+            setOnline(true)
             neverConnected.set(false)
 
             // Request tunnel synthesis for this connection
@@ -249,7 +249,7 @@ class TCPClientInterface(
         // Note: Do NOT reset backoff here - network change handler will reset when appropriate
         // This allows progressive backoff across reconnect cycles
 
-        while (!online.get() && !detached.get()) {
+        while (!online.value && !detached.get()) {
             val delayMs = backoff.nextDelay()
 
             if (delayMs == null) {
@@ -287,7 +287,7 @@ class TCPClientInterface(
             val buffer = ByteArray(4096)
 
             try {
-                while (isActive && online.get() && !detached.get()) {
+                while (isActive && online.value && !detached.get()) {
                     if (sock.isClosed || !sock.isConnected || sock.isInputShutdown) {
                         break
                     }
@@ -312,7 +312,7 @@ class TCPClientInterface(
                             debugLog("  socket state: isConnected=${sock.isConnected}, isClosed=${sock.isClosed}")
                             debugLog("  socket state: isInputShutdown=${sock.isInputShutdown}, isOutputShutdown=${sock.isOutputShutdown}")
                         }
-                        online.set(false)
+                        setOnline(false)
                         break
                     }
                 }
@@ -333,7 +333,7 @@ class TCPClientInterface(
                     }
                 }
                 if (!detached.get()) {
-                    online.set(false)
+                    setOnline(false)
                 }
             }
 
@@ -346,7 +346,7 @@ class TCPClientInterface(
     }
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) {
+        if (!online.value || detached.get()) {
             throw IllegalStateException("Interface is not online")
         }
 
@@ -446,7 +446,7 @@ class TCPClientInterface(
         backoff.reset()
 
         // If currently offline and not detached, trigger reconnection
-        if (!online.get() && !detached.get() && !reconnecting.get()) {
+        if (!online.value && !detached.get() && !reconnecting.get()) {
             ioScope.launch {
                 reconnect()
             }
@@ -468,7 +468,7 @@ class TCPClientInterface(
             debugLog("  frames sent: ${framesSent.get()}, frames received: ${framesReceived.get()}")
             debugLog("  detached: ${detached.get()}")
         }
-        online.set(false)
+        setOnline(false)
         closeSocket()
 
         if (!detached.get()) {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPServerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPServerInterface.kt
@@ -105,7 +105,7 @@ class TCPServerInterface(
             serverSocket = ServerSocket()
             serverSocket?.reuseAddress = true
             serverSocket?.bind(InetSocketAddress(bindAddress, bindPort))
-            online.set(true)
+            setOnline(true)
             log("Listening on $bindAddress:$bindPort")
 
             acceptJob = ioScope.launch {
@@ -118,7 +118,7 @@ class TCPServerInterface(
     }
 
     private suspend fun acceptLoop() {
-        while (online.get() && !detached.get()) {
+        while (online.value && !detached.get()) {
             try {
                 val server = serverSocket ?: break
                 // Blocking accept wrapped in IO dispatcher
@@ -151,7 +151,7 @@ class TCPServerInterface(
 
                     // Rebroadcast to all OTHER clients (not the sender)
                     for (otherClient in clients) {
-                        if (otherClient !== iface && otherClient.online.get()) {
+                        if (otherClient !== iface && otherClient.online.value) {
                             try {
                                 otherClient.processOutgoing(data)
                             } catch (e: Exception) {
@@ -197,7 +197,7 @@ class TCPServerInterface(
     override fun processOutgoing(data: ByteArray) {
         for (client in clients) {
             try {
-                if (client.online.get()) {
+                if (client.online.value) {
                     client.processOutgoing(data)
                 }
             } catch (e: Exception) {
@@ -292,7 +292,7 @@ class TCPServerClientInterface internal constructor(
     override fun start() {
         socket.tcpNoDelay = true
         socket.soTimeout = 0
-        online.set(true)
+        setOnline(true)
 
         readJob = ioScope.launch {
             readLoop()
@@ -303,7 +303,7 @@ class TCPServerClientInterface internal constructor(
         val buffer = ByteArray(4096)
 
         try {
-            while (online.get() && !detached.get()) {
+            while (online.value && !detached.get()) {
                 // Blocking read wrapped in IO dispatcher
                 val bytesRead = withContext(Dispatchers.IO) {
                     socket.getInputStream().read(buffer)
@@ -334,7 +334,7 @@ class TCPServerClientInterface internal constructor(
     }
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) {
+        if (!online.value || detached.get()) {
             throw IllegalStateException("Interface is not online")
         }
 
@@ -368,7 +368,7 @@ class TCPServerClientInterface internal constructor(
 
     override fun detach() {
         if (detached.getAndSet(true)) return
-        online.set(false)
+        setOnline(false)
 
         // Cancel coroutines first
         readJob?.cancel()

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/udp/UDPInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/udp/UDPInterface.kt
@@ -135,7 +135,7 @@ class UDPInterface(
                 setupSender()
             }
 
-            online.set(true)
+            setOnline(true)
             log("Interface started successfully")
 
         } catch (e: Exception) {
@@ -305,7 +305,7 @@ class UDPInterface(
     }
 
     override fun processOutgoing(data: ByteArray) {
-        if (!online.get() || detached.get()) {
+        if (!online.value || detached.get()) {
             throw IllegalStateException("Interface is not online")
         }
 
@@ -342,7 +342,7 @@ class UDPInterface(
 
         log("Detaching interface")
         running.set(false)
-        online.set(false)
+        setOnline(false)
 
         // Cancel coroutines first
         readJob?.cancel()

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/InterfaceAdapterPhyStatsTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/InterfaceAdapterPhyStatsTest.kt
@@ -20,7 +20,7 @@ class InterfaceAdapterPhyStatsTest {
      */
     private class StubInterface : Interface("StubPhyStats") {
         override fun processOutgoing(data: ByteArray) {}
-        override fun start() { online.set(true) }
+        override fun start() { setOnline(true) }
     }
 
     @Test

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
@@ -1,6 +1,9 @@
 package network.reticulum.interfaces
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import network.reticulum.interfaces.tcp.TCPClientInterface
 import network.reticulum.interfaces.udp.UDPInterface
 import org.junit.jupiter.api.AfterEach
@@ -404,5 +407,94 @@ class ScopeInjectionTest {
 
         assertTrue(udp.detached.get(), "Should be detached after stop()")
         assertFalse(udp.online.value, "Should be offline after stop()")
+    }
+
+    // ========================
+    // StateFlow Emission Tests (reactive observation — core motivation of refactor)
+    // ========================
+
+    @Test
+    @Timeout(5)
+    fun `online StateFlow emits false to true transition on start`() = runBlocking {
+        // Regression guard for the core motivation of the AtomicBoolean -> StateFlow refactor:
+        // consumers that captured the scalar at registration must now observe the transition.
+        val udp = UDPInterface(
+            name = "emission-udp",
+            bindPort = 15601,
+            forwardIp = "127.0.0.1",
+            forwardPort = 15602
+        )
+        interfaces.add(udp)
+
+        // Collect the flow BEFORE start() — simulates a consumer that subscribes at registration
+        // time, when the interface is still offline. StateFlow replays the current value (false),
+        // then emits true once start() completes.
+        val observed = mutableListOf<Boolean>()
+        val collectScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val collectJob = collectScope.launch {
+            udp.online.take(2).toList(observed)
+        }
+
+        // Ensure the collector has subscribed and replayed the initial false
+        delay(50)
+        assertEquals(listOf(false), observed, "Initial StateFlow value must replay to late subscriber")
+
+        udp.start()
+        collectJob.join()
+        collectScope.cancel()
+
+        assertEquals(listOf(false, true), observed,
+            "StateFlow must emit false -> true transition to observers subscribed before start()")
+    }
+
+    @Test
+    @Timeout(5)
+    fun `online StateFlow emits true to false transition on stop`() = runBlocking {
+        val udp = UDPInterface(
+            name = "emission-stop-udp",
+            bindPort = 15611,
+            forwardIp = "127.0.0.1",
+            forwardPort = 15612
+        )
+        interfaces.add(udp)
+
+        udp.start()
+        assertTrue(udp.online.value, "Precondition: online after start")
+
+        // Subscribe after start — should replay current value (true), then observe false on stop
+        val observed = mutableListOf<Boolean>()
+        val collectScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val collectJob = collectScope.launch {
+            udp.online.take(2).toList(observed)
+        }
+
+        delay(50)
+        assertEquals(listOf(true), observed, "Post-start subscriber must replay current value (true)")
+
+        udp.stop()
+        collectJob.join()
+        collectScope.cancel()
+
+        assertEquals(listOf(true, false), observed,
+            "StateFlow must emit true -> false transition on stop")
+    }
+
+    @Test
+    @Timeout(5)
+    fun `online StateFlow replays current value to late subscribers`() = runBlocking {
+        val udp = UDPInterface(
+            name = "replay-udp",
+            bindPort = 15621,
+            forwardIp = "127.0.0.1",
+            forwardPort = 15622
+        )
+        interfaces.add(udp)
+
+        udp.start()
+        assertTrue(udp.online.value)
+
+        // Late subscriber receives the current value without waiting for a new emission
+        val replayed = udp.online.first()
+        assertTrue(replayed, "StateFlow.first() must return the current value to a late subscriber")
     }
 }

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
@@ -2,6 +2,7 @@ package network.reticulum.interfaces
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import network.reticulum.interfaces.tcp.TCPClientInterface
@@ -426,24 +427,26 @@ class ScopeInjectionTest {
         )
         interfaces.add(udp)
 
-        // Collect the flow BEFORE start() — simulates a consumer that subscribes at registration
-        // time, when the interface is still offline. StateFlow replays the current value (false),
-        // then emits true once start() completes.
-        val observed = mutableListOf<Boolean>()
+        // Use a CompletableDeferred to guarantee happens-before between "collector has
+        // subscribed and received the initial false replay" and "start() fires the true
+        // emission". Without this handshake, start() could race ahead of the subscription
+        // and the collector would see true as its initial replay, missing the transition.
+        val subscribed = CompletableDeferred<Unit>()
         val collectScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val collectJob = collectScope.launch {
-            udp.online.take(2).toList(observed)
+        val observed = collectScope.async {
+            udp.online
+                .onEach { if (!subscribed.isCompleted) subscribed.complete(Unit) }
+                .take(2)
+                .toList()
         }
 
-        // Ensure the collector has subscribed and replayed the initial false
-        delay(50)
-        assertEquals(listOf(false), observed, "Initial StateFlow value must replay to late subscriber")
-
+        subscribed.await()  // barrier: collector has the initial false
         udp.start()
-        collectJob.join()
+
+        val values = observed.await()  // barrier: take(2) has completed
         collectScope.cancel()
 
-        assertEquals(listOf(false, true), observed,
+        assertEquals(listOf(false, true), values,
             "StateFlow must emit false -> true transition to observers subscribed before start()")
     }
 
@@ -461,21 +464,23 @@ class ScopeInjectionTest {
         udp.start()
         assertTrue(udp.online.value, "Precondition: online after start")
 
-        // Subscribe after start — should replay current value (true), then observe false on stop
-        val observed = mutableListOf<Boolean>()
+        // Handshake guarantees the subscription is live (and has replayed true) before stop()
+        val subscribed = CompletableDeferred<Unit>()
         val collectScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val collectJob = collectScope.launch {
-            udp.online.take(2).toList(observed)
+        val observed = collectScope.async {
+            udp.online
+                .onEach { if (!subscribed.isCompleted) subscribed.complete(Unit) }
+                .take(2)
+                .toList()
         }
 
-        delay(50)
-        assertEquals(listOf(true), observed, "Post-start subscriber must replay current value (true)")
-
+        subscribed.await()  // barrier: collector has the initial true
         udp.stop()
-        collectJob.join()
+
+        val values = observed.await()  // barrier: take(2) has completed
         collectScope.cancel()
 
-        assertEquals(listOf(true, false), observed,
+        assertEquals(listOf(true, false), values,
             "StateFlow must emit true -> false transition on stop")
     }
 

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
@@ -54,12 +54,12 @@ class ScopeInjectionTest {
         interfaces.add(udp)
 
         udp.start()
-        assertTrue(udp.online.get(), "Should be online")
+        assertTrue(udp.online.value, "Should be online")
 
         // Explicit stop should work
         udp.stop()
         Thread.sleep(100)
-        assertFalse(udp.online.get(), "Should be offline after stop")
+        assertFalse(udp.online.value, "Should be offline after stop")
     }
 
     @Test
@@ -80,14 +80,14 @@ class ScopeInjectionTest {
         interfaces.add(udp)
 
         udp.start()
-        assertTrue(udp.online.get(), "Should be online")
+        assertTrue(udp.online.value, "Should be online")
 
         // Cancel parent scope (simulates service stop)
         parentScope.cancel()
 
         // Wait for cancellation to propagate (should be quick)
         delay(500)
-        assertFalse(udp.online.get(), "Should be offline after parent cancellation")
+        assertFalse(udp.online.value, "Should be offline after parent cancellation")
     }
 
     @Test
@@ -106,7 +106,7 @@ class ScopeInjectionTest {
         interfaces.add(udp)
 
         udp.start()
-        assertTrue(udp.online.get())
+        assertTrue(udp.online.value)
 
         // Measure cancellation time
         val startTime = System.currentTimeMillis()
@@ -114,12 +114,12 @@ class ScopeInjectionTest {
 
         // Poll for completion (max 1 second)
         var elapsed = 0L
-        while (udp.online.get() && elapsed < 1000) {
+        while (udp.online.value && elapsed < 1000) {
             delay(50)
             elapsed = System.currentTimeMillis() - startTime
         }
 
-        assertFalse(udp.online.get(), "Should be offline within 1 second")
+        assertFalse(udp.online.value, "Should be offline within 1 second")
         assertTrue(elapsed < 1000, "Cancellation took ${elapsed}ms, should be < 1000ms")
     }
 
@@ -149,14 +149,14 @@ class ScopeInjectionTest {
 
         udp1.start()
         udp2.start()
-        assertTrue(udp1.online.get() && udp2.online.get(), "Both should be online")
+        assertTrue(udp1.online.value && udp2.online.value, "Both should be online")
 
         // Cancel parent
         parentScope.cancel()
         delay(500)
 
-        assertFalse(udp1.online.get(), "UDP1 should be offline")
-        assertFalse(udp2.online.get(), "UDP2 should be offline")
+        assertFalse(udp1.online.value, "UDP1 should be offline")
+        assertFalse(udp2.online.value, "UDP2 should be offline")
     }
 
     // ========================
@@ -264,15 +264,15 @@ class ScopeInjectionTest {
         interfaces.add(udp)
 
         udp.start()
-        assertTrue(udp.online.get(), "Should be online after start")
+        assertTrue(udp.online.value, "Should be online after start")
 
         // Wait and verify interface STAYS online while parent is active
         // This simulates the app being backgrounded (service keeps running)
         delay(500)
-        assertTrue(udp.online.get(), "Should STILL be online after 500ms with active parent")
+        assertTrue(udp.online.value, "Should STILL be online after 500ms with active parent")
 
         delay(500)
-        assertTrue(udp.online.get(), "Should STILL be online after 1 second with active parent")
+        assertTrue(udp.online.value, "Should STILL be online after 1 second with active parent")
 
         // Parent scope is still active - interface should remain operational
         assertTrue(parentScope.isActive, "Parent scope should still be active")
@@ -351,7 +351,7 @@ class ScopeInjectionTest {
         delay(500)
 
         // UDP should still be online despite TCP failure
-        assertTrue(udp.online.get(), "UDP should remain online when sibling TCP fails")
+        assertTrue(udp.online.value, "UDP should remain online when sibling TCP fails")
     }
 
     @Test
@@ -370,7 +370,7 @@ class ScopeInjectionTest {
         interfaces.add(udp)
 
         udp.start()
-        assertTrue(udp.online.get())
+        assertTrue(udp.online.value)
 
         // Multiple detach calls should be safe
         udp.detach()
@@ -378,7 +378,7 @@ class ScopeInjectionTest {
         udp.detach()
 
         assertTrue(udp.detached.get(), "Should be detached")
-        assertFalse(udp.online.get(), "Should be offline")
+        assertFalse(udp.online.value, "Should be offline")
     }
 
     @Test
@@ -397,12 +397,12 @@ class ScopeInjectionTest {
         interfaces.add(udp)
 
         udp.start()
-        assertTrue(udp.online.get())
+        assertTrue(udp.online.value)
 
         // stop() should work the same as detach()
         udp.stop()
 
         assertTrue(udp.detached.get(), "Should be detached after stop()")
-        assertFalse(udp.online.get(), "Should be offline after stop()")
+        assertFalse(udp.online.value, "Should be offline after stop()")
     }
 }

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/LocalInterfaceTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/LocalInterfaceTest.kt
@@ -38,7 +38,7 @@ class LocalInterfaceTest {
         server = LocalServerInterface(name = "TestServer", tcpPort = 0)
         server!!.start()
 
-        assertTrue(server!!.online.get())
+        assertTrue(server!!.online.value)
         assertTrue(server!!.clientCount() == 0)
     }
 
@@ -57,8 +57,8 @@ class LocalInterfaceTest {
         // Give connection time to establish
         Thread.sleep(200)
 
-        assertTrue(server!!.online.get())
-        assertTrue(client.online.get())
+        assertTrue(server!!.online.value)
+        assertTrue(client.online.value)
         assertEquals(1, server!!.clientCount())
     }
 
@@ -225,7 +225,7 @@ class LocalInterfaceTest {
             server = LocalServerInterface(name = "TestServer", socketPath = socketPath)
             server!!.start()
 
-            assertTrue(server!!.online.get())
+            assertTrue(server!!.online.value)
 
             // Start client
             val client = LocalClientInterface(name = "TestClient", socketPath = socketPath)
@@ -235,7 +235,7 @@ class LocalInterfaceTest {
             // Give connection time to establish
             Thread.sleep(200)
 
-            assertTrue(client.online.get())
+            assertTrue(client.online.value)
             assertEquals(1, server!!.clientCount())
         } catch (e: UnsupportedOperationException) {
             // Unix sockets detected but not fully supported by JVM implementation

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/SharedInstanceRoutingTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/SharedInstanceRoutingTest.kt
@@ -262,7 +262,7 @@ class SharedInstanceRoutingTest {
 
         // All clients should be disconnected
         clients.forEach { client ->
-            assertFalse(client.online.get())
+            assertFalse(client.online.value)
         }
     }
 }

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/rnode/RNodeInterfaceTcpKeepaliveTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/rnode/RNodeInterfaceTcpKeepaliveTest.kt
@@ -14,7 +14,7 @@ class RNodeInterfaceTcpKeepaliveTest {
         val output = ByteArrayOutputStream()
         val iface = createInterface(output, activityKeepaliveMs = 3_500L)
 
-        iface.online.set(true)
+        iface.setOnline(true)
         setLastWriteMs(iface, System.currentTimeMillis() - 4_000L)
 
         invokeHandleIdleMaintenance(iface)
@@ -27,7 +27,7 @@ class RNodeInterfaceTcpKeepaliveTest {
         val output = ByteArrayOutputStream()
         val iface = createInterface(output, activityKeepaliveMs = 3_500L)
 
-        iface.online.set(false)
+        iface.setOnline(false)
         setLastWriteMs(iface, System.currentTimeMillis() - 4_000L)
 
         invokeHandleIdleMaintenance(iface)
@@ -40,7 +40,7 @@ class RNodeInterfaceTcpKeepaliveTest {
         val output = ByteArrayOutputStream()
         val iface = createInterface(output, activityKeepaliveMs = 3_500L)
 
-        iface.online.set(true)
+        iface.setOnline(true)
         setLastWriteMs(iface, System.currentTimeMillis() - 1_000L)
 
         invokeHandleIdleMaintenance(iface)

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/spp/SppInterfaceTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/spp/SppInterfaceTest.kt
@@ -81,7 +81,7 @@ class SppInterfaceTest {
         iface.start()
 
         // Wait for interface to come online
-        waitForCondition { iface.online.get() }
+        waitForCondition { iface.online.value }
 
         // Test 1: Send data via processOutgoing, verify HDLC framing on wire
         // Payload must be > 19 bytes (HEADER_MIN_SIZE) or deframer will drop it
@@ -174,7 +174,7 @@ class SppInterfaceTest {
         clientIface.start()
         serverIface.start()
 
-        waitForCondition { clientIface.online.get() && serverIface.online.get() }
+        waitForCondition { clientIface.online.value && serverIface.online.value }
 
         // Client → Server (payload > 19 bytes)
         val clientPayload = ByteArray(40) { (it + 0x30).toByte() }
@@ -226,16 +226,16 @@ class SppInterfaceTest {
         iface.start()
 
         // Wait for first connection
-        waitForCondition { iface.online.get() }
+        waitForCondition { iface.online.value }
         assertEquals(1, connectCount.get())
 
         // Kill the first connection by closing its streams
         firstConnection.close()
 
         // Wait for reconnection to succeed
-        waitForCondition(timeoutMs = 10_000) { connectCount.get() >= 2 && iface.online.get() }
+        waitForCondition(timeoutMs = 10_000) { connectCount.get() >= 2 && iface.online.value }
         assertEquals(2, connectCount.get())
-        assertTrue(iface.online.get(), "Should be online after reconnection")
+        assertTrue(iface.online.value, "Should be online after reconnection")
     }
 
     @Test
@@ -252,7 +252,7 @@ class SppInterfaceTest {
         interfaces.add(iface)
 
         // Don't start — interface should be offline
-        assertFalse(iface.online.get())
+        assertFalse(iface.online.value)
         assertThrows(IllegalStateException::class.java) {
             iface.processOutgoing(ByteArray(32))
         }

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/udp/UDPInterfaceTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/udp/UDPInterfaceTest.kt
@@ -44,7 +44,7 @@ class UDPInterfaceTest {
         interfaces.add(receiver)
         receiver.start()
 
-        assertTrue(receiver.online.get(), "Receiver should be online")
+        assertTrue(receiver.online.value, "Receiver should be online")
         assertTrue(receiver.canReceive, "Receiver should be able to receive")
 
         // Create sender interface
@@ -57,7 +57,7 @@ class UDPInterfaceTest {
         interfaces.add(sender)
         sender.start()
 
-        assertTrue(sender.online.get(), "Sender should be online")
+        assertTrue(sender.online.value, "Sender should be online")
         assertTrue(sender.canSend, "Sender should be able to send")
 
         // Send test data
@@ -382,13 +382,13 @@ class UDPInterfaceTest {
         assertEquals(1064, iface.getEffectiveMtu())
         assertTrue(iface.canReceive)
         assertTrue(iface.canSend)
-        assertFalse(iface.online.get())
+        assertFalse(iface.online.value)
 
         iface.start()
-        assertTrue(iface.online.get())
+        assertTrue(iface.online.value)
 
         iface.detach()
-        assertFalse(iface.online.get())
+        assertFalse(iface.online.value)
         assertTrue(iface.detached.get())
     }
 
@@ -422,11 +422,11 @@ class UDPInterfaceTest {
         interfaces.add(iface)
 
         iface.start()
-        assertTrue(iface.online.get())
+        assertTrue(iface.online.value)
 
         // Second start should be safe
         iface.start()
-        assertTrue(iface.online.get())
+        assertTrue(iface.online.value)
     }
 
     @Test
@@ -455,10 +455,10 @@ class UDPInterfaceTest {
         interfaces.add(iface)
 
         iface.start()
-        assertTrue(iface.online.get())
+        assertTrue(iface.online.value)
 
         iface.detach()
-        assertFalse(iface.online.get())
+        assertFalse(iface.online.value)
 
         assertThrows(IllegalStateException::class.java) {
             iface.processOutgoing("test".toByteArray())

--- a/rns-test/src/main/kotlin/network/reticulum/interop/RnsLiveTestBase.kt
+++ b/rns-test/src/main/kotlin/network/reticulum/interop/RnsLiveTestBase.kt
@@ -101,13 +101,13 @@ abstract class RnsLiveTestBase : InteropTestBase() {
         println("  [Setup] Waiting for TCP connection...")
         val connectionDeadline = System.currentTimeMillis() + 10_000
         while (System.currentTimeMillis() < connectionDeadline) {
-            if (kotlinTcpClient!!.online.get()) {
+            if (kotlinTcpClient!!.online.value) {
                 println("  [Setup] TCP connection established")
                 break
             }
             Thread.sleep(100)
         }
-        require(kotlinTcpClient!!.online.get()) {
+        require(kotlinTcpClient!!.online.value) {
             "TCP connection to Python not established within 10 seconds"
         }
 

--- a/rns-test/src/test/kotlin/network/reticulum/emulator/EmulatorLinkTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/emulator/EmulatorLinkTest.kt
@@ -128,7 +128,7 @@ class EmulatorLinkTest {
 
         // Wait for interface to connect
         val connectTimeout = System.currentTimeMillis() + 10_000
-        while (!clientInterface!!.online.get()) {
+        while (!clientInterface!!.online.value) {
             if (System.currentTimeMillis() > connectTimeout) {
                 throw AssertionError("Failed to connect to emulator on $EMULATOR_HOST:$EMULATOR_PORT")
             }
@@ -222,7 +222,7 @@ class EmulatorLinkTest {
 
         // Wait for connection
         val connectTimeout = System.currentTimeMillis() + 10_000
-        while (!clientInterface!!.online.get()) {
+        while (!clientInterface!!.online.value) {
             if (System.currentTimeMillis() > connectTimeout) {
                 throw AssertionError("Failed to connect to emulator")
             }

--- a/rns-test/src/test/kotlin/network/reticulum/integration/IfacTcpIntegrationTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/IfacTcpIntegrationTest.kt
@@ -182,12 +182,12 @@ class IfacTcpIntegrationTest {
 
         // Wait for connection
         var attempts = 0
-        while (!kotlinInterface!!.online.get() && attempts < 30) {
+        while (!kotlinInterface!!.online.value && attempts < 30) {
             Thread.sleep(500)
             attempts++
         }
 
-        assertTrue(kotlinInterface!!.online.get(), "Interface should come online")
+        assertTrue(kotlinInterface!!.online.value, "Interface should come online")
         println("Connection established!")
 
         // Wait for packets from Python (announces happen every 30 seconds in the test server)
@@ -236,12 +236,12 @@ class IfacTcpIntegrationTest {
 
         // Wait for connection
         var attempts = 0
-        while (!kotlinInterface!!.online.get() && attempts < 20) {
+        while (!kotlinInterface!!.online.value && attempts < 20) {
             Thread.sleep(500)
             attempts++
         }
 
-        assertTrue(kotlinInterface!!.online.get(), "Interface should come online")
+        assertTrue(kotlinInterface!!.online.value, "Interface should come online")
         println("Connection established without IFAC!")
 
         // Wait briefly for any packets
@@ -281,13 +281,13 @@ class IfacTcpIntegrationTest {
 
         // Wait for connection (TCP should still connect)
         var attempts = 0
-        while (!kotlinInterface!!.online.get() && attempts < 20) {
+        while (!kotlinInterface!!.online.value && attempts < 20) {
             Thread.sleep(500)
             attempts++
         }
 
         // Connection may establish at TCP level
-        if (kotlinInterface!!.online.get()) {
+        if (kotlinInterface!!.online.value) {
             println("TCP connected (expected - IFAC is application-layer)")
 
             // Wait for packets

--- a/rns-test/src/test/kotlin/network/reticulum/integration/LiveTcpServerTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/LiveTcpServerTest.kt
@@ -66,11 +66,11 @@ class LiveTcpServerTest {
         // Wait for TCP connection
         val deadline = System.currentTimeMillis() + 10_000
         while (System.currentTimeMillis() < deadline) {
-            if (tcpClient!!.online.get()) break
+            if (tcpClient!!.online.value) break
             Thread.sleep(100)
         }
 
-        assertTrue(tcpClient!!.online.get(), "Should connect to $host:$port")
+        assertTrue(tcpClient!!.online.value, "Should connect to $host:$port")
         println("  [Setup] Connected to live server")
     }
 
@@ -85,9 +85,9 @@ class LiveTcpServerTest {
     @DisplayName("TCP connection stays online")
     @Timeout(10)
     fun `tcp connection stays online`() {
-        assertTrue(tcpClient!!.online.get(), "TCP connection should be online")
+        assertTrue(tcpClient!!.online.value, "TCP connection should be online")
         Thread.sleep(2000)
-        assertTrue(tcpClient!!.online.get(), "TCP connection should stay online after 2s")
+        assertTrue(tcpClient!!.online.value, "TCP connection should stay online after 2s")
         println("  [Test] TCP connection stable")
     }
 

--- a/rns-test/src/test/kotlin/network/reticulum/integration/TcpIntegrationTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/TcpIntegrationTest.kt
@@ -67,8 +67,8 @@ class TcpIntegrationTest {
         // Wait for connection
         Thread.sleep(500)
 
-        assertTrue(server.online.get(), "Server should be online")
-        assertTrue(client.online.get(), "Client should be online")
+        assertTrue(server.online.value, "Server should be online")
+        assertTrue(client.online.value, "Client should be online")
         assertEquals(1, server.clientCount(), "Server should have one client")
     }
 

--- a/rns-test/src/test/kotlin/network/reticulum/integration/TcpPythonInteropTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/TcpPythonInteropTest.kt
@@ -211,7 +211,7 @@ class TcpPythonInteropTest {
 
         // Wait for connection
         val startTime = System.currentTimeMillis()
-        while (!newClient.online.get() && System.currentTimeMillis() - startTime < CONNECTION_TIMEOUT_MS) {
+        while (!newClient.online.value && System.currentTimeMillis() - startTime < CONNECTION_TIMEOUT_MS) {
             Thread.sleep(50)
         }
 
@@ -264,13 +264,13 @@ class TcpPythonInteropTest {
     @EnabledIf("isPythonServerRunning")
     fun `connection holds for 5 seconds`() {
         val client = connectClient()
-        assertTrue(client.online.get(), "Client should be online after connect")
+        assertTrue(client.online.value, "Client should be online after connect")
 
         // Wait 5 seconds
         println("Waiting 5 seconds to verify connection stability...")
         Thread.sleep(5000)
 
-        assertTrue(client.online.get(), "Client should still be online after 5 seconds")
+        assertTrue(client.online.value, "Client should still be online after 5 seconds")
         println("Connection held stable for 5 seconds")
     }
 
@@ -280,7 +280,7 @@ class TcpPythonInteropTest {
     @EnabledIf("isPythonServerRunning")
     fun `kotlin to python packet delivery`() {
         val client = connectClient()
-        assertTrue(client.online.get(), "Client should be online")
+        assertTrue(client.online.value, "Client should be online")
 
         // Clear previous output
         pythonOutputLines.clear()
@@ -305,7 +305,7 @@ class TcpPythonInteropTest {
     @EnabledIf("isPythonServerRunning")
     fun `python to kotlin packet delivery`() {
         val client = connectClient()
-        assertTrue(client.online.get(), "Client should be online")
+        assertTrue(client.online.value, "Client should be online")
 
         // Clear received packets
         receivedPackets.clear()
@@ -339,7 +339,7 @@ class TcpPythonInteropTest {
     @EnabledIf("isPythonServerRunning")
     fun `bidirectional exchange`() {
         val client = connectClient()
-        assertTrue(client.online.get(), "Client should be online")
+        assertTrue(client.online.value, "Client should be online")
 
         // Clear state
         receivedPackets.clear()

--- a/rns-test/src/test/kotlin/network/reticulum/integration/TunnelIntegrationTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/integration/TunnelIntegrationTest.kt
@@ -88,7 +88,7 @@ class TunnelIntegrationTest {
 
         // Wait for connection
         Thread.sleep(1000)
-        assertTrue(client.online.get(), "Client should be online")
+        assertTrue(client.online.value, "Client should be online")
 
         // wantsTunnel might already be false if job loop processed it
         println("Initial wantsTunnel: ${clientRef.wantsTunnel}")
@@ -178,7 +178,7 @@ class TunnelIntegrationTest {
         // Wait for connection and tunnel synthesis
         Thread.sleep(3000)
 
-        assertTrue(client.online.get(), "Client should be online")
+        assertTrue(client.online.value, "Client should be online")
 
         // Build announce, then deregister destination so Transport doesn't skip
         // it as local (in a real setup, server and client have separate Transport instances)

--- a/rns-test/src/test/kotlin/network/reticulum/interop/transport/AnnounceForwardingE2ETest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/interop/transport/AnnounceForwardingE2ETest.kt
@@ -137,11 +137,11 @@ class AnnounceForwardingE2ETest : InteropTestBase() {
         // Wait for TCP connection
         val tcpDeadline = System.currentTimeMillis() + 10_000
         while (System.currentTimeMillis() < tcpDeadline) {
-            if (kotlinTcpClient!!.online.get()) break
+            if (kotlinTcpClient!!.online.value) break
             Thread.sleep(100)
         }
 
-        if (!kotlinTcpClient!!.online.get()) {
+        if (!kotlinTcpClient!!.online.value) {
             println("  [Setup] WARNING: TCP to Python did not establish, TCP E2E tests may fail")
             println("  [Setup] (Known issue: tunnel synthesis packets cause Python to drop connection)")
         } else {

--- a/rns-test/src/test/kotlin/network/reticulum/test/TunnelTestMain.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/test/TunnelTestMain.kt
@@ -71,7 +71,7 @@ fun main() {
     println("Waiting for tunnel synthesis...")
     Thread.sleep(3000)
 
-    if (!tcpClient.online.get()) {
+    if (!tcpClient.online.value) {
         println("✗ Failed to connect to server")
         return
     }

--- a/test-scripts/kotlin_tunnel_test.kt
+++ b/test-scripts/kotlin_tunnel_test.kt
@@ -38,7 +38,7 @@ fun main() {
     // Wait for connection
     Thread.sleep(1000)
 
-    if (client.online.get()) {
+    if (client.online.value) {
         println("Connected! Waiting for tunnel synthesis...")
 
         // Check wantsTunnel flag
@@ -64,7 +64,7 @@ fun main() {
             Thread.sleep(5000)
 
             println("Status:")
-            println("  Online: ${client.online.get()}")
+            println("  Online: ${client.online.value}")
             println("  WantsTunnel: ${clientRef.wantsTunnel}")
             println("  TunnelId: ${clientRef.tunnelId?.let { it.take(8).joinToString("") { "%02x".format(it) } }}")
             println("  Active tunnels: ${Transport.getTunnels().size}")


### PR DESCRIPTION
## Summary

- Converts `Interface.online` from `AtomicBoolean` to a public read-only `StateFlow<Boolean>` backed by a private `MutableStateFlow`. Scalar reads use `online.value`; observers can collect the flow for change notifications.
- Adds a public `setOnline(Boolean)` helper as the sole mutation point. Every subclass (RNode, TCP client/server, Local client/server, UDP, Auto + peer, BLE + peer, I2P + peer, SPP, Nearby + peer, Pipe) updated in lockstep.
- Bumps `kotlinx-coroutines-core` in `rns-interfaces` from `implementation` to `api` since `StateFlow<Boolean>` is now part of the public API.

## Motivation

`RNodeInterface` sets itself online ~4 seconds after registration (once the USB handshake completes). Consumers that captured the `online` value at registration time (e.g., Columba's `NativeInterfaceFactory` → `InterfaceMgmtVM`) saw `false` and never observed the transition, leaving the UI card stale forever. `StateFlow` gives the "current value + updates" shape that lets observers react to transitions without polling.

## Scope

**Included:**
- `rns-interfaces/Interface.kt` (base class, API change)
- `rns-interfaces/InterfaceAdapter.kt` (delegates via `.value`)
- 12 concrete interface subclasses (same-instance `online.set(x)` → `setOnline(x)`, `online.get()` → `online.value`)
- `conformance-bridge/BehavioralTransport.kt` (MockInterface start() override)
- Test updates across `rns-interfaces/src/test`, `rns-test/src/main`, `rns-test/src/test`, `test-scripts`

**Transport-side `InterfaceRef.online: Boolean`:** unchanged. Transport.kt and InterfaceDiscovery.kt that read `interface.online` keep working — only the Interface implementation layer changed.

## Breaking change

Any external caller using `iface.online.get()` / `iface.online.set(x)` on a concrete `Interface` subclass must migrate to `iface.online.value` / `iface.setOnline(x)`. The only known external consumer is Columba, which currently accesses interfaces through `InterfaceRef` (unaffected) and will get an observer added in a stacked Columba PR that uses the new flow to refresh UI state on RNode handshake completion.

## Test plan

- [x] `./gradlew :rns-core:test :rns-interfaces:test` — passing locally
- [x] `./gradlew :conformance-bridge:compileKotlin :rns-test:compileTestKotlin` — compiles
- [ ] Reviewer: sanity-check no cross-instance `peer.setOnline(false)` call path regresses (NearbyInterface.detach uses this to tear down spawned peers without triggering the re-entrant detach path — behavior preserved)

## Follow-up

Columba PR [`fix/rnode-interface-ui-stale-online-state`](https://github.com/torlando-tech/columba) bumps `reticulumKt` to v0.0.9 and adds a StateFlow collector on each registered Interface's `onlineState`, re-emitting interface snapshots on every change.

Co-Authored-By: Claude Opus 4.7 (1M context)