### PR TITLE
chore(conformance-bridge): reroute stdout to stderr after READY

### DIFF
--- a/conformance-bridge/src/main/kotlin/KotlinBridge.kt
+++ b/conformance-bridge/src/main/kotlin/KotlinBridge.kt
@@ -24,8 +24,18 @@ private val gson = Gson()
 private val crypto: CryptoProvider = BouncyCastleProvider()
 
 fun main() {
-    println("READY")
-    System.out.flush()
+    val realStdout = System.out
+    realStdout.println("READY")
+    realStdout.flush()
+
+    // Hijack System.out → stderr after READY so println() from
+    // reticulum-kt internals doesn't leak onto the JSON-RPC channel
+    // (where the bridge_client filters non-JSON lines and silently
+    // drops the diagnostic). Without this, every `println(...)` in
+    // Transport / Link / Resource is invisible to anyone running the
+    // conformance suite. JSON-RPC writes below use the captured
+    // realStdout reference so the response channel still works.
+    System.setOut(java.io.PrintStream(System.err, true))
 
     val reader = System.`in`.bufferedReader()
     while (true) {
@@ -46,14 +56,14 @@ fun main() {
                     addProperty("success", true)
                     add("result", result)
                 }
-                println(gson.toJson(response))
+                realStdout.println(gson.toJson(response))
             } catch (e: Exception) {
                 val response = JsonObject().apply {
                     addProperty("id", id)
                     addProperty("success", false)
                     addProperty("error", e.message ?: "Unknown error")
                 }
-                println(gson.toJson(response))
+                realStdout.println(gson.toJson(response))
             }
         } catch (e: Exception) {
             val response = JsonObject().apply {
@@ -61,7 +71,7 @@ fun main() {
                 addProperty("success", false)
                 addProperty("error", "JSON parse error: ${e.message}")
             }
-            println(gson.toJson(response))
+            realStdout.println(gson.toJson(response))
         }
         System.out.flush()
     }

--- a/conformance-bridge/src/main/kotlin/KotlinBridge.kt
+++ b/conformance-bridge/src/main/kotlin/KotlinBridge.kt
@@ -73,7 +73,7 @@ fun main() {
             }
             realStdout.println(gson.toJson(response))
         }
-        System.out.flush()
+        realStdout.flush()
     }
 }
 


### PR DESCRIPTION
## Summary
After printing \`READY\`, hijack \`System.out\` to point at \`System.err\` so subsequent \`println()\` from reticulum-kt internals doesn't leak onto the JSON-RPC channel. The captured \`realStdout\` reference is used for actual JSON-RPC writes, so the response channel still works.

## Why
\`println()\` from \`Transport.kt\` / \`Link.kt\` / etc. was going to **stdout** — the JSON-RPC channel — where the conformance \`bridge_client\` filters non-JSON lines and silently drops them. That invisibility actively hid the real cause of what looked like a Resource transfer bug at >= ~96 KB payloads.

The actual cause turned out to be a test-infrastructure deadlock: the verbose log output filled the OS pipe buffer (~64 KB), the kotlin subprocess blocked on its next stdout write, the link-DATA forwarding loop stalled, and the test reported sender \`status=7 FAILED\`. With this redirect *plus* a corresponding stderr-draining thread in conformance \`bridge_client.py\` (filed at torlando-tech/reticulum-conformance#22), all 32 trios in \`test_resource_multihop\` pass, including every kotlin combination at 256 KB.

## Test plan
- [x] Manual repro: reference→kotlin→reference at 96/128/192/256 KB now passes
- [x] Full reticulum-conformance \`test_resource_multihop\` suite: 32/32 pass

## Stacked on
None — clean off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)