### PR TITLE
fix(resource): stop double-firing resourceConcluded on receive

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -2172,7 +2172,19 @@ class Link private constructor(
                         network.reticulum.resource.Resource.accept(
                             advertisement = advertisement,
                             link = this,
-                            callback = { res -> resourceConcluded(res) },
+                            // Do NOT pass `callback = { res -> resourceConcluded(res) }`
+                            // here — Resource.assemble() already calls
+                            // `link.resourceConcluded(this)` directly when the
+                            // transfer completes, which fires `callbacks.resourceConcluded`
+                            // on this link. Passing a per-resource callback that ALSO
+                            // calls `resourceConcluded(res)` re-fires the user-level
+                            // callback a second time, causing every received Resource
+                            // (e.g. an LXMF message in RESOURCE representation) to be
+                            // delivered twice on the receiver side. Mirrors Python
+                            // RNS, where Link.py wires the user callback directly as
+                            // the per-resource callback (Link.py:1097, 1102) and
+                            // Link.resource_concluded() is pure bookkeeping.
+                            callback = null,
                         )
                     if (resource != null) {
                         registerIncomingResource(resource)
@@ -2197,7 +2209,13 @@ class Link private constructor(
                                     network.reticulum.resource.Resource.accept(
                                         advertisement = advertisement,
                                         link = this,
-                                        callback = { res -> resourceConcluded(res) },
+                                        // See note above on the ACCEPT_ALL branch — the same
+                                        // double-fire applies here. Resource.assemble() calls
+                                        // link.resourceConcluded(this) directly when the
+                                        // transfer completes; passing a per-resource callback
+                                        // that re-calls resourceConcluded(res) here delivers
+                                        // every received Resource twice.
+                                        callback = null,
                                     )
                                 if (resource != null) {
                                     registerIncomingResource(resource)


### PR DESCRIPTION
## Summary
Receive-side Resources fire the link's user-level \`resourceConcluded\` callback **twice** instead of once. Two-line surgical fix in \`Link.kt\`'s accept sites; aligns Kotlin with Python RNS dispatch semantics.

## Root cause
\`Link.handleData()\` accepted inbound Resources with \`callback = { res -> resourceConcluded(res) }\` (Link.kt:2175 ACCEPT_ALL, :2200 ACCEPT_APP). That callback ended up wired onto \`Resource.callbacks.completed\`. Then \`Resource.assemble()\`:
- line 1194: \`link.resourceConcluded(this)\` → fires \`callbacks.resourceConcluded\` (1st time)
- line 1200: \`callbacks.completed?.invoke(this)\` → invokes the lambda from Link.kt:2175 → re-calls \`resourceConcluded(res)\` → fires \`callbacks.resourceConcluded\` (2nd time)

## Comparison to Python RNS
Python's \`Link.resource_concluded()\` is pure bookkeeping — it does NOT fire the user callback. The user callback (set via \`set_resource_concluded_callback\`) is wired only as the per-resource \`self.callback\` (\`Reticulum/RNS/Link.py:1097, 1102\`). Single dispatch.

## Fix
Drop the \`{ res -> resourceConcluded(res) }\` wiring from both Link.kt accept sites. \`Resource.assemble()\`'s direct call to \`link.resourceConcluded(this)\` becomes the single dispatch point. \`callbacks.completed\` remains available for callers that explicitly opt in via \`Resource.create(..., callback = ...)\`.

## Surfaced by
The lxmf-conformance suite as \`received 2 messages, expected exactly 1\` on every kotlin-receiver trio of \`test_combined_text_and_attachment_over_resource\` and \`test_direct_large_message_resource_transfer\`. Both use payloads larger than \`LINK_PACKET_MAX_CONTENT\`, forcing the RESOURCE-mode transfer path.

This bug was previously documented as a known issue in the existing project memory ("\`Resource.assemble()\` invokes \`Link.resourceConcluded\` twice per completed transfer ... should be filed as a reticulum-kt issue") — the reticulum-conformance bridge dedups locally so it never surfaced there. LXMF-kt's \`handleResourceConcluded\` doesn't dedup, so when the lxmf-conformance suite started running cross-impl, it hit hard.

## Verification
After this fix + a corresponding bridge_client stderr-drain (lxmf-conformance#1) + a sibling LXMF-kt CI workflow, the full python+kotlin lxmf-conformance suite goes from 24 passed / 4 failed → **28 passed / 0 failed in 4m18s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)