### PR TITLE
fix(rns-android): wire LocalClientInterface factory before Reticulum.start

### DIFF
--- a/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
@@ -383,6 +383,23 @@ class ReticulumService : LifecycleService() {
                 // Check if another shared instance is already running
                 val sharedInstanceExists = Reticulum.isSharedInstanceRunning(config.sharedInstancePort)
 
+                // Wire the LocalClientInterface factory before Reticulum.start
+                // so its connect-to-shared-instance path has something to call.
+                // Without this, `Reticulum.tryConnectToSharedInstance` logs
+                // "LocalClientInterface factory not set, cannot connect to
+                // shared instance" and silently falls back to standalone
+                // — even when sharedInstanceExists=true. The factory is
+                // applied via the companion's pending-factory mechanism,
+                // which Reticulum.start() picks up between Reticulum(...)
+                // construction and rns.initialize().
+                Reticulum.setLocalClientFactory { port, host ->
+                    network.reticulum.interfaces.local.LocalClientInterface(
+                        name = "SharedInstanceClient",
+                        tcpPort = port,
+                        tcpHost = host,
+                    )
+                }
+
                 reticulum = Reticulum.start(
                     configDir = configDir,
                     enableTransport = config.enableTransport,

--- a/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
@@ -400,6 +400,26 @@ class ReticulumService : LifecycleService() {
                     )
                 }
 
+                // Wire the interface registrar so Transport can send/receive
+                // packets through the shared-instance connection. Without
+                // this, tryConnectToSharedInstance logs "No interface
+                // registrar set, packets will not be processed" — the TCP
+                // socket connects, but every packet arriving from the daemon
+                // is silently dropped (onPacketReceived is never wired) and
+                // Transport never routes outbound packets to the shared
+                // instance. Matches the python ref's behavior at
+                // RNS/Reticulum.py:414 — `RNS.Transport.interfaces.append(interface)`.
+                // The cast to network.reticulum.interfaces.Interface is safe
+                // since the factory above only produces LocalClientInterface,
+                // which extends Interface; the `Any` return type on the
+                // factory exists to keep rns-core decoupled from rns-interfaces.
+                Reticulum.setInterfaceRegistrar { iface ->
+                    if (iface is network.reticulum.interfaces.Interface) {
+                        val ref = network.reticulum.interfaces.InterfaceAdapter.getOrCreate(iface)
+                        network.reticulum.transport.Transport.registerInterface(ref)
+                    }
+                }
+
                 reticulum = Reticulum.start(
                     configDir = configDir,
                     enableTransport = config.enableTransport,


### PR DESCRIPTION
## Summary

Fixes a silent fallthrough where `rns-android.ReticulumService` would detect a sibling shared instance on the configured port (`Reticulum.isSharedInstanceRunning(port) = true`) but then fail to attach as a client because no `LocalClientInterface` factory was registered — logging:

```
[Reticulum] LocalClientInterface factory not set, cannot connect to shared instance
[Reticulum] No shared instance found, starting standalone
```

…and the service silently downgrades to standalone-mode, with all peer / announce traffic stuck device-local. Reproduced on eridanus running against a Mac-side rnsd via `adb reverse tcp:37428 tcp:37428`.

## Changes

In `ReticulumService.initializeReticulum()`, call `Reticulum.setLocalClientFactory { port, host -> LocalClientInterface(name="SharedInstanceClient", tcpPort=port, tcpHost=host) }` before `Reticulum.start(...)`. The companion's pending-factory mechanism applies it to the newly-constructed instance before `rns.initialize()` runs.

rns-android already `api`-depends on `:rns-interfaces` so the import is free.

## Test plan

- [x] `./gradlew :rns-android:compileDebugKotlin` — clean
- [ ] Manual: phone with `adb reverse tcp:37428` to a Mac-side rnsd, restart consumer app, confirm logs read "Connected to shared instance" rather than "No shared instance found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)