### PR TITLE
Bump conformance-bridge LXMF-kt pin v0.0.4 → v0.0.8

### DIFF
--- a/conformance-bridge/build.gradle.kts
+++ b/conformance-bridge/build.gradle.kts
@@ -23,11 +23,11 @@ dependencies {
 
     // LXMF-kt: the Kotlin port of LXMF. Only used by the conformance
     // bridge's lxmf_* commands (see Lxmf.kt); rns-core / rns-interfaces
-    // do not depend on LXMF. Pinned to v0.0.4 (latest published tag as
+    // do not depend on LXMF. Pinned to v0.0.8 (latest published tag as
     // of this PR). JitPack collapsed the multi-module project into the
     // root artifact, so the coordinate is the repo itself rather than
     // com.github.torlando-tech.LXMF-kt:lxmf-core.
-    implementation("com.github.torlando-tech:LXMF-kt:v0.0.4")
+    implementation("com.github.torlando-tech:LXMF-kt:v0.0.8")
 
     // Coroutines — Lxmf.kt calls LXMRouter.handleOutbound (suspend) and
     // needs runBlocking to adapt it to the synchronous bridge protocol.


### PR DESCRIPTION
## Summary

Picks up four merged LXMF-kt PRs since v0.0.4:

| LXMF-kt PR | Tag | What |
|---|---|---|
| #11 | v0.0.5 | Release `pendingOutboundMutex` before per-message dispatch |
| #13 | v0.0.7 | Make `processingScope` process-lifetime to prevent silent drop after stop() |
| #14 | v0.0.8 | Dedup inbound LXMessages on `message.hash` — fixes the DIRECT multi-packet double-delivery (LXMF-kt#8) |
| #16 | v0.0.8 | Heterogeneous dedup keys for PROPAGATED + PAPER (LXMF-kt#15) |

Affects only the conformance-bridge module — `rns-core` / `rns-interfaces` don't depend on LXMF-kt. With this pin bumped, the conformance harness can drop the LXMF-kt#8 xfail (separate reticulum-conformance PR).

Net diff: +2 / -2 (`conformance-bridge/build.gradle.kts` — pin + comment).

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._