### PR TITLE
fix(android): stop leaking a FINE_LOCATION maxSdkVersion cap onto consumers

### DIFF
--- a/rns-android/src/main/AndroidManifest.xml
+++ b/rns-android/src/main/AndroidManifest.xml
@@ -12,8 +12,17 @@
         android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
-        android:maxSdkVersion="32" />
+    <!--
+        BLE scanning on API <= 30 requires ACCESS_FINE_LOCATION, but this
+        library intentionally does NOT declare it. ACCESS_FINE_LOCATION is a
+        dangerous, app-scoped permission; declaring it here with an
+        android:maxSdkVersion cap merges that cap onto the consuming app's own
+        FINE permission and silently strips precise location on newer API
+        levels (no "Use precise location" toggle, GPS unavailable). Consumers
+        that need legacy (API <= 30) BLE scanning must declare and request
+        ACCESS_FINE_LOCATION themselves — BleScanner.hasScanPermission() only
+        checks it at runtime; a library cannot request it.
+    -->
 
     <!-- BLE hardware feature (not required; graceful degradation if unavailable) -->
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />


### PR DESCRIPTION
## Problem

`rns-android`'s manifest declares `ACCESS_FINE_LOCATION` with `android:maxSdkVersion="32"` (in the legacy "API ≤ 30 BLE" block). Android's manifest merger propagates that cap to **every consuming app**: an app that declares its own *uncapped* `ACCESS_FINE_LOCATION` ends up with `maxSdkVersion="32"` merged in, so on **API ≥ 33** the OS drops fine location entirely — no "Use precise location" toggle, GPS unavailable, every position fuzzed to ~1–3 km.

This silently broke precise location / location sharing in a downstream app (torlando-tech/columba#855); the consumer had to work around it with `tools:remove="android:maxSdkVersion"`.

## Fix

Remove the `ACCESS_FINE_LOCATION` declaration from the library manifest:

- It's a **dangerous, app-scoped** permission. A library declaring it forces the permission (and here, its `maxSdkVersion` cap) onto all consumers, and there's no manifest-merge way to scope it so it doesn't leak.
- `BleScanner.hasScanPermission()` only **checks** the permission at runtime (a library can't request it), so removing the declaration doesn't change that logic.
- Consumers needing legacy (API ≤ 30) BLE scanning declare + request `ACCESS_FINE_LOCATION` themselves (which they already must for the runtime grant). Consumers needing precise location for their own features keep their uncapped declaration. Modern BLE-only consumers (API 31+, `BLUETOOTH_SCAN`/`neverForLocation`) no longer over-declare location.

A manifest comment records the reasoning. Verified `:rns-android:processDebugManifest` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
