### PR TITLE
fix(local): drop redundant withContext in readLoop

### DIFF
--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/local/LocalClientInterface.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import network.reticulum.interfaces.Interface
 import network.reticulum.interfaces.framing.HDLC
 import java.io.IOException
@@ -300,10 +299,11 @@ class LocalClientInterface : Interface {
         try {
             while (online.value && !detached.get()) {
                 val sock = socket ?: break
-                // Blocking read wrapped in IO dispatcher
-                val bytesRead = withContext(Dispatchers.IO) {
-                    sock.getInputStream().read(buffer)
-                }
+                // The enclosing coroutine is launched on `ioScope` which is
+                // already bound to Dispatchers.IO; calling read() directly
+                // matches python's `LocalInterface.py:302 self.socket.recv(4096)`
+                // pattern without a redundant dispatcher hop per iteration.
+                val bytesRead = sock.getInputStream().read(buffer)
 
                 if (bytesRead > 0) {
                     val data = buffer.copyOf(bytesRead)

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/LocalInterfaceTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/LocalInterfaceTest.kt
@@ -298,8 +298,12 @@ class LocalInterfaceTest {
                 }
             }
 
-            // Give the server's spawned children time to settle.
-            Thread.sleep(20)
+            // Give the server's spawned children time to settle. The per-round
+            // settle is only there so the inline `client.online.value` check
+            // below isn't racing the probe-spawn detach machinery on slow
+            // runners; the load-bearing assertion is the terminal
+            // `receivedCount == numRounds` check which has its own 2 s drain.
+            Thread.sleep(50)
 
             assertTrue(
                 client.online.value,

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/LocalInterfaceTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/local/LocalInterfaceTest.kt
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 /**
@@ -241,6 +244,81 @@ class LocalInterfaceTest {
             // Unix sockets detected but not fully supported by JVM implementation
             println("Unix sockets partially supported, skipping: ${e.message}")
         }
+    }
+
+    /**
+     * Stress regression for the spawned-child read loop. On Android, real-world
+     * Carina-as-shared-instance soak (>30 min uptime) has been observed to wedge
+     * a long-lived spawned child's read loop — inbound bytes stop draining even
+     * though the socket remains ESTABLISHED and outbound bytes still flow. The
+     * suspected interaction was a redundant `withContext(Dispatchers.IO)` inside
+     * the read loop (already running on `ioScope`'s IO dispatcher), which this
+     * commit removes to match python's direct synchronous `socket.recv(4096)`
+     * pattern at `RNS/Interfaces/LocalInterface.py:302`.
+     *
+     * The wedge is not deterministically reproducible on a desktop JVM, so this
+     * test does not assert "wedge is fixed" — it asserts "long-lived spawned
+     * child keeps draining inbound bytes under aggressive sibling probe churn",
+     * which is the regression guard for any future change that disturbs the
+     * read loop body.
+     */
+    @Test
+    fun `long-lived spawned child keeps draining inbound bytes under sibling probe churn`() {
+        val tcpPort = 37435
+        val numRounds = 50
+        val probesPerRound = 5
+        val packetData = "Long-lived client packet >>>".toByteArray()
+
+        val receivedCount = AtomicInteger(0)
+
+        server = LocalServerInterface(name = "TestServer", tcpPort = tcpPort)
+        server!!.onPacketReceived = { data, _ ->
+            if (data.contentEquals(packetData)) {
+                receivedCount.incrementAndGet()
+            }
+        }
+        server!!.start()
+
+        val client = LocalClientInterface(name = "LongLivedClient", tcpPort = tcpPort)
+        clients.add(client)
+        client.start()
+        Thread.sleep(200)
+        assertEquals(1, server!!.clientCount())
+
+        repeat(numRounds) { round ->
+            // Send one packet from the long-lived client.
+            client.processOutgoing(packetData)
+
+            // Churn transient sibling probes (open + immediate close), mimicking
+            // the watchdog-probe shape that `Reticulum.isSharedInstanceRunning`
+            // produces on every shared-instance auto-recovery poll.
+            repeat(probesPerRound) {
+                Socket().use { probe ->
+                    probe.connect(InetSocketAddress("127.0.0.1", tcpPort), 1000)
+                }
+            }
+
+            // Give the server's spawned children time to settle.
+            Thread.sleep(20)
+
+            assertTrue(
+                client.online.value,
+                "Long-lived client went offline at round $round under sibling churn",
+            )
+        }
+
+        // Wait for last packet to drain.
+        val deadline = System.currentTimeMillis() + 2000
+        while (System.currentTimeMillis() < deadline && receivedCount.get() < numRounds) {
+            Thread.sleep(50)
+        }
+
+        assertEquals(
+            numRounds,
+            receivedCount.get(),
+            "Long-lived client sent $numRounds packets, server received ${receivedCount.get()}. " +
+                "Read loop may have wedged under sibling churn.",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `LocalClientInterface.readLoop` is launched on `ioScope` which is already bound to `Dispatchers.IO`. The inner `withContext(Dispatchers.IO) { socket.read(buffer) }` was a redundant dispatcher hop per iteration.
- Calling `read()` directly on the enclosing coroutine's thread matches python's `RNS/Interfaces/LocalInterface.py:302 self.socket.recv(4096)` — a plain synchronous blocking read on the per-interface read thread, no nested dispatcher / executor.
- Adds a stress regression test (`long-lived spawned child keeps draining inbound bytes under sibling probe churn`): 50 rounds of bidirectional packet send + 5 transient sibling probe sockets per round, asserting all packets drain through the long-lived spawned child's read loop.

## Why now

Speculative partial fix for a real-world Android shared-instance soak bug: spawned-child read loops have been observed to wedge inside the blocking `read()` after >30 min uptime, with no exit log, while concurrent outbound traffic (announce fanout) keeps flowing through `processOutgoing` on the same interface. Mechanism unproven and suspected to be ART/coroutine-dispatcher specific — the desktop-JVM stress test in this PR does NOT reproduce the wedge even under aggressive churn, on either `main` or this branch.

Bringing the read loop body into python parity eliminates one potential dispatcher-interaction point that the kotlin port introduces over python's threading-Thread synchronous model. Production observation after deploy will determine whether further intervention is needed (per-interface read watchdog, NIO selector, or dedicated thread per spawned child).

## Test plan

- [x] `./gradlew :rns-interfaces:test --tests "*long-lived spawned child keeps draining*"` passes
- [x] No regression on other `LocalInterfaceTest` cases (pre-existing port-collision failures on 37428/37429 unrelated — same on `main`)
- [ ] Production soak on Android (Carina as shared-instance host, Eridanus as client) — observable signal is whether the wedge recurs in the same time-frame as before. Will know within a day or two of deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)