### PR TITLE
Defer Link.status=ACTIVE publication until bookkeeping is complete (fixes #42)

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -606,12 +606,21 @@ class Link private constructor(
                 return false
             }
 
-            // Link is now active
+            // Link is now active — but do NOT publish status=ACTIVE until every
+            // piece of bookkeeping that an outbound send() depends on is in place.
+            // `status` is @Volatile, so the final write at the end of this block
+            // acts as a release fence: any thread that subsequently observes
+            // status==ACTIVE is guaranteed to see the activeLinks membership,
+            // attachedInterfaceHash, and pathTable entry written earlier.
+            //
+            // This ordering fixes the race behind #42: bridge callers that
+            // `link_open(...)` and then immediately `link_send(first_payload)`
+            // could previously observe status=ACTIVE during the ~16-line window
+            // before registerLinkPath ran, causing Transport.outbound() to miss
+            // the pathTable entry and drop the first DATA packet.
             rtt = System.currentTimeMillis() - requestTime
             remoteIdentity = destination.identity
             mdu = LinkConstants.calculateMdu(mtu)
-            status = LinkConstants.ACTIVE
-            activatedAt = System.currentTimeMillis()
 
             // Calculate establishment rate (bytes per ms)
             val linkRtt = rtt
@@ -628,6 +637,10 @@ class Link private constructor(
             packet.receivingInterfaceHash?.let { interfaceHash ->
                 Transport.registerLinkPath(linkId, interfaceHash, packet.hops)
             }
+
+            // Publish ACTIVE only after all the above is visible.
+            activatedAt = System.currentTimeMillis()
+            status = LinkConstants.ACTIVE
 
             log("Link ${linkId.toHexString()} established, RTT: ${rtt}ms")
 

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -1886,8 +1886,12 @@ class Link private constructor(
 
             // Use max of measured and remote RTT
             rtt = maxOf(measuredRtt, remoteRtt)
-            status = LinkConstants.ACTIVE
+            // Set activatedAt BEFORE the volatile status write so any thread that
+            // observes status==ACTIVE via the volatile read is also guaranteed to
+            // see a non-zero activatedAt (getAge()/noInboundFor() correctness).
+            // This mirrors the ordering applied to validateProof() for issue #42.
             activatedAt = System.currentTimeMillis()
+            status = LinkConstants.ACTIVE
 
             // Calculate establishment rate (bytes per ms)
             val linkRtt = rtt


### PR DESCRIPTION
## Summary

Fixes the race where Kotlin-sender bursts drop the first user DATA packet after link establishment on multi-hop paths (~33% reproduction rate in CI).

## Root cause

`Link.validateProof` set `status = LinkConstants.ACTIVE` **before** several pieces of bookkeeping that an outbound `send()` depends on:

| Line | Operation |
|---|---|
| 613 | `status = ACTIVE` *(was here — visible to other threads)* |
| 622 | `Transport.activateLink(this)` adds to `activeLinks` |
| 625 | `attachedInterfaceHash = packet.receivingInterfaceHash` |
| 629 | `Transport.registerLinkPath(linkId, ...)` writes `pathTable` |

Bridge callers that poll `status==ACTIVE` and then immediately call `link.send(first_payload)` could observe ACTIVE during the ~16-line window before `pathTable` had the entry — `Transport.outbound()` missed the lookup for the linkId and dropped the first DATA packet. Subsequent packets (after the pathTable entry actually landed) routed correctly.

## Fix

Reorder so `status = LinkConstants.ACTIVE` is the *last* visible side-effect, after `activateLink` / `attachedInterfaceHash` / `registerLinkPath`. `status` is already `@Volatile`, so the final volatile write acts as a release fence — any thread that observes ACTIVE is guaranteed to also see the earlier writes.

The STALE→ACTIVE revival path (line 1600) and the server-side RTT path (line 1876) don't need the same reorder: revival already has pathTable populated from the original establishment, and the server-side doesn't consult pathTable for its outbound flow.

## Test plan

- [x] `:rns-core:test` passes locally.
- [ ] CI green.
- [ ] Follow-up: run `pytest tests/wire/test_link_multihop.py::test_link_data_roundtrip_multiple_packets -k 'kotlin->reference->reference' -v --count 20` in reticulum-conformance and confirm 0 failures.

Fixes #42.

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._