### PR TITLE
perf(transport): release jobsLock around blocking interface I/O

### DIFF
--- a/port-deviations.md
+++ b/port-deviations.md
@@ -39,6 +39,20 @@ This file is the **single source of truth** for every place where reticulum-kt's
 
 ## Deviations
 
+### Eager cleanup on `Resource.accept` exception — `rns-core/.../Resource.kt::accept`
+
+**Python reference:** `RNS/Resource.py:223-244`. Python's `Resource.accept` calls `link.register_incoming_resource(resource)` and then `resource.hashmap_update(0, resource.hashmap_raw)` and finally `resource.watchdog_job()`. If `hashmap_update` throws, the outer `try/except` catches it, logs, and returns None — but the resource has already been registered via `register_incoming_resource`, and the watchdog has not yet been started, so the registration leaks for the lifetime of the link with no recovery path.
+
+**Category:** new feature (defensive cleanup beyond the python reference).
+
+**Date:** 2026-04-29.
+
+**Tracking:** reticulum-kt#64 greptile P1 ("zombie blocks hash on requestNext failure").
+
+**Description:** kotlin's `Resource.accept` adds a `resource?.cancel()` in its catch block so a thrown initialization or `requestNext()` cleans up the registration immediately. Without this, a thrown send would leave the advertisement hash blocked in the link's `incomingResources` until either (a) kotlin's watchdog times out — which kotlin's `initializeFromAdvertisement` does start before the throw site, so eventual recovery exists at ~16-20s, OR (b) the link tears down. The eager cleanup brings recovery from "eventually" to "immediately," which matters for the dedup guard's user-visible behavior: a sender retransmit after a brief network glitch is otherwise dropped silently. This is a strict improvement over python's behavior — python in the equivalent path never recovers.
+
+**Re-evaluation:** if/when python adds equivalent cleanup upstream, this entry can be removed and the kotlin code labeled as "matches python" again.
+
 ### Explicit write serialization on TCP interfaces — `rns-interfaces/.../TCPClientInterface.kt::processOutgoing`, `TCPServerInterface.kt::processOutgoing`
 
 **Python reference:** `RNS/Interfaces/TCPInterface.py:320-345` (`process_outgoing`). Python sets a `self.writing = True/False` flag but the actual serialization of concurrent writes is implicit: the GIL guarantees atomicity around `socket.sendall`, and the original `while self.writing: time.sleep(0.01)` busy-loop is commented out. Python effectively does not serialize concurrent calls to `process_outgoing`.

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -39,6 +39,20 @@ This file is the **single source of truth** for every place where reticulum-kt's
 
 ## Deviations
 
+### Optimistic identity-CAS on pathTable/linkTable updates after `transmit()` — `rns-core/.../Transport.kt::processOutbound`, transport forwarding, link forwarding
+
+**Python reference:** `RNS/Transport.py:134, 136` — python protects `path_table` and `link_table` with dedicated per-table locks (`path_table_lock`, `link_table_lock`) acquired only when the table is read or written, distinct from the main `jobs_lock` that wraps inbound/outbound entry points.
+
+**Category:** language/runtime forced.
+
+**Date:** 2026-04-29.
+
+**Tracking:** reticulum-kt#64 greptile P1 carry-over ("stale pathEntry read-modify-write on pathTable/linkTable after lock re-acquisition in transmit's callers").
+
+**Description:** kotlin's `Transport` uses a single process-wide `jobsLock` covering both inbound and outbound. After `transmit()` was changed to release `jobsLock` around blocking interface I/O (a separate deviation needed for perf — see #65), the post-transmit `pathTable[key] = pathEntry.touch()` and `linkTable[key] = linkEntry.copy(...)` patterns at `processOutbound` lines 2885-2887, 2972-2974, and 3118-3122 became read-modify-write hazards: another thread processing a fresher inbound announce on the same destination could replace the entry during the release window, and the post-transmit blind write would clobber it with a stale-derived value. Rather than introducing per-table locks (which would require restructuring all `pathTable`/`linkTable` access sites — a much larger change), kotlin uses optimistic identity-CAS at the three affected sites: re-read `pathTable[key]`/`linkTable[key]` after `transmit()` returns and only write back if the current entry is still `=== pathEntry` (or `=== linkEntry`). If a fresher entry has replaced ours during the release, we skip our touch and leave their newer state alone. Python's per-table locks achieve the same invariant via stricter exclusion; kotlin's optimistic check achieves it via "no overwrite of fresher state."
+
+**Re-evaluation:** if `Transport`'s state model is ever refactored to per-table locks (matching python's structure exactly), this can be retired. Until then, every new post-transmit `pathTable`/`linkTable` write site needs the same identity-CAS check.
+
 ### Watchdog uses Thread + interrupt() instead of flag-check job ID — `rns-core/.../Resource.kt::startWatchdog`, `stopWatchdog`, `watchdogJob`
 
 **Python reference:** `RNS/Resource.py:560-670` (`watchdog_job` / `__watchdog_job_id`). Python spawns a daemon thread that runs a `while self.status < Resource.ASSEMBLING and this_job_id == self.__watchdog_job_id` loop. Stopping a watchdog increments `__watchdog_job_id` so the next loop iteration's compare-and-exit fires; no thread interruption is involved.

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -39,4 +39,16 @@ This file is the **single source of truth** for every place where reticulum-kt's
 
 ## Deviations
 
