### PR TITLE
Annotate BLE packets with rStatRssi so LXMF surfaces received RSSI

### DIFF
--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -452,8 +452,11 @@ class BLEInterface(
         // Check if interface already exists for this identity (MAC rotation)
         val existing = peers[identityHex]
         if (existing != null) {
-            existing.updateConnection(connection, address)
+            // Order matters: discoveryRssi is read by startRssiPolling() inside
+            // updateConnection() to seed rStatRssi. Write the fresh scan RSSI
+            // first so the seed reflects the new connection, not the old one.
             existing.discoveryRssi = rssi
+            existing.updateConnection(connection, address)
             addressToIdentity[address] = identityHex
             identityToAddress[identityHex] = address
             log("Reused existing interface for ${identityHex.take(8)} at new address ${address.takeLast(8)}")

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
@@ -93,17 +93,27 @@ class BLEPeerInterface(
     }
 
     /**
-     * Poll RSSI every 10 seconds on central (outgoing) connections.
-     * Peripheral connections don't have a GATT client handle, so RSSI reads are unsupported.
+     * Poll RSSI every 10 seconds on central (outgoing) connections and mirror
+     * the value into the base-class [rStatRssi] so Transport.inbound annotates
+     * every received packet with it. This is a poll-interval-stale proxy for
+     * per-packet RSSI — Android's BluetoothGatt does not expose RSSI per GATT
+     * notification. Peripheral connections have no GATT client handle so
+     * [android.bluetooth.BluetoothGatt.readRemoteRssi] is unavailable there;
+     * we leave [rStatRssi] null on that side (packets stay un-annotated).
      */
     private fun startRssiPolling() {
         if (!isOutgoing) return
+        // Seed with the scan-time RSSI so packets received during the first
+        // 10-second polling window are still annotated with a meaningful value.
+        rStatRssi = discoveryRssi
         rssiJob = scope.launch {
             while (online.value && !detached.get()) {
                 delay(10_000)
                 if (!online.value || detached.get()) break
                 try {
-                    currentRssi = connection.readRemoteRssi()
+                    val rssi = connection.readRemoteRssi()
+                    currentRssi = rssi
+                    rStatRssi = rssi
                 } catch (_: Exception) {
                     // Not all connections support RSSI reading — silently ignore
                 }

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
@@ -100,8 +100,13 @@ class BLEPeerInterface(
      * notification. Peripheral connections have no GATT client handle so
      * [android.bluetooth.BluetoothGatt.readRemoteRssi] is unavailable there;
      * we leave [rStatRssi] null on that side (packets stay un-annotated).
+     *
+     * Visible as `internal` (rather than private) so unit tests can exercise
+     * the seed-from-[discoveryRssi] path without waiting on a real 10-second
+     * GATT polling loop. The per-tick poll logic lives in [pollAndApplyRssi]
+     * and is tested separately.
      */
-    private fun startRssiPolling() {
+    internal fun startRssiPolling() {
         if (!isOutgoing) return
         // Seed with the scan-time RSSI so packets received during the first
         // 10-second polling window are still annotated with a meaningful value.
@@ -110,14 +115,29 @@ class BLEPeerInterface(
             while (online.value && !detached.get()) {
                 delay(10_000)
                 if (!online.value || detached.get()) break
-                try {
-                    val rssi = connection.readRemoteRssi()
-                    currentRssi = rssi
-                    rStatRssi = rssi
-                } catch (_: Exception) {
-                    // Not all connections support RSSI reading — silently ignore
-                }
+                pollAndApplyRssi()
             }
+        }
+    }
+
+    /**
+     * One RSSI poll tick: read from the GATT connection and mirror the result
+     * into both [currentRssi] (for peer scoring) and the base-class
+     * [rStatRssi] (for per-packet annotation via Transport.inbound). Any
+     * exception from [BLEPeerConnection.readRemoteRssi] is silently swallowed
+     * so a flaky read doesn't clobber a previously-valid reading.
+     *
+     * Visible as `internal` so unit tests can call it directly with a fake
+     * connection, avoiding the 10-second `delay` inside [startRssiPolling]'s
+     * launch block.
+     */
+    internal suspend fun pollAndApplyRssi() {
+        try {
+            val rssi = connection.readRemoteRssi()
+            currentRssi = rssi
+            rStatRssi = rssi
+        } catch (_: Exception) {
+            // Not all connections support RSSI reading — silently ignore
         }
     }
 

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEPeerInterfaceRssiTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEPeerInterfaceRssiTest.kt
@@ -1,0 +1,153 @@
+package network.reticulum.interfaces.ble
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for BLE per-packet RSSI annotation.
+ *
+ * [BLEPeerInterface.startRssiPolling] seeds the base-class `rStatRssi` from
+ * `discoveryRssi` and then updates it via [BLEPeerInterface.pollAndApplyRssi]
+ * every 10 seconds on central (outgoing) connections. Transport.inbound later
+ * reads `rStatRssi` onto each received packet; LXMF surfaces it as
+ * `LXMessage.receivedRssi`. Without these annotations, BLE messages render
+ * with no signal info in downstream UIs.
+ */
+@DisplayName("BLEPeerInterface RSSI annotation")
+class BLEPeerInterfaceRssiTest {
+
+    private val liveInterfaces = mutableListOf<BLEPeerInterface>()
+
+    @AfterEach
+    fun cleanup() {
+        // Cancels internal scopes (and the rssiJob inside) to avoid leaking
+        // coroutines across test cases.
+        liveInterfaces.forEach { runCatching { it.detach() } }
+        liveInterfaces.clear()
+    }
+
+    @Test
+    fun `peripheral connection leaves rStatRssi null - Android has no peripheral-side RSSI`() {
+        val peer = newPeerInterface(isOutgoing = false, discoveryRssi = -65)
+
+        peer.startRssiPolling()
+
+        // Peripheral side (GATT server) has no readRemoteRssi equivalent,
+        // so rStatRssi must stay null — packets on that interface stay
+        // un-annotated rather than carry fabricated values.
+        peer.rStatRssi shouldBe null
+    }
+
+    @Test
+    fun `central connection seeds rStatRssi from discoveryRssi on start`() {
+        val peer = newPeerInterface(isOutgoing = true, discoveryRssi = -72)
+
+        peer.startRssiPolling()
+
+        // First 10-second polling window: packets received before the first
+        // readRemoteRssi poll completes must still be annotated, so we seed
+        // from the scan-time RSSI captured at peer discovery.
+        peer.rStatRssi shouldBe -72
+    }
+
+    @Test
+    fun `poll updates both currentRssi and rStatRssi from readRemoteRssi`() =
+        runTest {
+            val conn = FakeBLEPeerConnection(rssiSupplier = { -58 })
+            val peer = newPeerInterface(connection = conn, isOutgoing = true)
+
+            peer.pollAndApplyRssi()
+
+            // currentRssi: used by peer-scoring.
+            // rStatRssi: read by Transport.inbound to annotate every packet.
+            // Both must be updated in lockstep.
+            peer.currentRssi shouldBe -58
+            peer.rStatRssi shouldBe -58
+        }
+
+    @Test
+    fun `poll exception is swallowed and prior rStatRssi is retained`() =
+        runTest {
+            val conn = FakeBLEPeerConnection(rssiSupplier = {
+                throw RuntimeException("GATT read failed")
+            })
+            val peer = newPeerInterface(connection = conn, isOutgoing = true)
+            peer.rStatRssi = -80 // prior valid reading from an earlier poll
+
+            peer.pollAndApplyRssi()
+
+            // A flaky readRemoteRssi must not clobber the last-known-good
+            // value; leaving rStatRssi null would mean the next annotated
+            // packet silently drops RSSI for no good reason.
+            peer.rStatRssi shouldBe -80
+        }
+
+    private fun newPeerInterface(
+        connection: FakeBLEPeerConnection = FakeBLEPeerConnection(rssiSupplier = { -70 }),
+        isOutgoing: Boolean = true,
+        discoveryRssi: Int = -70,
+    ): BLEPeerInterface {
+        val parent =
+            BLEInterface(
+                name = "BLE-test",
+                driver = StubBLEDriver(),
+                transportIdentity = ByteArray(16),
+            )
+        val peer =
+            BLEPeerInterface(
+                name = "BLE|test",
+                connection = connection,
+                parentBleInterface = parent,
+                peerIdentity = ByteArray(16),
+            )
+        peer.isOutgoing = isOutgoing
+        peer.discoveryRssi = discoveryRssi
+        liveInterfaces += peer
+        return peer
+    }
+
+    /**
+     * Minimal [BLEPeerConnection] fake. `readRemoteRssi` behavior is
+     * controlled by the caller-supplied [rssiSupplier] to exercise both
+     * happy-path and exception-path poll outcomes.
+     */
+    private class FakeBLEPeerConnection(
+        private val rssiSupplier: () -> Int,
+    ) : BLEPeerConnection {
+        override val address: String = "00:11:22:33:44:55"
+        override val mtu: Int = 185
+        override val identity: ByteArray? = ByteArray(16)
+        override val receivedFragments: SharedFlow<ByteArray> = MutableSharedFlow()
+        override suspend fun sendFragment(data: ByteArray) = Unit
+        override suspend fun readIdentity(): ByteArray = ByteArray(16)
+        override suspend fun writeIdentity(identity: ByteArray) = Unit
+        override suspend fun readRemoteRssi(): Int = rssiSupplier()
+        override fun close() = Unit
+    }
+
+    /**
+     * Minimal [BLEDriver] stub sufficient to construct a [BLEInterface]
+     * parent; no method on the driver is called during these tests.
+     */
+    private class StubBLEDriver : BLEDriver {
+        override suspend fun startAdvertising() = Unit
+        override suspend fun stopAdvertising() = Unit
+        override suspend fun startScanning() = Unit
+        override suspend fun stopScanning() = Unit
+        override suspend fun connect(address: String): BLEPeerConnection =
+            error("unused in RSSI tests")
+
+        override suspend fun disconnect(address: String) = Unit
+        override fun shutdown() = Unit
+        override val discoveredPeers: SharedFlow<DiscoveredPeer> = MutableSharedFlow()
+        override val incomingConnections: SharedFlow<BLEPeerConnection> = MutableSharedFlow()
+        override val connectionLost: SharedFlow<String> = MutableSharedFlow()
+        override val localAddress: String? = null
+        override val isRunning: Boolean = false
+    }
+}


### PR DESCRIPTION
## Summary

- `BLEPeerInterface` has polled `currentRssi` from `BluetoothGatt.readRemoteRssi` every 10 seconds on central/outgoing connections, but only stored it for peer-scoring — never in `rStatRssi`. Transport's per-packet annotation path (`packet.rssi = interfaceRef.rStatRssi`) therefore always sees null for BLE.
- LXMF-kt v0.0.5 annotates `LXMessage.receivedRssi` from `sourcePacket.rssi`, so the downstream effect in Columba (and any consumer that reads `LXMessage.receivedRssi`) is that the **BLE message-details UI renders no RSSI**.
- Fix mirrors the polled value into `rStatRssi` on each successful poll and seeds it with `discoveryRssi` up front so packets received in the first 10s window aren't orphaned.

## Scope

Central (outgoing) connections only:
- `readRemoteRssi` is a GATT-client API and is unavailable on `BluetoothGattServer`.
- Peripheral-side (`isOutgoing = false`) interfaces therefore remain un-annotated — correct behavior given the Android limitation. SNR stays null across all BLE paths (classic GATT doesn't expose SNR).

## Tradeoff

RSSI annotations are up to ~10 seconds stale relative to the packet they ride on. Android's GATT API doesn't expose per-notification RSSI, so this is the best approximation achievable at the transport layer.

## Test plan

- [x] `:rns-interfaces:compileKotlin` clean
- [ ] Manual: install downstream (Columba) and verify BLE message details show a non-null RSSI value on the central side
- [ ] Manual: verify peripheral side still renders RSSI as blank / null (expected — Android limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)