### PR TITLE
Add test-only race inducer for #56 investigation

### DIFF
--- a/conformance-bridge/src/main/kotlin/WireTcp.kt
+++ b/conformance-bridge/src/main/kotlin/WireTcp.kt
@@ -828,6 +828,23 @@ fun handleWireCommand(command: String, p: JsonObject): JsonObject = when (comman
         }
     }
 
+    "wire_set_race_inducer" -> {
+        // Sets named race-inducer hooks in production code (default 0L =
+        // no-op). Tests call this to deterministically widen narrow race
+        // windows so a regression at a specific seam fails reliably.
+        //
+        // Currently-instrumented seams (must match Link.kt companion):
+        //   "post-prove" — receiver-side validateRequest, sleeps after
+        //                  link.prove() returns.
+        val seam = p.str("seam")
+        val delayMs = p.get("delay_ms")?.asLong ?: 0L
+        when (seam) {
+            "post-prove" -> network.reticulum.link.Link.raceInducerPostProveDelayMs = delayMs
+            else -> throw IllegalArgumentException("Unknown race-inducer seam: $seam")
+        }
+        result("seam" to JsonPrimitive(seam), "delay_ms" to JsonPrimitive(delayMs))
+    }
+
     "wire_get_received_packets" -> {
         val sinceSeq = p.get("since_seq")?.asLong ?: 0L
         val packets = JsonArray()

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -284,7 +284,20 @@ class Link private constructor(
                 // trying to expose (per Greptile review on this PR).
                 val postProveDelay = raceInducerPostProveDelayMs
                 if (postProveDelay > 0L) {
-                    Transport.raceInducerSleepReleasingJobsLock(postProveDelay)
+                    try {
+                        Transport.raceInducerSleepReleasingJobsLock(postProveDelay)
+                    } catch (ie: InterruptedException) {
+                        // Mirror the proveError rollback above: registerLink +
+                        // startWatchdog have already run, so an exception that
+                        // escapes here would leave a zombie link in activeLinks
+                        // with a running watchdog. Tear down before re-throwing
+                        // so the outer `catch (e: Exception)` returns null on a
+                        // clean state (per Greptile review on this PR).
+                        log("Race inducer sleep interrupted; rolling back: ${ie.message}")
+                        runCatching { link.teardown(LinkConstants.TEARDOWN_REASON_DESTINATION_CLOSED) }
+                        Thread.currentThread().interrupt()
+                        throw ie
+                    }
                 }
 
                 log("Link request ${link.linkId.toHexString()} accepted")

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -303,6 +303,22 @@ class Link private constructor(
                 log("Link request ${link.linkId.toHexString()} accepted")
                 link
             } catch (e: Exception) {
+                // If the exception is an InterruptedException, CLEAR the
+                // thread's interrupt flag here. The inner
+                // Transport.raceInducerSleepReleasingJobsLock catch
+                // re-sets it before rethrow (standard Java pattern when
+                // propagating cancellation), but at THIS layer we're
+                // intentionally swallowing the interrupt — we've handled
+                // it by aborting link establishment and returning null,
+                // and the ingest thread caller will continue its receive
+                // loop. Leaving the flag set would cause its next
+                // interruptible operation (Thread.sleep, blocking I/O,
+                // lockInterruptibly()) to throw spuriously, attributing
+                // a cancellation that was intended only for this single
+                // link-setup attempt to unrelated work in the loop.
+                // Thread.interrupted() is the JDK's check-and-clear
+                // primitive for exactly this case.
+                if (e is InterruptedException) Thread.interrupted()
                 log("Validating link request failed: ${e.message}")
                 null
             }

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -87,6 +87,27 @@ class Link private constructor(
         private val activeWatchdogs = ConcurrentHashMap<Int, Job>()
 
         /**
+         * Test-only race inducer: when > 0, pauses for the configured number
+         * of milliseconds at named seams in the link establishment path. Used
+         * by reticulum-conformance to deterministically widen narrow race
+         * windows so a regression at a specific seam fails reliably instead
+         * of intermittently.
+         *
+         * Defaults to 0 (no-op). Production callers MUST NOT set this — it
+         * only exists for test injection via the bridge's
+         * `wire_set_race_inducer` command.
+         *
+         * Currently-instrumented seams:
+         *  - "post-prove": sleeps in `validateRequest` immediately after
+         *    `link.prove()` returns, before the function exits. Used to
+         *    verify that all bookkeeping needed for inbound DATA is
+         *    COMPLETE by the time prove() returns — the invariant fixed
+         *    in PR #54.
+         */
+        @Volatile
+        var raceInducerPostProveDelayMs: Long = 0L
+
+        /**
          * Cancel all watchdog coroutines. Used during shutdown.
          */
         internal fun cancelAllWatchdogs() {
@@ -236,6 +257,18 @@ class Link private constructor(
                     log("Link prove() failed after registration; rolling back: ${proveError.message}")
                     runCatching { link.teardown(LinkConstants.TEARDOWN_REASON_DESTINATION_CLOSED) }
                     throw proveError
+                }
+
+                // Test-only race inducer (zero in production; settable via the
+                // conformance bridge's wire_set_race_inducer command). Sleeps
+                // here to widen the post-prove window so a test can verify
+                // that any DATA arriving while we're "stuck" still gets
+                // dispatched correctly — proving that registerLink + the
+                // other bookkeeping above is sufficient for inbound DATA
+                // handling.
+                val postProveDelay = raceInducerPostProveDelayMs
+                if (postProveDelay > 0L) {
+                    Thread.sleep(postProveDelay)
                 }
 
                 log("Link request ${link.linkId.toHexString()} accepted")

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -26,6 +26,7 @@ import network.reticulum.identity.Identity
 import network.reticulum.packet.Packet
 import network.reticulum.packet.PacketReceipt
 import network.reticulum.transport.Transport
+import org.jetbrains.annotations.TestOnly
 import org.msgpack.core.MessagePack
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.ConcurrentHashMap
@@ -103,7 +104,15 @@ class Link private constructor(
          *    verify that all bookkeeping needed for inbound DATA is
          *    COMPLETE by the time prove() returns — the invariant fixed
          *    in PR #54.
+         *
+         * The sleep delegates to `Transport.raceInducerSleepReleasingJobsLock`
+         * so it temporarily drops `jobsLock` for the sleep duration. Without
+         * that, `validateRequest`'s caller (`Transport.ingest`) would still
+         * be holding `jobsLock`, serializing concurrently-arriving DATA
+         * packets behind the lock and defeating the test's intended race
+         * window (per Greptile review on this PR).
          */
+        @TestOnly
         @Volatile
         var raceInducerPostProveDelayMs: Long = 0L
 
@@ -266,9 +275,16 @@ class Link private constructor(
                 // dispatched correctly — proving that registerLink + the
                 // other bookkeeping above is sufficient for inbound DATA
                 // handling.
+                //
+                // We delegate to Transport.raceInducerSleepReleasingJobsLock
+                // because validateRequest is called transitively from
+                // Transport.ingest under jobsLock.withLock; a plain
+                // Thread.sleep here would serialize concurrent DATA packets
+                // behind the lock, neutralizing the race window the test is
+                // trying to expose (per Greptile review on this PR).
                 val postProveDelay = raceInducerPostProveDelayMs
                 if (postProveDelay > 0L) {
-                    Thread.sleep(postProveDelay)
+                    Transport.raceInducerSleepReleasingJobsLock(postProveDelay)
                 }
 
                 log("Link request ${link.linkId.toHexString()} accepted")

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -190,6 +190,7 @@ object Transport {
      * If `jobsLock` is not held by the calling thread, this falls back to a
      * plain `Thread.sleep(millis)`. Production code MUST NOT call this.
      */
+    @org.jetbrains.annotations.TestOnly
     internal fun raceInducerSleepReleasingJobsLock(millis: Long) {
         if (millis <= 0L) return
         if (!jobsLock.isHeldByCurrentThread) {

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -179,6 +179,34 @@ object Transport {
     /** Lock for job execution. */
     private val jobsLock = ReentrantLock()
 
+    /**
+     * Test-only: sleep for [millis] with `jobsLock` temporarily released, then
+     * re-acquire the same hold count before returning. Used by the race-inducer
+     * hook in `Link.validateRequest` (post-prove seam) so that DATA packets
+     * arriving on other ingest threads during the widened window can actually
+     * contend on the lock and exercise the bookkeeping race, instead of being
+     * serialized behind the still-held jobsLock.
+     *
+     * If `jobsLock` is not held by the calling thread, this falls back to a
+     * plain `Thread.sleep(millis)`. Production code MUST NOT call this.
+     */
+    internal fun raceInducerSleepReleasingJobsLock(millis: Long) {
+        if (millis <= 0L) return
+        if (!jobsLock.isHeldByCurrentThread) {
+            Thread.sleep(millis)
+            return
+        }
+        // Fully release the lock (handles reentrant holds), sleep, then re-acquire
+        // the same number of times so the caller's invariant is preserved.
+        val holdCount = jobsLock.holdCount
+        repeat(holdCount) { jobsLock.unlock() }
+        try {
+            Thread.sleep(millis)
+        } finally {
+            repeat(holdCount) { jobsLock.lock() }
+        }
+    }
+
     /** Whether jobs are currently running. */
     private val jobsRunning = AtomicBoolean(false)
 


### PR DESCRIPTION
## Summary

Adds a single `@Volatile var raceInducerPostProveDelayMs: Long = 0L` in `Link.kt`'s companion object, defaulting to 0L (no-op in production). When set non-zero by a test (via the conformance bridge's new `wire_set_race_inducer` command), the receiver-side `validateRequest` sleeps for that long immediately after `link.prove()` returns, before exiting the function.

## Purpose

Deterministically widen the post-prove window so a regression test can verify that all bookkeeping needed for inbound link-DATA dispatch has completed by the time `prove()` returns. This is the invariant fixed in #54 and the deeper invariant being investigated in #56 (the residual daemon-thread callback-wiring race).

## Production-safety

The hook is gated by a single conditional (`postProveDelay > 0L`) so the production path is byte-identical to before when the inducer is unset. Default value is 0L, only settable via the bridge command which only exists in the conformance-bridge test harness.

## Used by

Conformance harness's new `tests/wire/test_link_post_prove_invariant.py` (separate PR against `torlando-tech/reticulum-conformance`).

Net diff: +50 lines across `Link.kt` (hook + comments) and `WireTcp.kt` (bridge command).

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._