-*(none yet — this file is new. As deviations are introduced or discovered, add them here.)*
+### Explicit write serialization on TCP interfaces — `rns-interfaces/.../TCPClientInterface.kt::processOutgoing`, `TCPServerInterface.kt::processOutgoing`
+
+**Python reference:** `RNS/Interfaces/TCPInterface.py:320-345` (`process_outgoing`). Python sets a `self.writing = True/False` flag but the actual serialization of concurrent writes is implicit: the GIL guarantees atomicity around `socket.sendall`, and the original `while self.writing: time.sleep(0.01)` busy-loop is commented out. Python effectively does not serialize concurrent calls to `process_outgoing`.
+
+**Category:** language/runtime forced.
+
+**Date:** 2026-04-29.
+
+**Tracking:** reticulum-kt#64; symptom history in `TCPServerInterface.kt:365-375` comment ("the old check-then-set on `writing` was racy and interleaved socket writes, corrupting resource transfers (status=CORRUPT / 7)").
+
+**Description:** kotlin/JVM has no GIL, so concurrent calls to `processOutgoing` from different threads (the read loop's reactive sends, link keepalives, resource ACK/request packets, etc.) can interleave bytes mid-frame on the same socket. The original kotlin port translated python's commented-out busy-spin into an active `Thread.sleep(10)` loop guarded by an `AtomicBoolean writing`, which was both racy (check-then-set is non-atomic) and slow (10ms latency floor on contention). The current code uses `ReentrantLock.lockInterruptibly()` (TCPClientInterface) or `synchronized(this)` (TCPServerInterface) to provide the mutual exclusion the GIL gives python for free. `lockInterruptibly()` is preferred over `lock()` because the original `Thread.sleep(10)` would throw `InterruptedException` on shutdown — preserving that interrupt-propagation lets clean teardown work even when a write is contended (greptile P2 finding on PR #64).
+
+**Re-evaluation:** if a future kotlin-on-Loom virtual-thread or kotlinx-coroutines-Mutex pattern offers GIL-equivalent atomicity for socket sends with no per-call lock cost, revisit. As of JDK 21 there is no such mechanism — explicit serialization remains the only correct expression of python's effective serialization.

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -1,0 +1,42 @@
+# reticulum-kt — Documented Deviations from the Python Reference
+
+This file is the **single source of truth** for every place where reticulum-kt's logic intentionally diverges from `markqvist/Reticulum`. Any divergence not listed here is a bug, not a deviation.
+
+## Rule
+
+> All logic in reticulum-kt MUST mirror the python reference identically. Deviations are allowed ONLY for one of two reasons, both of which MUST be documented here before the code lands.
+
+**Allowed reason 1 — Language/runtime forced.** The python pattern cannot be expressed faithfully in kotlin or on the JVM. Examples: coroutines vs threads, `@Volatile` vs the GIL, `ReentrantLock` where python relies on GIL-implicit serialization, `kotlinx.coroutines.runBlocking` boundaries at JVM/non-coroutine seams.
+
+**Allowed reason 2 — New feature not present in python.** Kotlin-only API surface added for downstream consumers (Android lifecycle adapters, mobile-specific entry points, etc.). The kotlin-only behavior must not change semantics of any code path that *does* exist in python.
+
+## Process
+
+1. Before changing a kotlin port file in a way that diverges from the python reference, read the corresponding python source.
+2. If the divergence is unavoidable for one of the two reasons above, add a section below using the template, then implement the change.
+3. If you're unsure whether a divergence is justified, ask the human owner before picking unilaterally. Ports drift one small "harmless" choice at a time.
+4. Reviewers should reject any PR that introduces a kotlin/python semantics divergence not represented in this file.
+
+## Entry template
+
+```markdown
+### <short title> — <kotlin-file-relative-path>:<line-or-symbol>
+
+**Python reference:** `<path>:<line>` (e.g. `RNS/Resource.py:560-670`)
+
+**Category:** language/runtime forced  |  new feature
+
+**Date:** YYYY-MM-DD
+
+**Tracking:** issue/PR link, if any.
+
+**Description:** what the kotlin code does, why it differs from python, and (for category 1) why no kotlin idiom can express the python semantics directly.
+
+**Re-evaluation:** if a future kotlin/JVM/library change would make the python pattern expressible, what to look for.
+```
+
+---
+
+## Deviations
+
+*(none yet — this file is new. As deviations are introduced or discovered, add them here.)*

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -39,6 +39,20 @@ This file is the **single source of truth** for every place where reticulum-kt's
 
 ## Deviations
 
+### Watchdog uses Thread + interrupt() instead of flag-check job ID — `rns-core/.../Resource.kt::startWatchdog`, `stopWatchdog`, `watchdogJob`
+
+**Python reference:** `RNS/Resource.py:560-670` (`watchdog_job` / `__watchdog_job_id`). Python spawns a daemon thread that runs a `while self.status < Resource.ASSEMBLING and this_job_id == self.__watchdog_job_id` loop. Stopping a watchdog increments `__watchdog_job_id` so the next loop iteration's compare-and-exit fires; no thread interruption is involved.
+
+**Category:** language/runtime forced.
+
+**Date:** 2026-04-29.
+
+**Tracking:** reticulum-kt#64 greptile P1 ("`cancel()` self-interrupts before `callbacks.failed`").
+
+**Description:** kotlin's watchdog uses `kotlin.concurrent.thread { ... }` + `Thread.sleep` + `Thread.interrupt()` for prompt wake-up rather than the python flag-check-after-sleep pattern. Both achieve the same end (loop exits when active=false), but the kotlin `interrupt()` call introduces a self-targeting hazard not present in python: when `cancel()` is invoked from inside `watchdogJob` itself (the new retries-exhausted branch), `stopWatchdog()` would interrupt the current thread, leaving the interrupt flag set during the subsequent `callbacks.failed?.invoke` and silently aborting any I/O the failed callback performs that uses interruptible primitives (notably `ReentrantLock.lockInterruptibly()` on TCP writes — added for shutdown responsiveness in this same PR). `stopWatchdog` therefore checks `Thread.currentThread() === watchdogThread` and skips the self-interrupt; the loop's `if (!watchdogActive) break` already handles the cooperative exit, matching python's flag-check semantics for this case.
+
+**Re-evaluation:** if kotlin coroutines replace the threaded watchdog (likely a future direction — `processingScope.launch { while (active) { delay(...); ... } }` would compose better with the rest of the rns-core async surface), the entire interrupt mechanism goes away and this deviation can be retired.
+
 ### Eager cleanup on `Resource.accept` exception — `rns-core/.../Resource.kt::accept`
 
 **Python reference:** `RNS/Resource.py:223-244`. Python's `Resource.accept` calls `link.register_incoming_resource(resource)` and then `resource.hashmap_update(0, resource.hashmap_raw)` and finally `resource.watchdog_job()`. If `hashmap_update` throws, the outer `try/except` catches it, logs, and returns None — but the resource has already been registered via `register_incoming_resource`, and the watchdog has not yet been started, so the registration leaks for the lifetime of the link with no recovery path.

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -2159,13 +2159,13 @@ class Link private constructor(
                 return
             }
 
-            // Dedupe duplicate advertisements. See [hasIncomingResource]
-            // for the rationale. Mirrors python `Resource.accept`'s
-            // `not has_incoming_resource(resource)` guard at Resource.py:223.
-            if (hasIncomingResource(advertisement.hash)) {
-                log("Ignoring RESOURCE_ADV ${advertisement.hash.toHexString()} — resource already transferring")
-                return
-            }
+            // Note: dedup of duplicate advertisements lives inside
+            // `Resource.accept` (mirroring python `Resource.py:223`), so
+            // all four call sites below — request, response, ACCEPT_APP,
+            // ACCEPT_ALL — are guarded uniformly. `Resource.accept`
+            // returns null on a hash that is already in
+            // `incomingResources`, and the `if (resource != null)`
+            // checks below skip registration in that case.
 
             // General resource advertisement - check strategy
             when (resourceStrategy) {

--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -2159,6 +2159,14 @@ class Link private constructor(
                 return
             }
 
+            // Dedupe duplicate advertisements. See [hasIncomingResource]
+            // for the rationale. Mirrors python `Resource.accept`'s
+            // `not has_incoming_resource(resource)` guard at Resource.py:223.
+            if (hasIncomingResource(advertisement.hash)) {
+                log("Ignoring RESOURCE_ADV ${advertisement.hash.toHexString()} — resource already transferring")
+                return
+            }
+
             // General resource advertisement - check strategy
             when (resourceStrategy) {
                 ACCEPT_NONE -> {
@@ -2576,7 +2584,12 @@ class Link private constructor(
     }
 
     /**
-     * Register an incoming resource with this link.
+     * Register an incoming resource with this link. Reference-dedup only —
+     * callers are expected to consult [hasIncomingResource] first to avoid
+     * registering a fresh Resource built from a duplicate RESOURCE_ADV. This
+     * mirrors Python `RNS.Link.register_incoming_resource` (Link.py:1308),
+     * which is also a plain append; the python `Resource.accept` does the
+     * hash-based dedup check before registration.
      */
     fun registerIncomingResource(resource: network.reticulum.resource.Resource) {
         synchronized(incomingResources) {
@@ -2586,6 +2599,38 @@ class Link private constructor(
             }
         }
     }
+
+    /**
+     * Returns true if an incoming resource with the same advertisement hash
+     * is already registered. Mirrors Python `RNS.Link.has_incoming_resource`
+     * (Link.py:1311) — the hash equality check that prevents accepting the
+     * same RESOURCE_ADV twice when the sender retransmits it.
+     *
+     * This check is load-bearing because Transport's packet hashlist
+     * intentionally skips LINK-destined packets (see Transport.processInbound's
+     * `rememberHash` calculation), so a sender retransmit reaches the link
+     * layer in raw form. Without this check, two independent Resource state
+     * machines would fill from the same parts, both `assemble()`, and the
+     * user delivery callback would fire twice (observed as `Inbox sizes
+     * [N, N]` in the cross-impl conformance suite when `jobsLock` was
+     * released around blocking I/O — the timing change exposed the latent
+     * race).
+     */
+    fun hasIncomingResource(advertisementHash: ByteArray): Boolean =
+        synchronized(incomingResources) {
+            incomingResources.any { it.hash.contentEquals(advertisementHash) }
+        }
+
+    /**
+     * Test-only: snapshot of the current incoming resource hashes.
+     * Used by `LinkResourceDedupTest` (in `rns-test`, a separate module —
+     * Kotlin `internal` would not cross the module boundary, hence `public`)
+     * to verify dedup behavior. Production code should NOT depend on this
+     * surface.
+     */
+    @org.jetbrains.annotations.VisibleForTesting
+    fun incomingResourceHashesForTest(): List<ByteArray> =
+        synchronized(incomingResources) { incomingResources.map { it.hash } }
 
     /**
      * Called when a resource transfer concludes (successfully or with failure).

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -119,6 +119,25 @@ class Resource private constructor(
             callback: ((Resource) -> Unit)? = null,
             progressCallback: ((Resource) -> Unit)? = null
         ): Resource? {
+            // Dedupe duplicate advertisements before doing any setup work.
+            // Mirrors python `RNS.Resource.accept`'s
+            // `if not resource.link.has_incoming_resource(resource)` guard
+            // at Resource.py:223 — the check sits inside accept() so all
+            // four `Link.processResourceAdv` call sites (isRequest,
+            // isResponse, ACCEPT_APP, ACCEPT_ALL) automatically benefit.
+            // Transport's packet hashlist intentionally skips LINK-destined
+            // packets, so a sender retransmit of `RESOURCE_ADV` reaches the
+            // link layer in raw form; without this check a fresh Resource
+            // instance gets built per retransmit and assemble fires twice
+            // (observed as `Inbox sizes [N, N]` in the cross-impl
+            // conformance suite).
+            if (link.hasIncomingResource(advertisement.hash)) {
+                log(
+                    "Ignoring RESOURCE_ADV ${advertisement.hash.toHexString()} — " +
+                        "resource already transferring",
+                )
+                return null
+            }
             return try {
                 val resource = Resource(link, initiator = false)
 

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -1256,6 +1256,16 @@ class Resource private constructor(
      * recovery path that existed pre-dedup.
      */
     fun cancel() {
+        // Idempotency guard. Mirrors python `Resource.py:1090`'s
+        // `elif self.status < Resource.COMPLETE:` check — once a resource
+        // has reached a terminal state (COMPLETE / FAILED / CORRUPT,
+        // status >= COMPLETE = 0x06), a second cancel() is a no-op.
+        // Necessary now that cancel() fires `callbacks.failed?.invoke`:
+        // without this guard, a double-cancel from application code +
+        // watchdog timeout would deliver the failed callback twice.
+        if (status >= ResourceConstants.COMPLETE) {
+            return
+        }
         stopWatchdog()
         status = ResourceConstants.FAILED
         link.resourceConcluded(this)

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -1347,10 +1347,24 @@ class Resource private constructor(
 
     /**
      * Stop the watchdog thread.
+     *
+     * Skips the `interrupt()` call when invoked from the watchdog thread
+     * itself (via `cancel()`'s call from `watchdogJob`'s retry-exhausted
+     * branch). Setting the interrupt flag on the current thread would
+     * propagate into any subsequent callback I/O — `callbacks.failed`
+     * runs on this same thread, and a TCP send from inside the failed
+     * callback uses `ReentrantLock.lockInterruptibly()` which checks
+     * the flag on entry and immediately throws, silently aborting the
+     * send. Python's watchdog uses a `__watchdog_job_id` flag check
+     * rather than thread interruption (Resource.py:560-670), so the
+     * equivalent self-targeting issue doesn't exist there.
      */
     private fun stopWatchdog() {
         watchdogActive = false
-        watchdogThread?.interrupt()
+        val thread = watchdogThread
+        if (thread != null && thread !== Thread.currentThread()) {
+            thread.interrupt()
+        }
         watchdogThread = null
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -138,8 +138,21 @@ class Resource private constructor(
                 )
                 return null
             }
+            // Track whether initialization registered the resource so that
+            // a thrown `requestNext()` doesn't leave a zombie entry in
+            // `link.incomingResources`. `initializeFromAdvertisement` calls
+            // `link.registerIncomingResource(this)` and `startWatchdog()`
+            // before we get a chance to call `requestNext()`; a throw from
+            // there with the registration leaked would mean the dedup guard
+            // above rejects every subsequent retransmit of the same
+            // advertisement.hash for the lifetime of the link, removing the
+            // recovery path entirely. Python's accept (Resource.py:223-244)
+            // has the same shape but the failure modes there are caught by
+            // its own watchdog cancellation; we mirror that recovery
+            // explicitly via `resource.cancel()`.
+            var resource: Resource? = null
             return try {
-                val resource = Resource(link, initiator = false)
+                resource = Resource(link, initiator = false)
 
                 callback?.let { resource.callbacks.completed = it }
                 progressCallback?.let { resource.callbacks.progress = it }
@@ -150,6 +163,7 @@ class Resource private constructor(
                 resource
             } catch (e: Exception) {
                 log("Failed to accept resource: ${e.message}")
+                resource?.cancel()
                 null
             }
         }
@@ -1228,11 +1242,24 @@ class Resource private constructor(
 
     /**
      * Cancel this resource transfer.
+     *
+     * Mirrors python `RNS.Resource.cancel` (Resource.py:1079-1108): set
+     * `status = FAILED`, remove from the link's incoming/outgoing list
+     * via `link.resourceConcluded`, and notify any registered failure
+     * callback. Without the `callbacks.failed?.invoke` fire here, the
+     * watchdog timeout path would silently drop the registration but
+     * leave the message-level state stuck at SENDING/TRANSFERRING.
+     * Without `link.resourceConcluded`, the hash would remain in
+     * `incomingResources` for the lifetime of the link — every
+     * subsequent retransmit of the same `RESOURCE_ADV` would be dropped
+     * by the dedup guard inside `Resource.accept`, removing the
+     * recovery path that existed pre-dedup.
      */
     fun cancel() {
         stopWatchdog()
         status = ResourceConstants.FAILED
         link.resourceConcluded(this)
+        callbacks.failed?.invoke(this)
         log("Resource ${hash.toHexString()} cancelled")
     }
 
@@ -1345,10 +1372,20 @@ class Resource private constructor(
                 if (idleTime > timeout) {
                     retries++
                     if (retries > ResourceConstants.MAX_RETRIES) {
-                        status = ResourceConstants.FAILED
+                        // Mirrors python `Resource.py:578, 591, 628, 636, 648,
+                        // 667, 690` etc. — every retries-exhausted branch in
+                        // python's watchdog calls `self.cancel()`. Calling
+                        // cancel() (rather than the previous inline
+                        // `status = FAILED; callbacks.failed?.invoke`) ensures
+                        // `link.resourceConcluded(this)` runs, which removes
+                        // the resource from `incomingResources` so a future
+                        // RESOURCE_ADV with the same hash is no longer
+                        // dropped by the dedup guard inside
+                        // `Resource.accept`. Without this, a single
+                        // watchdog-fail leaves the hash registered for the
+                        // lifetime of the link, killing the recovery path.
                         log("Resource ${hash.toHexString()} timed out after $retries retries")
-                        callbacks.failed?.invoke(this)
-                        watchdogActive = false
+                        cancel()
                         break
                     } else {
                         log("Resource timeout, retry $retries/${ResourceConstants.MAX_RETRIES}")

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -2883,9 +2883,26 @@ object Transport {
                                 }
 
                                 transmit(outboundInterface, newRaw)
-                                val touched = pathEntry.touch()
-                                pathTable[packet.destinationHash.toKey()] = touched
-                                pathStore?.upsertPath(packet.destinationHash, touched)
+                                // Compare-by-identity before writing back the
+                                // touched timestamp: `transmit()` releases
+                                // `jobsLock` for the blocking socket I/O, so
+                                // another thread (typically `Transport.inbound`
+                                // processing a fresher announce on the same
+                                // destination) may have replaced this entry
+                                // during the release window. Only touch if the
+                                // entry is still the one we observed before
+                                // transmit; otherwise the fresher entry wins
+                                // and our touch would be a stale overwrite.
+                                // Python avoids this via per-table
+                                // `path_table_lock` (Transport.py:134); kotlin
+                                // uses optimistic identity-CAS — see
+                                // port-deviations.md.
+                                val key = packet.destinationHash.toKey()
+                                if (pathTable[key] === pathEntry) {
+                                    val touched = pathEntry.touch()
+                                    pathTable[key] = touched
+                                    pathStore?.upsertPath(packet.destinationHash, touched)
+                                }
                                 log(
                                     "Transport forwarding ${packet.packetType} for ${packet.destinationHash.toHexString()} via ${outboundInterface.name} (remaining_hops=${pathEntry.hops})",
                                 )
@@ -2970,8 +2987,13 @@ object Transport {
         val newRaw = raw.copyOf()
         newRaw[1] = packet.hops.toByte()
         transmit(outboundInterface, newRaw)
-        linkTable[packet.destinationHash.toKey()] =
-            linkEntry.copy(timestamp = System.currentTimeMillis())
+        // Optimistic identity-CAS: don't overwrite a fresher linkEntry that
+        // another thread may have written during transmit's lock release.
+        // See port-deviations.md (path/link table identity-CAS).
+        val linkKey = packet.destinationHash.toKey()
+        if (linkTable[linkKey] === linkEntry) {
+            linkTable[linkKey] = linkEntry.copy(timestamp = System.currentTimeMillis())
+        }
         log(
             "Forwarding ${packet.packetType}/${packet.context} for " +
                 "${packet.destinationHash.toHexString()} via ${outboundInterface.name}",
@@ -3116,10 +3138,17 @@ object Transport {
                 }
 
                 if (sent) {
-                    // Update path timestamp
-                    val touched = pathEntry.touch()
-                    pathTable[packet.destinationHash.toKey()] = touched
-                    pathStore?.upsertPath(packet.destinationHash, touched)
+                    // Update path timestamp. Optimistic identity-CAS: only
+                    // touch if the entry is still ours; transmit's lock
+                    // release may have allowed a fresher inbound update to
+                    // replace pathTable[key]. See port-deviations.md
+                    // (path/link table identity-CAS).
+                    val key = packet.destinationHash.toKey()
+                    if (pathTable[key] === pathEntry) {
+                        val touched = pathEntry!!.touch()
+                        pathTable[key] = touched
+                        pathStore?.upsertPath(packet.destinationHash, touched)
+                    }
                 }
             } else {
                 log("Path exists for $destHex but interface not found")

--- a/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/transport/Transport.kt
@@ -3198,6 +3198,23 @@ object Transport {
     /**
      * Transmit raw data on an interface.
      * Applies IFAC masking if the interface has IFAC enabled.
+     *
+     * Releases [jobsLock] across the blocking [InterfaceRef.send] call. The lock
+     * scope of the caller (typically [outbound] or [inbound]) covers the routing
+     * decision and any state writes, both of which complete before transmit is
+     * called. The actual socket I/O may block — TCP write waiting for kernel
+     * buffer drain, AutoInterface waiting on UDP socket, etc — and holding
+     * jobsLock across that block prevents other threads from processing inbound
+     * packets, including the very acks/requests we need to make progress on
+     * resource transfers. Release+re-acquire pattern matches what
+     * [raceInducerSleepReleasingJobsLock] does for tests; here it's a perf fix.
+     *
+     * Safety: the routing decision (path lookup, link table) is committed before
+     * we get here. Concurrent transmits on the same interface are serialized
+     * inside the interface's own send path. Re-acquiring jobsLock after the
+     * write returns lets the caller's loop continue with whatever state mutated
+     * during the released window — same posture as if the inbound packet that
+     * mutated it had arrived a few microseconds later.
      */
     private fun transmit(
         interfaceRef: InterfaceRef,
@@ -3218,7 +3235,20 @@ object Transport {
                 val context = data[18].toInt() and 0xFF
                 log("TX PACKET: flags=0x${"%02x".format(flags)} hops=$hops dest=${destHash.take(16)}... ctx=0x${"%02x".format(context)} size=${data.size}")
             }
-            interfaceRef.send(transmitData)
+
+            val heldByCurrent = jobsLock.isHeldByCurrentThread
+            val holdCount = if (heldByCurrent) jobsLock.holdCount else 0
+            if (holdCount > 0) {
+                repeat(holdCount) { jobsLock.unlock() }
+            }
+            try {
+                interfaceRef.send(transmitData)
+            } finally {
+                if (holdCount > 0) {
+                    repeat(holdCount) { jobsLock.lock() }
+                }
+            }
+
             trafficTxBytes += transmitData.size
             recordTxBytes(interfaceRef, transmitData.size)
         } catch (e: Exception) {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
@@ -95,7 +95,15 @@ class TCPClientInterface(
     private var socket: Socket? = null
     private val reconnecting = AtomicBoolean(false)
     private val neverConnected = AtomicBoolean(true)
-    private val writing = AtomicBoolean(false)
+
+    // Serializes concurrent writes to the socket. Was previously an
+    // AtomicBoolean check-then-set with a 10ms Thread.sleep busy-spin —
+    // that's both racy (two threads can pass the check before either sets
+    // the flag, interleaving frame bytes on the socket) and slow
+    // (concurrent writes pay 10ms minimum per turn). A ReentrantLock gives
+    // proper mutual exclusion AND wakes immediately when the prior write
+    // releases, removing the per-frame floor on concurrent send latency.
+    private val writeLock = java.util.concurrent.locks.ReentrantLock()
 
     // Debug counters
     private val framesSent = AtomicLong(0)
@@ -360,14 +368,8 @@ class TCPClientInterface(
             throw IOException("Socket not in valid state for write: $state")
         }
 
-        // Wait for any pending write to complete
-        while (writing.get()) {
-            Thread.sleep(10)
-        }
-
+        writeLock.lock()
         try {
-            writing.set(true)
-
             val framedData = if (useKissFraming) {
                 KISS.frame(data)
             } else {
@@ -417,7 +419,7 @@ class TCPClientInterface(
             teardown()
             throw e
         } finally {
-            writing.set(false)
+            writeLock.unlock()
         }
     }
 

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
@@ -368,7 +368,14 @@ class TCPClientInterface(
             throw IOException("Socket not in valid state for write: $state")
         }
 
-        writeLock.lock()
+        // lockInterruptibly() preserves the previous behaviour: the old
+        // Thread.sleep(10) busy-spin would throw InterruptedException
+        // when the writer thread was interrupted during shutdown. A plain
+        // lock() parks uninterruptibly, which would silently swallow the
+        // interrupt until the socket gets closed via teardown(). Keeping
+        // the interrupt path lets stop()-style teardowns drain promptly
+        // even when a write is contended.
+        writeLock.lockInterruptibly()
         try {
             val framedData = if (useKissFraming) {
                 KISS.frame(data)

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -1,0 +1,226 @@
+package network.reticulum.link
+
+import network.reticulum.common.DestinationDirection
+import network.reticulum.common.DestinationType
+import network.reticulum.destination.Destination
+import network.reticulum.identity.Identity
+import network.reticulum.resource.ResourceAdvertisement
+import network.reticulum.transport.Transport
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.msgpack.core.MessagePack
+import java.io.ByteArrayOutputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the resource-advertisement dedup at the Link layer.
+ *
+ * Background: Transport's packet hashlist intentionally skips LINK-destined
+ * packets (Transport.processInbound's `rememberHash` calculation marks links
+ * `false`). When a sender retransmits a `RESOURCE_ADV` — because its watchdog
+ * fired or the receiver's request was lost — the duplicate reaches the
+ * receiver-side `Link.processResourceAdv` in raw form. Without a hash-based
+ * dedup the receiver builds two `Resource` instances for the same
+ * `advertisement.hash`, both fill from the same incoming parts, both
+ * `assemble()`, and the user delivery callback fires twice.
+ *
+ * Symptom from the cross-impl conformance suite: `Inbox sizes [N, N]` —
+ * the same N-byte message landing in the inbox twice. Surfaced once
+ * `Transport.transmit()` was changed to release `jobsLock` around blocking
+ * I/O, which loosened timing enough to expose this latent race.
+ *
+ * Mirrors python `RNS.Link.has_incoming_resource` (Link.py:1311) +
+ * `Resource.accept`'s `not link.has_incoming_resource(resource)` guard
+ * (Resource.py:223).
+ */
+@DisplayName("Link Resource Dedup Tests")
+class LinkResourceDedupTest {
+
+    @BeforeEach
+    fun setup() {
+        Transport.stop()
+        Thread.sleep(100)
+        Transport.start(enableTransport = false)
+    }
+
+    @AfterEach
+    fun teardown() {
+        Transport.stop()
+        Thread.sleep(100)
+    }
+
+    @Test
+    @DisplayName("hasIncomingResource returns false on a fresh link")
+    @Timeout(5)
+    fun `hasIncomingResource returns false on a fresh link`() {
+        val link = freshLink()
+        val anyHash = ByteArray(16) { 0xAB.toByte() }
+        assertFalse(
+            link.hasIncomingResource(anyHash),
+            "Fresh link should have no incoming resources",
+        )
+    }
+
+    @Test
+    @DisplayName("hasIncomingResource returns true after registering a resource with the same hash")
+    @Timeout(5)
+    fun `hasIncomingResource returns true after registering a resource`() {
+        val link = freshLink()
+        val advHash = ByteArray(16) { 0x55.toByte() }
+        val adv = ResourceAdvertisement.unpack(buildAdvertisementBytes(hash = advHash))
+        assertNotNull(adv, "Advertisement should unpack")
+
+        // Use accept(), then register manually — accept() builds a Resource
+        // initialized to the advertisement's hash. The internal requestNext()
+        // call may throw because the link isn't ACTIVE, but accept catches
+        // and returns null. Bypass by using the simpler reflection path:
+        // construct a Resource via reflection, set hash field, register.
+        val resource = makeResourceWithHash(link, advHash)
+
+        link.registerIncomingResource(resource)
+
+        assertTrue(
+            link.hasIncomingResource(advHash),
+            "hasIncomingResource should return true for a registered hash",
+        )
+        assertFalse(
+            link.hasIncomingResource(ByteArray(16) { 0x99.toByte() }),
+            "hasIncomingResource should return false for a different hash",
+        )
+        assertEquals(
+            1,
+            link.incomingResourceHashesForTest().size,
+            "Exactly one resource should be registered",
+        )
+    }
+
+    @Test
+    @DisplayName("registerIncomingResource is idempotent for the same Resource instance")
+    @Timeout(5)
+    fun `registerIncomingResource is idempotent for the same instance`() {
+        val link = freshLink()
+        val advHash = ByteArray(16) { 0x77.toByte() }
+        val resource = makeResourceWithHash(link, advHash)
+
+        link.registerIncomingResource(resource)
+        link.registerIncomingResource(resource)
+        link.registerIncomingResource(resource)
+
+        assertEquals(
+            1,
+            link.incomingResourceHashesForTest().size,
+            "Re-registering the same Resource instance should be a no-op",
+        )
+    }
+
+    @Test
+    @DisplayName("hasIncomingResource flags duplicate-hash registrations from a fresh ADV")
+    @Timeout(5)
+    fun `hasIncomingResource flags duplicate-hash registrations from a fresh ADV`() {
+        // The actual regression: a sender retransmit produces a SECOND
+        // ResourceAdvertisement that decodes to a fresh Resource INSTANCE
+        // sharing the same hash with one we've already accepted.
+        // hasIncomingResource must catch that. The production fix in
+        // Link.processResourceAdv consults this method before accepting.
+        val link = freshLink()
+        val advHash = ByteArray(16) { 0x42.toByte() }
+
+        // First "accept": register a Resource for advHash.
+        val firstResource = makeResourceWithHash(link, advHash)
+        link.registerIncomingResource(firstResource)
+
+        // Simulate the retransmit producing a SEPARATE Resource instance
+        // with the same advertisement hash (different object identity,
+        // identical hash bytes — exactly what Resource.accept would build
+        // from a duplicate ADV).
+        val secondResource = makeResourceWithHash(link, advHash.copyOf())
+        assertFalse(
+            firstResource === secondResource,
+            "Test sanity: the two Resource instances must be distinct objects",
+        )
+
+        // The dedup check must catch the duplicate.
+        assertTrue(
+            link.hasIncomingResource(secondResource.hash),
+            "hasIncomingResource must catch duplicate-hash from a fresh Resource instance " +
+                "(production: Link.processResourceAdv consults this before Resource.accept)",
+        )
+    }
+
+    // -------------------- Helpers --------------------
+
+    private fun freshLink(): Link {
+        val identity = Identity.create()
+        val destination = Destination.create(
+            identity = identity,
+            direction = DestinationDirection.IN,
+            type = DestinationType.SINGLE,
+            appName = "lifecycle",
+            aspects = arrayOf("dedup", "test"),
+        )
+        return Link.create(destination)
+    }
+
+    /**
+     * Build a Resource whose `hash` field is set to [advHash]. Resource has a
+     * private constructor, so this uses reflection — the alternative is
+     * standing up a fully active Link + valid encrypted advertisement, which
+     * is far heavier than what's needed to test the dedup invariant.
+     */
+    private fun makeResourceWithHash(link: Link, advHash: ByteArray): network.reticulum.resource.Resource {
+        val ctor = network.reticulum.resource.Resource::class.java
+            .getDeclaredConstructor(Link::class.java, Boolean::class.javaPrimitiveType)
+        ctor.isAccessible = true
+        val resource = ctor.newInstance(link, false) as network.reticulum.resource.Resource
+
+        val hashField = network.reticulum.resource.Resource::class.java.getDeclaredField("hash")
+        hashField.isAccessible = true
+        hashField.set(resource, advHash)
+        return resource
+    }
+
+    /**
+     * Mirrors `ResourceIntegrationTest.createMockAdvertisement()` — just the
+     * msgpack-packed advertisement bytes; the hash field is parameterized so
+     * we can build two advertisements with matching hashes.
+     */
+    @Suppress("LongMethod")
+    private fun buildAdvertisementBytes(hash: ByteArray): ByteArray {
+        val output = ByteArrayOutputStream()
+        val packer = MessagePack.newDefaultPacker(output)
+
+        packer.packMapHeader(11)
+
+        packer.packString("t"); packer.packInt(1000)  // transfer size
+        packer.packString("d"); packer.packInt(1000)  // data size
+        packer.packString("n"); packer.packInt(5)     // num parts
+
+        packer.packString("h")
+        packer.packBinaryHeader(hash.size); packer.writePayload(hash)
+
+        packer.packString("r")
+        val randomHash = ByteArray(4) { (it + 100).toByte() }
+        packer.packBinaryHeader(randomHash.size); packer.writePayload(randomHash)
+
+        packer.packString("o")
+        packer.packBinaryHeader(hash.size); packer.writePayload(hash)
+
+        packer.packString("i"); packer.packInt(1)  // segment index
+        packer.packString("l"); packer.packInt(1)  // total segments
+        packer.packString("q"); packer.packNil()   // request ID
+        packer.packString("f"); packer.packInt(0)  // flags
+
+        packer.packString("m")
+        val hashmap = ByteArray(20)
+        packer.packBinaryHeader(hashmap.size); packer.writePayload(hashmap)
+
+        packer.close()
+        return output.toByteArray()
+    }
+}

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -4,6 +4,7 @@ import network.reticulum.common.DestinationDirection
 import network.reticulum.common.DestinationType
 import network.reticulum.destination.Destination
 import network.reticulum.identity.Identity
+import network.reticulum.resource.Resource
 import network.reticulum.resource.ResourceAdvertisement
 import network.reticulum.transport.Transport
 import org.junit.jupiter.api.AfterEach
@@ -16,6 +17,7 @@ import java.io.ByteArrayOutputStream
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -149,7 +151,47 @@ class LinkResourceDedupTest {
         assertTrue(
             link.hasIncomingResource(secondResource.hash),
             "hasIncomingResource must catch duplicate-hash from a fresh Resource instance " +
-                "(production: Link.processResourceAdv consults this before Resource.accept)",
+                "(production: Resource.accept consults this — covers all four call sites)",
+        )
+    }
+
+    @Test
+    @DisplayName("Resource.accept returns null on duplicate-hash advertisement (covers all 4 call sites)")
+    @Timeout(5)
+    fun `Resource accept returns null on duplicate-hash advertisement`() {
+        // Greptile P1 on PR #64: the dedup must live inside Resource.accept,
+        // not just at the general-strategy branch of Link.processResourceAdv.
+        // Otherwise the isRequest, isResponse, and ACCEPT_APP branches —
+        // which all call Resource.accept directly — bypass the check and
+        // double-deliver. Mirror python `Resource.py:223` exactly: the
+        // `not link.has_incoming_resource(resource)` guard sits inside
+        // accept(), so every call site benefits uniformly.
+        val link = freshLink()
+        val advHash = ByteArray(16) { 0xCD.toByte() }
+
+        // Seed the link's incomingResources with a Resource for advHash.
+        link.registerIncomingResource(makeResourceWithHash(link, advHash))
+        assertEquals(1, link.incomingResourceHashesForTest().size)
+
+        // Now build an advertisement whose `h` matches advHash — this is
+        // exactly what a sender retransmit produces. Resource.accept must
+        // detect the duplicate and return null without registering a
+        // second Resource.
+        val adv = ResourceAdvertisement.unpack(buildAdvertisementBytes(hash = advHash))
+        assertNotNull(adv, "Test sanity: advertisement should unpack")
+
+        val accepted = Resource.accept(advertisement = adv, link = link)
+        assertNull(
+            accepted,
+            "Resource.accept must return null when the advertisement hash is already incoming — " +
+                "the dedup guard inside accept() is what protects the isRequest/isResponse/ACCEPT_APP " +
+                "branches that bypass the Link-layer check",
+        )
+        assertEquals(
+            1,
+            link.incomingResourceHashesForTest().size,
+            "No second Resource should be registered — the duplicate ADV must be dropped " +
+                "before any setup work runs",
         )
     }
 


### PR DESCRIPTION
## Summary

Two related fixes for slow Resource transfers under load:

### 1. Transport.transmit() releases jobsLock around blocking I/O

Previously transmit() called interfaceRef.send() while still holding the process-global jobsLock that wraps both Transport.outbound() and Transport.inbound(). For TCP that send() is a blocking outputStream.write+flush which can stall on kernel buffer backpressure. While stalled, NO inbound packets get processed by anyone — they all wait for jobsLock — which is exactly the path the peer's ack/request needs to traverse before we can make progress on the resource transfer. Classic head-of-line block.

Fix: release jobsLock for the duration of interfaceRef.send() using the same hold-count save/restore pattern the existing raceInducerSleepReleasingJobsLock test helper uses. Routing decisions (path table, link table) are committed before transmit is reached, so releasing during I/O doesn't break any invariant the lock protects.

### 2. TCPClientInterface replaces writing busy-spin with proper lock

processOutgoing's while (writing.get()) Thread.sleep(10) had two problems: racy check-then-set on the AtomicBoolean (two threads can pass the check before either sets the flag, interleaving socket writes — same bug TCPServerInterface.kt:370-374 already documents) and 10ms latency floor on concurrent sends. Replace with a ReentrantLock for proper mutual exclusion with immediate wake.

## Why this matters

Surfaced via LXMF-kt#21 conformance flakes — kotlin-as-sender Resource transfers to lxmd were stalling at SENDING for 60+ seconds on GitHub Actions runners. Same code locally completes in 7-22 seconds. Lock contention amplified by limited cores.

## Test plan

- [x] :rns-core:test and :rns-interfaces:test pass
- [x] Local cross-impl conformance: 8/8 pass in 2m09s
- [ ] LXMF-kt#21 conformance run with this fix consumed via JitPack