### PR TITLE
Register receiver-side link with Transport before sending LRPROOF (#42 residual)

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -195,15 +195,32 @@ class Link private constructor(
                     Transport.registerLinkPath(link.linkId, interfaceHash, packet.hops)
                 }
 
-                // Perform handshake and send proof
+                // Perform handshake (derives crypto state) BEFORE publishing
+                // the link via Transport.registerLink. The order here is the
+                // receiver-side mirror of the sender-side fix in #53: any
+                // side-effect that makes the link visible to the peer must
+                // happen AFTER all bookkeeping the receiver needs to dispatch
+                // inbound traffic.
+                //
+                // Specifically: link.prove() sends the LRPROOF on the wire,
+                // which the sender treats as "link is up" and begins sending
+                // user DATA on. Transport.processData() looks up the receiver
+                // link in activeLinks (Transport.kt:3752); if registerLink
+                // hasn't run yet when DATA arrives, the lookup misses and
+                // the packet is dropped silently. On a fast loopback
+                // kotlin->reference->kotlin path, the sender's first DATA
+                // can race ahead of Transport.registerLink; this manifested
+                // as the residual #42 first-packet-of-burst loss surviving
+                // the sender-side fix in #53.
                 link.handshake()
-                link.prove()
-
                 link.requestTime = System.currentTimeMillis()
                 Transport.registerLink(link)
-
                 link.lastInbound = System.currentTimeMillis()
                 link.startWatchdog()
+
+                // Now safe to send LRPROOF — receiver is fully wired to
+                // accept inbound DATA on this link.
+                link.prove()
 
                 log("Link request ${link.linkId.toHexString()} accepted")
                 link

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -219,8 +219,24 @@ class Link private constructor(
                 link.startWatchdog()
 
                 // Now safe to send LRPROOF — receiver is fully wired to
-                // accept inbound DATA on this link.
-                link.prove()
+                // accept inbound DATA on this link. If prove() throws after
+                // registerLink/startWatchdog have run, we must roll the link
+                // back out of activeLinks and stop the watchdog so it doesn't
+                // sit in HANDSHAKE state until the establishment timeout
+                // fires (zombie-link cleanup, per Greptile review on #54).
+                try {
+                    link.prove()
+                } catch (proveError: Exception) {
+                    // teardown(...) sets status=CLOSED, calls stopWatchdog(),
+                    // and Transport.deregisterLink(link) — the full unwind for
+                    // the partial registration we just did. Skips the close
+                    // packet send because previousStatus is HANDSHAKE (not
+                    // ACTIVE), so it won't try to encrypt with a key the
+                    // failed prove() never installed.
+                    log("Link prove() failed after registration; rolling back: ${proveError.message}")
+                    runCatching { link.teardown(LinkConstants.TEARDOWN_REASON_DESTINATION_CLOSED) }
+                    throw proveError
+                }
 
                 log("Link request ${link.linkId.toHexString()} accepted")
                 link


### PR DESCRIPTION
## Summary

Receiver-side mirror of [#53](https://github.com/torlando-tech/reticulum-kt/pull/53)'s sender-side fix for the same #42 first-packet-of-burst loss. After #53, an occasional kotlin-receiver flake remained, surfaced by the reticulum-conformance harness under full-suite load.

## Race

In `Link.validateLinkRequest`:

```
link.handshake()
link.prove()                  ← LRPROOF on the wire — sender now treats link as ACTIVE
                                and may immediately send DATA.
link.requestTime = ...
Transport.registerLink(link)  ← link added to activeLinks HERE.
```

Between `prove()` and `registerLink(link)`, the sender can complete its side, mark ACTIVE, and send the first user DATA packet. The receiver's `Transport.processData` looks up `activeLinks` for the `linkId` ([Transport.kt:3752](https://github.com/torlando-tech/reticulum-kt/blob/main/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt#L3752)) and finds nothing — packet is dropped silently. Subsequent sends (after the typical inter-send gap) succeed because `registerLink` has completed by then.

## Fix

Reorder so `Transport.registerLink` (and `requestTime` / `lastInbound` / `startWatchdog`) all run **before** `link.prove()`. The LRPROOF is now the last visible side-effect — once it goes on the wire, the receiver is fully wired to handle inbound DATA on this link.

## Verification

Reproduction baseline (against current main): the residual flake hits in 1-of-3 to 1-of-5 full-suite runs of the conformance harness's `test_link_data_roundtrip_multiple_packets`, manifesting as the missing-first-packet signature documented in #42.

With this fix:
- The original `kotlin->reference->kotlin` flake is gone (10/10 isolated runs clean).
- A different, narrower race surfaced under full-suite load on `reference->kotlin->kotlin` (also 10/10 isolated runs clean) — likely a separate transport-side forwarding window. Tracked as #56; not introduced by this change, just freshly visible now that the louder receiver-side race is closed.

Net diff: `+21 / -4` lines in `Link.kt` (single function, two-line code reorder + an explanatory comment block).

Fixes the residual surface of #42.

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._
