### PR TITLE
Fix BLEInterface incoming-handshake storm and blacklist race

### DIFF
--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -317,13 +317,13 @@ class BLEInterface(
 
             if (isBlacklisted(address)) {
                 log("Rejecting incoming from ${address.takeLast(8)}: blacklisted")
-                try { driver.disconnect(address) } catch (_: Exception) {}
+                rejectConnection(address)
                 return@collect
             }
 
             if (!incomingHandshakesInFlight.add(address)) {
                 log("Handshake already in flight for ${address.takeLast(8)}, rejecting duplicate incoming")
-                try { driver.disconnect(address) } catch (_: Exception) {}
+                rejectConnection(address)
                 return@collect
             }
 
@@ -334,6 +334,22 @@ class BLEInterface(
                     incomingHandshakesInFlight.remove(address)
                 }
             }
+        }
+    }
+
+    /**
+     * Fire-and-forget driver disconnect used by the incoming collect lambda's
+     * pre-flight rejects. Swallows driver errors (the remote may already be
+     * gone) but re-throws [CancellationException] so scope cancellation still
+     * propagates through the outer `collect`.
+     */
+    private suspend fun rejectConnection(address: String) {
+        try {
+            driver.disconnect(address)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Driver disconnect is best-effort — the connection may already be gone.
         }
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -59,7 +59,7 @@ class BLEInterface(
     private val identityToAddress = ConcurrentHashMap<String, String>()
 
     // Exponential blacklist: address -> expiry + failure count
-    private data class BlacklistEntry(val expiry: Long, val failureCount: Int)
+    internal data class BlacklistEntry(val expiry: Long, val failureCount: Int)
     private val blacklist = ConcurrentHashMap<String, BlacklistEntry>()
 
     // Reconnection backoff: address -> next-attempt-after timestamp
@@ -68,6 +68,12 @@ class BLEInterface(
 
     // Addresses currently being connected to (prevents concurrent attempts to same address)
     private val pendingConnections = ConcurrentHashMap.newKeySet<String>()
+
+    // Addresses with an in-flight incoming identity handshake. Single-flight
+    // guard so rapid repeated GATT connects from the same MAC don't each spawn
+    // their own 30-second handshake coroutine (battery-burning log storm seen
+    // 2026-04-21 on the .71 phone).
+    private val incomingHandshakesInFlight = ConcurrentHashMap.newKeySet<String>()
 
     init {
         spawnedInterfaces = java.util.concurrent.CopyOnWriteArrayList()
@@ -148,6 +154,7 @@ class BLEInterface(
         addressToIdentity.clear()
         identityToAddress.clear()
         pendingConnections.clear()
+        incomingHandshakesInFlight.clear()
 
         // Shut down the BLE driver
         driver.shutdown()
@@ -294,11 +301,38 @@ class BLEInterface(
 
     /**
      * Collect incoming connections from the GATT server and handle identity handshake.
+     *
+     * Pre-flight filtering (before spawning the 30s-timeout handshake coroutine):
+     *  - Blacklisted address: disconnect immediately; do not waste a handshake slot.
+     *  - Already an incoming handshake in flight for this MAC: disconnect the
+     *    duplicate so one connection can complete instead of three timing out.
+     *
+     * This guards against the 2026-04-21 battery-burning log storm where the
+     * same MAC spawned concurrent handshake coroutines, all timing out at the
+     * same instant and racing to bump the blacklist counter.
      */
     private suspend fun collectIncomingConnections() {
         driver.incomingConnections.collect { connection ->
+            val address = connection.address
+
+            if (isBlacklisted(address)) {
+                log("Rejecting incoming from ${address.takeLast(8)}: blacklisted")
+                try { driver.disconnect(address) } catch (_: Exception) {}
+                return@collect
+            }
+
+            if (!incomingHandshakesInFlight.add(address)) {
+                log("Handshake already in flight for ${address.takeLast(8)}, rejecting duplicate incoming")
+                try { driver.disconnect(address) } catch (_: Exception) {}
+                return@collect
+            }
+
             scope.launch {
-                handleIncomingConnection(connection)
+                try {
+                    handleIncomingConnection(connection)
+                } finally {
+                    incomingHandshakesInFlight.remove(address)
+                }
             }
         }
     }
@@ -563,17 +597,34 @@ class BLEInterface(
     /**
      * Add an address to the blacklist with exponential backoff.
      * Duration grows: 60s, 120s, 180s, 240s, 300s, 360s, 420s, 480s (capped at 8x base).
+     *
+     * Uses [ConcurrentHashMap.compute] so concurrent callers serialize on the
+     * map bucket lock — the prior read-then-write race dropped increments and
+     * produced duplicate log lines (#2 / #3 / #4 at the same timestamp for a
+     * single underlying failure event).
      */
     private fun addToBlacklist(address: String) {
-        val existing = blacklist[address]
-        val count = (existing?.failureCount ?: 0) + 1
-        val duration = BLEConstants.BLACKLIST_BASE_DURATION_MS * minOf(count, BLEConstants.BLACKLIST_MAX_MULTIPLIER)
-        blacklist[address] = BlacklistEntry(
-            expiry = System.currentTimeMillis() + duration,
-            failureCount = count,
-        )
-        log("Blacklisted ${address.takeLast(8)} for ${duration / 1000}s (failure #$count)")
+        val entry = blacklist.compute(address) { _, existing ->
+            val count = (existing?.failureCount ?: 0) + 1
+            val duration = BLEConstants.BLACKLIST_BASE_DURATION_MS *
+                minOf(count, BLEConstants.BLACKLIST_MAX_MULTIPLIER)
+            BlacklistEntry(
+                expiry = System.currentTimeMillis() + duration,
+                failureCount = count,
+            )
+        }!!
+        val durationSec = (entry.expiry - System.currentTimeMillis()) / 1000
+        log("Blacklisted ${address.takeLast(8)} for ${durationSec}s (failure #${entry.failureCount})")
     }
+
+    // ---- Test-only accessors ----
+    // Narrow visibility concession so `BLEInterfaceIncomingHandshakeTest` can
+    // seed/inspect the blacklist without broadening the public API.
+
+    internal fun addToBlacklistForTest(address: String) = addToBlacklist(address)
+
+    internal fun getBlacklistEntryForTest(address: String): BlacklistEntry? =
+        blacklist[address]
 
     private fun isInBackoff(address: String): Boolean {
         val nextAttemptAfter = reconnectBackoff[address] ?: return false

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -613,8 +613,13 @@ class BLEInterface(
                 failureCount = count,
             )
         }!!
-        val durationSec = (entry.expiry - System.currentTimeMillis()) / 1000
-        log("Blacklisted ${address.takeLast(8)} for ${durationSec}s (failure #${entry.failureCount})")
+        // Recompute duration from failureCount instead of (expiry - now) so the
+        // log line matches the stored window exactly (avoids the "59s for a 60s
+        // entry" jitter when the compute lambda and the log line straddle a
+        // millisecond boundary).
+        val durationMs = BLEConstants.BLACKLIST_BASE_DURATION_MS *
+            minOf(entry.failureCount, BLEConstants.BLACKLIST_MAX_MULTIPLIER)
+        log("Blacklisted ${address.takeLast(8)} for ${durationMs / 1000}s (failure #${entry.failureCount})")
     }
 
     // ---- Test-only accessors ----

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -317,13 +317,13 @@ class BLEInterface(
 
             if (isBlacklisted(address)) {
                 log("Rejecting incoming from ${address.takeLast(8)}: blacklisted")
-                rejectConnection(address)
+                closeRejectedConnection(connection)
                 return@collect
             }
 
             if (!incomingHandshakesInFlight.add(address)) {
                 log("Handshake already in flight for ${address.takeLast(8)}, rejecting duplicate incoming")
-                rejectConnection(address)
+                closeRejectedConnection(connection)
                 return@collect
             }
 
@@ -338,18 +338,17 @@ class BLEInterface(
     }
 
     /**
-     * Fire-and-forget driver disconnect used by the incoming collect lambda's
-     * pre-flight rejects. Swallows driver errors (the remote may already be
-     * gone) but re-throws [CancellationException] so scope cancellation still
-     * propagates through the outer `collect`.
+     * Close the specific rejected [BLEPeerConnection] without invoking
+     * [BLEDriver.disconnect], which is address-scoped and would tear down any
+     * other active GATT slot for the same MAC — including the first incoming
+     * connection in a duplicate-rejection scenario, defeating the single-flight
+     * guard. [BLEPeerConnection.close] only drops this specific connection.
      */
-    private suspend fun rejectConnection(address: String) {
+    private fun closeRejectedConnection(connection: BLEPeerConnection) {
         try {
-            driver.disconnect(address)
-        } catch (e: CancellationException) {
-            throw e
+            connection.close()
         } catch (_: Exception) {
-            // Driver disconnect is best-effort — the connection may already be gone.
+            // Best-effort: the remote may have already torn the connection down.
         }
     }
 

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEInterfaceIncomingHandshakeTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEInterfaceIncomingHandshakeTest.kt
@@ -1,6 +1,6 @@
 package network.reticulum.interfaces.ble
 
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Regression tests for the 2026-04-21 BLE incoming-handshake storm.
@@ -64,26 +65,35 @@ class BLEInterfaceIncomingHandshakeTest {
             driver.incomingConnections.emit(connB)
 
             // Deterministic waits instead of a fixed quiescence delay (flaky on
-            // slow CI): wait until the first handshake subscribes AND the
-            // duplicate is rejected via driver.disconnect.
+            // slow CI): wait until the first handshake subscribes AND exactly
+            // one of the two FakeBLEPeerConnection objects has been close()d.
             waitUntil("first handshake subscribes to receivedFragments") {
                 connA.receivedFragmentsSubscribers +
                     connB.receivedFragmentsSubscribers >= 1
             }
-            waitUntil("duplicate is rejected via driver.disconnect") {
-                driver.disconnectCalls.contains(DUP_MAC)
+            waitUntil("duplicate connection is closed via BLEPeerConnection.close") {
+                connA.closeCount + connB.closeCount >= 1
             }
 
             // Exactly one handshake must have subscribed to receivedFragments.
-            // With the concurrency bug, BOTH connections subscribe and each
+            // With the single-flight bug, BOTH connections subscribe and each
             // burns its own 30s handshake-timeout coroutine.
             val subscribers = connA.receivedFragmentsSubscribers +
                 connB.receivedFragmentsSubscribers
             subscribers shouldBe 1
 
-            // The duplicate must be proactively disconnected via the driver
-            // (not left to time out after 30s).
-            driver.disconnectCalls shouldContain DUP_MAC
+            // Exactly one of the two connections must have been closed (the
+            // duplicate). Closing a specific BLEPeerConnection rather than
+            // calling driver.disconnect(address) is important: the latter is
+            // address-scoped per the driver contract and would tear down the
+            // in-flight handshake we are trying to protect.
+            val closes = connA.closeCount + connB.closeCount
+            closes shouldBe 1
+
+            // driver.disconnect(address) must NOT be called here — it is
+            // address-scoped and would kill the live handshake. Guard against
+            // the regression Greptile flagged on PR #51 iteration 3.
+            driver.disconnectCalls.shouldBeEmpty()
         }
     }
 
@@ -107,19 +117,25 @@ class BLEInterfaceIncomingHandshakeTest {
             driver.incomingConnections.emit(conn)
 
             // Deterministic wait on the observable outcome: the pre-flight
-            // blacklist check must have called driver.disconnect.
-            waitUntil("blacklisted MAC rejected via driver.disconnect") {
-                driver.disconnectCalls.contains(BLACKLISTED_MAC)
+            // blacklist check closes the new connection directly.
+            waitUntil("blacklisted MAC closed via BLEPeerConnection.close") {
+                conn.closeCount >= 1
             }
 
             // No handshake subscription — we never read receivedFragments.
-            // With the current bug, handleIncomingConnection proceeds into
-            // performHandshakeAsPeripheral() regardless of blacklist status,
-            // subscribing to receivedFragments and burning a 30s timeout.
+            // With the missing pre-flight bug, handleIncomingConnection
+            // proceeds into performHandshakeAsPeripheral() regardless of
+            // blacklist status, subscribing to receivedFragments and burning
+            // a 30s timeout.
             conn.receivedFragmentsSubscribers shouldBe 0
 
-            // Driver was told to drop the connection.
-            driver.disconnectCalls shouldContain BLACKLISTED_MAC
+            // The incoming connection was closed directly.
+            conn.closeCount shouldBe 1
+
+            // driver.disconnect(address) must NOT be called — address-scoped
+            // teardown could collide with any other active connection to the
+            // same MAC.
+            driver.disconnectCalls.shouldBeEmpty()
         }
     }
 
@@ -229,7 +245,9 @@ class BLEInterfaceIncomingHandshakeTest {
     /**
      * Minimal [BLEPeerConnection] fake. Exposes subscriber count on the
      * receivedFragments flow so tests can tell whether the peripheral-side
-     * identity handshake actually started (which subscribes via `first { }`).
+     * identity handshake actually started (which subscribes via `first { }`),
+     * and a close-call counter so tests can verify the duplicate-rejection
+     * path closed THIS specific connection rather than a different one.
      */
     private class FakeBLEPeerConnection(
         override val address: String,
@@ -241,11 +259,15 @@ class BLEInterfaceIncomingHandshakeTest {
             _receivedFragments.asSharedFlow()
         val receivedFragmentsSubscribers: Int
             get() = _receivedFragments.subscriptionCount.value
+        private val _closeCount = AtomicInteger(0)
+        val closeCount: Int get() = _closeCount.get()
         override suspend fun sendFragment(data: ByteArray) = Unit
         override suspend fun readIdentity(): ByteArray = ByteArray(16)
         override suspend fun writeIdentity(identity: ByteArray) = Unit
         override suspend fun readRemoteRssi(): Int = -70
-        override fun close() = Unit
+        override fun close() {
+            _closeCount.incrementAndGet()
+        }
     }
 
     /**

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEInterfaceIncomingHandshakeTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEInterfaceIncomingHandshakeTest.kt
@@ -63,10 +63,16 @@ class BLEInterfaceIncomingHandshakeTest {
             driver.incomingConnections.emit(connA)
             driver.incomingConnections.emit(connB)
 
-            // Let the launched handlers run. We don't need the 30s handshake to fire,
-            // just enough time for the handlers to either start the handshake
-            // (subscribe to receivedFragments) or reject the duplicate.
-            waitForQuiescence()
+            // Deterministic waits instead of a fixed quiescence delay (flaky on
+            // slow CI): wait until the first handshake subscribes AND the
+            // duplicate is rejected via driver.disconnect.
+            waitUntil("first handshake subscribes to receivedFragments") {
+                connA.receivedFragmentsSubscribers +
+                    connB.receivedFragmentsSubscribers >= 1
+            }
+            waitUntil("duplicate is rejected via driver.disconnect") {
+                driver.disconnectCalls.contains(DUP_MAC)
+            }
 
             // Exactly one handshake must have subscribed to receivedFragments.
             // With the concurrency bug, BOTH connections subscribe and each
@@ -100,7 +106,11 @@ class BLEInterfaceIncomingHandshakeTest {
             val conn = FakeBLEPeerConnection(address = BLACKLISTED_MAC)
             driver.incomingConnections.emit(conn)
 
-            waitForQuiescence()
+            // Deterministic wait on the observable outcome: the pre-flight
+            // blacklist check must have called driver.disconnect.
+            waitUntil("blacklisted MAC rejected via driver.disconnect") {
+                driver.disconnectCalls.contains(BLACKLISTED_MAC)
+            }
 
             // No handshake subscription — we never read receivedFragments.
             // With the current bug, handleIncomingConnection proceeds into
@@ -192,9 +202,23 @@ class BLEInterfaceIncomingHandshakeTest {
         }
     }
 
-    /** Let launched handlers make progress before we inspect state. */
-    private suspend fun waitForQuiescence() {
-        delay(150)
+    /**
+     * Poll [condition] until it holds or a 2-second deadline elapses. Preferred
+     * over a fixed [delay] because a slow CI scheduler can postpone launched
+     * coroutines past a hard-coded wait window; polling a deterministic
+     * observable is robust to that. Throws [kotlinx.coroutines.TimeoutCancellationException]
+     * with [description] included on timeout to give a legible failure message.
+     */
+    private suspend fun waitUntil(description: String, condition: () -> Boolean) {
+        try {
+            withTimeout(2_000) {
+                while (!condition()) {
+                    delay(10)
+                }
+            }
+        } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            error("waitUntil: $description never became true within 2s")
+        }
     }
 
     companion object {

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEInterfaceIncomingHandshakeTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEInterfaceIncomingHandshakeTest.kt
@@ -1,0 +1,253 @@
+package network.reticulum.interfaces.ble
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Regression tests for the 2026-04-21 BLE incoming-handshake storm.
+ *
+ * Observed on a Columba `.71` phone: the same MAC spawned multiple parallel
+ * `Identity handshake timeout for incoming <MAC>, disconnecting` events at
+ * the same timestamp, each incrementing the blacklist failure counter
+ * (producing log lines for `failure #2`, `#3`, `#4` at the same instant).
+ *
+ * Three root causes in [BLEInterface] that together produce the storm:
+ *   1. `collectIncomingConnections()` spawns a new 30s handshake coroutine
+ *      for every incoming [BLEPeerConnection] event on the same MAC; no
+ *      single-flight guard.
+ *   2. `handleIncomingConnection` does NOT check the blacklist, so a
+ *      blacklisted peer re-connecting still burns a 30s handshake slot.
+ *   3. `addToBlacklist` is a non-atomic read-modify-write on a
+ *      ConcurrentHashMap, so N concurrent callers may race and produce
+ *      fewer than N increments (or in the worst case, N duplicate
+ *      increments as observed in the field).
+ *
+ * Each test below isolates one of those three failure modes.
+ */
+@DisplayName("BLEInterface incoming handshake concurrency")
+class BLEInterfaceIncomingHandshakeTest {
+
+    private val liveInterfaces = mutableListOf<BLEInterface>()
+
+    @AfterEach
+    fun cleanup() {
+        liveInterfaces.forEach { runCatching { it.detach() } }
+        liveInterfaces.clear()
+    }
+
+    @Test
+    fun `two rapid incoming connections for same MAC start only one handshake`() {
+        runBlocking {
+            val driver = StubBLEDriver()
+            val iface = newInterface(driver)
+
+            iface.start()
+            // Allow collectIncomingConnections() to subscribe to driver.incomingConnections
+            // before we emit anything (replay=0, so emissions before subscribe are lost).
+            waitForCollector(driver)
+
+            val connA = FakeBLEPeerConnection(address = DUP_MAC)
+            val connB = FakeBLEPeerConnection(address = DUP_MAC)
+
+            driver.incomingConnections.emit(connA)
+            driver.incomingConnections.emit(connB)
+
+            // Let the launched handlers run. We don't need the 30s handshake to fire,
+            // just enough time for the handlers to either start the handshake
+            // (subscribe to receivedFragments) or reject the duplicate.
+            waitForQuiescence()
+
+            // Exactly one handshake must have subscribed to receivedFragments.
+            // With the concurrency bug, BOTH connections subscribe and each
+            // burns its own 30s handshake-timeout coroutine.
+            val subscribers = connA.receivedFragmentsSubscribers +
+                connB.receivedFragmentsSubscribers
+            subscribers shouldBe 1
+
+            // The duplicate must be proactively disconnected via the driver
+            // (not left to time out after 30s).
+            driver.disconnectCalls shouldContain DUP_MAC
+        }
+    }
+
+    @Test
+    fun `incoming connection from blacklisted MAC is rejected without starting handshake`() {
+        runBlocking {
+            val driver = StubBLEDriver()
+            val iface = newInterface(driver)
+
+            // Seed a live blacklist entry for the address via the same code
+            // path a real failure would take. Driving this through
+            // `addToBlacklist` keeps the test narrow (one accessor exposed
+            // @VisibleForTesting) while exercising the production blacklist
+            // structure end-to-end.
+            iface.addToBlacklistForTest(BLACKLISTED_MAC)
+
+            iface.start()
+            waitForCollector(driver)
+
+            val conn = FakeBLEPeerConnection(address = BLACKLISTED_MAC)
+            driver.incomingConnections.emit(conn)
+
+            waitForQuiescence()
+
+            // No handshake subscription — we never read receivedFragments.
+            // With the current bug, handleIncomingConnection proceeds into
+            // performHandshakeAsPeripheral() regardless of blacklist status,
+            // subscribing to receivedFragments and burning a 30s timeout.
+            conn.receivedFragmentsSubscribers shouldBe 0
+
+            // Driver was told to drop the connection.
+            driver.disconnectCalls shouldContain BLACKLISTED_MAC
+        }
+    }
+
+    @Test
+    fun `concurrent addToBlacklist calls increment failureCount exactly once per call`() {
+        val driver = StubBLEDriver()
+        val iface = newInterface(driver)
+        val address = "11:22:33:44:55:66"
+        val concurrentCallers = 64
+
+        // Fire many addToBlacklist calls that are ALL released at the same
+        // instant via a CountDownLatch, forcing maximum contention on the
+        // read-modify-write sequence inside `addToBlacklist`. With the
+        // non-atomic bug, multiple callers read the same `existing`
+        // entry, each compute the same `existing.failureCount + 1`, and
+        // then each overwrite each other's put -- so the final count
+        // ends up strictly less than N.
+        //
+        // Running on the JVM thread pool (not coroutine dispatcher) to
+        // defeat any scheduler-level serialization: we want real threads
+        // hammering the ConcurrentHashMap entry.
+        val latch = java.util.concurrent.CountDownLatch(1)
+        val done = java.util.concurrent.CountDownLatch(concurrentCallers)
+        val pool = java.util.concurrent.Executors.newFixedThreadPool(concurrentCallers)
+        try {
+            repeat(concurrentCallers) {
+                pool.execute {
+                    try {
+                        latch.await()
+                        iface.addToBlacklistForTest(address)
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+            latch.countDown() // release the kraken
+            check(done.await(10, java.util.concurrent.TimeUnit.SECONDS)) {
+                "addToBlacklistForTest callers did not finish"
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        val entry = iface.getBlacklistEntryForTest(address)
+        checkNotNull(entry) { "blacklist entry missing for $address" }
+
+        // Every caller must have contributed exactly one increment. Without
+        // the atomic `compute {}` fix, this assertion fails because concurrent
+        // read-modify-write on the ConcurrentHashMap entry loses increments
+        // -- the same #2/#3/#4 storm seen in the wild, where multiple
+        // concurrent handshake timeouts race to bump the counter.
+        entry.failureCount shouldBe concurrentCallers
+
+        // Defensive: catch the reverse bug where a future `compute` refactor
+        // could double-count; final count must never exceed the caller count.
+        entry.failureCount shouldBeLessThanOrEqual concurrentCallers
+    }
+
+    // ---- Helpers ----
+
+    private fun newInterface(driver: StubBLEDriver): BLEInterface {
+        val iface = BLEInterface(
+            name = "BLE-test",
+            driver = driver,
+            transportIdentity = ByteArray(16),
+        )
+        liveInterfaces += iface
+        return iface
+    }
+
+    /**
+     * Give `collectIncomingConnections()` time to subscribe to the driver's
+     * SharedFlow. Without this, `emit()` is dropped (replay=0, no subscribers).
+     */
+    private suspend fun waitForCollector(driver: StubBLEDriver) {
+        withTimeout(2_000) {
+            while (driver.incomingConnections.subscriptionCount.value < 1) {
+                delay(10)
+            }
+        }
+    }
+
+    /** Let launched handlers make progress before we inspect state. */
+    private suspend fun waitForQuiescence() {
+        delay(150)
+    }
+
+    companion object {
+        private const val DUP_MAC = "AA:BB:CC:DD:EE:01"
+        private const val BLACKLISTED_MAC = "AA:BB:CC:DD:EE:02"
+    }
+
+    /**
+     * Minimal [BLEPeerConnection] fake. Exposes subscriber count on the
+     * receivedFragments flow so tests can tell whether the peripheral-side
+     * identity handshake actually started (which subscribes via `first { }`).
+     */
+    private class FakeBLEPeerConnection(
+        override val address: String,
+    ) : BLEPeerConnection {
+        override val mtu: Int = 185
+        override val identity: ByteArray? = null
+        private val _receivedFragments = MutableSharedFlow<ByteArray>(replay = 0)
+        override val receivedFragments: SharedFlow<ByteArray> =
+            _receivedFragments.asSharedFlow()
+        val receivedFragmentsSubscribers: Int
+            get() = _receivedFragments.subscriptionCount.value
+        override suspend fun sendFragment(data: ByteArray) = Unit
+        override suspend fun readIdentity(): ByteArray = ByteArray(16)
+        override suspend fun writeIdentity(identity: ByteArray) = Unit
+        override suspend fun readRemoteRssi(): Int = -70
+        override fun close() = Unit
+    }
+
+    /**
+     * [BLEDriver] stub that records disconnect() calls and exposes a
+     * MutableSharedFlow for incoming connections so tests can drive emission
+     * timing deterministically.
+     */
+    private class StubBLEDriver : BLEDriver {
+        override suspend fun startAdvertising() = Unit
+        override suspend fun stopAdvertising() = Unit
+        override suspend fun startScanning() = Unit
+        override suspend fun stopScanning() = Unit
+        override suspend fun connect(address: String): BLEPeerConnection =
+            error("unused in incoming-handshake tests")
+
+        override suspend fun disconnect(address: String) {
+            disconnectCalls += address
+        }
+
+        override fun shutdown() = Unit
+        override val discoveredPeers: SharedFlow<DiscoveredPeer> = MutableSharedFlow()
+        override val incomingConnections = MutableSharedFlow<BLEPeerConnection>(replay = 0)
+        override val connectionLost: SharedFlow<String> = MutableSharedFlow()
+        override val localAddress: String? = null
+        override val isRunning: Boolean = false
+
+        val disconnectCalls: MutableList<String> = CopyOnWriteArrayList()
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes a battery-burning BLE concurrency bug observed 2026-04-21 on a Columba `.71` phone (~50x the next-heaviest app over 55min foreground-service time)
- Three separate root causes in `BLEInterface.kt`, all triggered by rapid repeated incoming GATT connects from the same MAC
- Scope is **Stack A only** (custom peer-to-peer Reticulum BLE interface in `rns-interfaces/.../ble/BLEInterface.kt`). This PR does **NOT** touch `RNodeInterface.kt` (Stack B, the phone↔RNode-radio KISS-framed serial path)

## The bugs

logcat from the affected session showed the fingerprint:
```
10:15:42.696 thread 28565: Identity handshake timeout for incoming 1A:3D:78, disconnecting
10:15:42.696 thread 10464: Identity handshake timeout for incoming 1A:3D:78, disconnecting
10:15:42.696 thread 7042:  Identity handshake timeout for incoming 1A:3D:78, disconnecting
10:15:42.696 Blacklisted 1A:3D:78 for 180s (failure #3)
10:15:42.696 Blacklisted 1A:3D:78 for 240s (failure #4)
10:15:42.696 Blacklisted 1A:3D:78 for 120s (failure #2)
```

Three concurrent handshake coroutines on one MAC, racing to bump the blacklist counter.

### 1. `collectIncomingConnections()` had no single-flight guard
Every `driver.incomingConnections.collect { ... scope.launch { handleIncomingConnection(connection) } }` emission spawned its own 30-second handshake coroutine. Rapid duplicates from the same MAC piled up N parallel timeouts.

### 2. `handleIncomingConnection` did not check the blacklist
The outgoing path (`collectDiscoveredPeers`) calls `isBlacklisted(address)` and skips. The incoming path did not — so a just-blacklisted MAC could re-connect incoming and burn another 30s handshake slot.

### 3. `addToBlacklist` was a non-atomic read-modify-write
```kotlin
val existing = blacklist[address]
val count = (existing?.failureCount ?: 0) + 1
blacklist[address] = BlacklistEntry(expiry = ..., failureCount = count)
```
`ConcurrentHashMap.put` is atomic per-key but this read-then-write sequence isn't. Concurrent callers read the same `existing` and each wrote `count + 1` — the duplicate `failure #2 / #3 / #4` log lines at the same timestamp are the visible symptom.

## The fix
- Add `incomingHandshakesInFlight: ConcurrentHashMap.newKeySet()` and gate `scope.launch { handleIncomingConnection(...) }` behind it. On rejected duplicates, call `driver.disconnect(address)` immediately.
- Check `isBlacklisted(address)` in `collectIncomingConnections` before the single-flight guard; disconnect immediately on hit.
- Rewrite `addToBlacklist` to use `ConcurrentHashMap.compute { ... }` so the read-modify-write serializes on the bucket lock.

## Regression coverage (TDD, tests written first)

`BLEInterfaceIncomingHandshakeTest` (new). Three tests, each isolating one failure mode, using the `FakeBLEPeerConnection` + `StubBLEDriver` pattern from `BLEPeerInterfaceRssiTest`:

1. **`two rapid incoming connections for same MAC start only one handshake`** — emit two `FakeBLEPeerConnection` instances with the same MAC on the driver's `SharedFlow`; assert `receivedFragments.subscriptionCount` summed across both is exactly 1 (one handshake), and `driver.disconnect(address)` was called. Against main: `expected:<1> but was:<2>`.

2. **`incoming connection from blacklisted MAC is rejected without starting handshake`** — seed a live blacklist entry, emit one incoming from that MAC; assert `receivedFragments.subscriptionCount` is 0 and `disconnect` was called. Against main: `expected:<0> but was:<1>`.

3. **`concurrent addToBlacklist calls increment failureCount exactly once per call`** — 64 JVM threads released simultaneously via a `CountDownLatch`, each calling `addToBlacklist(address)`; assert `failureCount == 64`. Against main: `expected:<64> but was:<1>` (catastrophic under-count — all 64 threads read `null` existing, each wrote 1).

## Visibility concessions
- `BlacklistEntry` promoted from `private` to `internal` (test-only field inspection)
- Two `internal fun {add,get}BlacklistEntryForTest` accessors added

No public API surface changes. No behavioral changes outside the BLE interface.

## Test plan
- [x] `JAVA_HOME=/home/tyler/android-studio/jbr ./gradlew :rns-interfaces:compileKotlin :rns-interfaces:compileTestKotlin` — clean
- [x] `./gradlew :rns-interfaces:test --tests "*BLEInterfaceIncomingHandshake*" --rerun-tasks` — all 3 pass against the fix, all 3 fail against main (confirmed pre-fix run)
- [x] `./gradlew :rns-interfaces:test --rerun-tasks` — no other regressions in the module
- [x] `./gradlew :rns-android:compileReleaseKotlin` — downstream Android module still compiles

## Does NOT touch
- `RNodeInterface.kt` / anything under `rnode/` (Stack B — different bug, different code path)
- `TCPServerInterface.kt` (Columba PR #834 uses it; signatures unchanged)
- `rns-core/` (no changes)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)