### PR TITLE
CI: migrate conformance workflow to per-impl CONFORMANCE_KOTLIN_BRIDGE_CMD

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -59,6 +59,20 @@ jobs:
           ./gradlew -q :rns-cli:printPipePeerRuntimeClasspath | perl -pe 's/\e\][^\a]*\a//g' >> "$GITHUB_ENV"
           echo 'EOF' >> "$GITHUB_ENV"
 
+      # Guard against a silent coverage regression: if this workflow is run
+      # against a reticulum-conformance checkout that predates per-impl
+      # override support (reticulum-conformance#13), then
+      # CONFORMANCE_KOTLIN_BRIDGE_CMD is silently ignored, kotlin peers fall
+      # back to the default Python RNS bridge, and CI can pass green without
+      # ever spawning the freshly-built JAR. Fail loudly instead.
+      - name: Verify conformance framework supports per-impl bridge overrides
+        working-directory: reticulum-conformance
+        run: |
+          if ! grep -q 'CONFORMANCE_KOTLIN_BRIDGE_CMD' conftest.py; then
+            echo "::error file=.github/workflows/conformance.yml::reticulum-conformance conftest.py does not recognize CONFORMANCE_KOTLIN_BRIDGE_CMD; kotlin peers would silently fall back to the Python bridge. Merge reticulum-conformance#13 first." >&2
+            exit 1
+          fi
+
       - name: Run bridge conformance tests
         working-directory: reticulum-conformance
         env:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -62,7 +62,13 @@ jobs:
       - name: Run bridge conformance tests
         working-directory: reticulum-conformance
         env:
-          CONFORMANCE_BRIDGE_CMD: java -jar ${{ github.workspace }}/reticulum-kt/conformance-bridge/build/libs/ConformanceBridge.jar
+          # Per-impl bridge overrides. Kotlin peers use the freshly-built
+          # JAR from the matching checkout; reference peers use the default
+          # Python bridge (conftest.py BRIDGE_COMMANDS["reference"]) so
+          # cross-impl parametrization actually exercises both stacks.
+          # The legacy CONFORMANCE_BRIDGE_CMD override was a superset of
+          # both, which silently masked xfails keyed off transport_impl.
+          CONFORMANCE_KOTLIN_BRIDGE_CMD: java -jar ${{ github.workspace }}/reticulum-kt/conformance-bridge/build/libs/ConformanceBridge.jar
           PYTHON_RNS_PATH: ${{ github.workspace }}/Reticulum
           PYTHON_LXMF_PATH: ${{ github.workspace }}/LXMF
         # tests/lxmf/ is the LXMF-layer conformance suite, owned by


### PR DESCRIPTION
## Summary

- Migrate this repo's conformance workflow from the deprecated global `CONFORMANCE_BRIDGE_CMD` to the per-impl `CONFORMANCE_KOTLIN_BRIDGE_CMD`.
- After this change, \`reference\` peers in cross-impl parametrization spawn the real Python RNS bridge (via reticulum-conformance's default), instead of masquerading as the Kotlin bridge.

## Why

The legacy global override applied to every peer regardless of impl, which silently bypassed xfails keyed on \`transport_impl == \"kotlin\"\`. A test like \`test_path_response_reuses_cached_announce[reference->reference->reference]\` was actually running 3 Kotlin bridges and tripping the reticulum-kt#46 TCPServerInterface fan-out bug — but the xfail at \`test_path_discovery.py:185\` never fired because the parametrization's impl names no longer matched the bridges actually spawned.

After reticulum-conformance#13 lands, the per-impl var is recognized and reference peers use the Python bridge.

## Depends on

- [ ] **reticulum-conformance#13** (\"Split CONFORMANCE_BRIDGE_CMD into per-impl env vars + add CI\") must merge first. Until then, the new env var is ignored by conformance's \`resolve_command()\` and this workflow effectively still routes everything to the default reference Python bridge for non-kotlin peers — but the reticulum-kt bridge would not be picked up for kotlin peers because it's only under the new env var. Merge ordering matters.

## Test plan

- [ ] Once reticulum-conformance#13 merges, this PR's conformance CI run should show xfails only on \`*->kotlin->*\` cases, with no residual failures.
- [x] Local run with the new per-impl var + fresh conformance main verifies the behavior (see PR #13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)