### PR TITLE
Fire receiver-side linkEstablished callbacks synchronously from rttPacket (fixes #56)

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -2037,7 +2037,7 @@ class Link private constructor(
                 try {
                     callback(this)
                 } catch (e: Exception) {
-                    log("Error in link established callback: ${e.message}")
+                    log("Error in link established callback:\n${e.stackTraceToString()}")
                 }
             }
 
@@ -2045,7 +2045,7 @@ class Link private constructor(
                 try {
                     ownerDest.invokeLinkEstablished(this)
                 } catch (e: Exception) {
-                    log("Error in destination link established callback: ${e.message}")
+                    log("Error in destination link established callback:\n${e.stackTraceToString()}")
                 }
             }
         } catch (e: Exception) {

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -2013,28 +2013,39 @@ class Link private constructor(
             log("Link RTT measured: ${rtt}ms")
             updateKeepalive()
 
-            // Notify the Link-level callback (set via link.setLinkEstablishedCallback).
+            // Fire both the link-level and destination-level "link established"
+            // callbacks SYNCHRONOUSLY from rttPacket — matches Python RNS
+            // (RNS/Link.py:550-551 fires both inline) and closes #56's
+            // receiver-side first-packet-loss residual.
+            //
+            // The previous async-via-thread(isDaemon = true) approach raced
+            // the read loop: rttPacket returned, the read loop immediately
+            // processed the next packet (the sender's first user DATA, sent
+            // as soon as the sender saw LRPROOF and went ACTIVE), and
+            // link.processRegularData ran callbacks.packet?.let { ... } —
+            // which was still null because the daemon thread that wires it
+            // (via destination.linkEstablished -> link.setPacketCallback)
+            // hadn't run yet. The DATA was silently dropped.
+            //
+            // Synchronous invocation guarantees that by the time the read
+            // loop reads the next packet, every callback the user registered
+            // in their linkEstablished handler is wired. Trade-off: a slow
+            // user callback now blocks the receive loop for that link's
+            // interface, same risk Python carries; documented as user
+            // contract that callbacks should not block.
             callbacks.linkEstablished?.let { callback ->
-                thread(isDaemon = true) {
-                    try {
-                        callback(this)
-                    } catch (e: Exception) {
-                        log("Error in link established callback: ${e.message}")
-                    }
+                try {
+                    callback(this)
+                } catch (e: Exception) {
+                    log("Error in link established callback: ${e.message}")
                 }
             }
 
-            // Notify the owning Destination's link-established callback. Python RNS fires
-            // this from rtt_packet() once status == ACTIVE (RNS/Link.py line 550–551);
-            // firing it earlier (e.g. on LINKREQUEST) leaves link.status == HANDSHAKE, and
-            // any link.send() from the callback silently fails.
             owner?.let { ownerDest ->
-                thread(isDaemon = true) {
-                    try {
-                        ownerDest.invokeLinkEstablished(this)
-                    } catch (e: Exception) {
-                        log("Error in destination link established callback: ${e.message}")
-                    }
+                try {
+                    ownerDest.invokeLinkEstablished(this)
+                } catch (e: Exception) {
+                    log("Error in destination link established callback: ${e.message}")
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary

Closes the residual multi-hop link-DATA race documented in [#56](https://github.com/torlando-tech/reticulum-kt/issues/56). Same single-line root cause for both patterns the issue enumerated: receiver-side `linkEstablished` callbacks were fired in `thread(isDaemon = true) { ... }` blocks at `Link.kt:2017-2025` and `Link.kt:2031-2039`. The receiver's read loop processed LRRTT, kicked off the daemon threads, and immediately returned to the loop. The next packet — the sender's first user DATA, sent the moment the sender saw LRPROOF — arrived and went through `processRegularData` → `callbacks.packet?.let { ... }`, but the daemon thread that wires the user's packet callback (via `destination.linkEstablished -> link.setPacketCallback`) hadn't run yet. **The DATA was silently dropped.**

## Fix

Invoke both callbacks **synchronously** from `rttPacket`, matching Python RNS ([`RNS/Link.py:550-551`](https://github.com/markqvist/Reticulum/blob/master/RNS/Link.py#L550-L551) fires both inline). By the time `rttPacket` returns to the read loop, every callback the user registered in their `linkEstablished` handler is wired. The next packet's `processRegularData` finds a non-null packet callback and delivers as expected.

**Trade-off**: a slow user callback now blocks the receive loop for this link's interface. Same risk Python carries; documented user contract that callbacks should not block.

## Verification

Five full multihop conformance suite runs against this fix (no xfails):

| Run | Result |
|---|---|
| 1 | 56 passed in 136.13s |
| 2 | 56 passed in 133.59s |
| 3 | 56 passed in 139.17s |
| 4 | 56 passed in 137.61s |
| 5 | 56 passed in 137.10s |

**280/280 tests pass. Zero flakes.**

Pre-fix baseline (issue #56's documented stress data): 60% per-suite flake rate, 6 failures across 5 runs, all with `receiver=kotlin`.

## Note on the issue's "Pattern A vs Pattern B"

The issue hypothesized two distinct races:
- Pattern A — Kotlin Transport forwarding (`*->kotlin->*` failures)
- Pattern B — Kotlin receiver narrowed-but-not-closed by #54

After this fix's stress data (zero flakes regardless of transport impl), Pattern A is **not** a separate transport-forwarding race. It was the same receiver-side bug, statistically more visible when both endpoints are kotlin (compounding scheduler jitter). Single fix closes the whole residual.

The deterministic post-prove invariant test from reticulum-conformance#19 was the diagnostic tool that surfaced the daemon-thread chain — credit to that test for narrowing the search.

Net diff: +28 / -17 lines in `Link.kt::rttPacket` (inline two existing daemon-thread blocks).

Fixes #56.

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._