### PR TITLE
feat(ble): data-path liveness probe (protocol v0.4.0)

### DIFF
--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEConstants.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEConstants.kt
@@ -93,6 +93,31 @@ object BLEConstants {
      */
     const val KEEPALIVE_INTERVAL_MS = 15_000L
 
+    // ---- Data-Path Liveness Probe (protocol v0.4.0) ----
+
+    /**
+     * A keepalive proves the *link* is up; it does not prove *data* still flows
+     * (under RF degradation 1-byte writes succeed while larger fragments fail, and
+     * the link layer keeps an idle connection alive). The data-path probe is an
+     * active 2-byte PING/PONG round-trip over the real data path: a healthy link
+     * round-trips it (which keeps the link fresh, so idle links are never reaped),
+     * a data-dead link does not (so it is detected and reconnected). The 2-byte
+     * frames are shorter than the 5-byte fragment header, so peers that predate the
+     * probe reject them as "too short" and are unaffected.
+     * Wire-compatible with the python ble-reticulum reference (BLE_PROTOCOL_v0.4.0.md).
+     */
+    const val PROBE_PING_BYTE: Byte = 0x04
+    const val PROBE_PONG_BYTE: Byte = 0x05
+
+    /** PING a link that has had no real data for this long. */
+    const val DATA_PATH_PROBE_INTERVAL_MS = 15_000L
+
+    /** Reconnect a probe-capable peer whose data path has been silent this long. */
+    const val DATA_PATH_TIMEOUT_MS = 45_000L
+
+    /** How often the per-peer probe/detect loop runs. */
+    const val DATA_PATH_PROBE_POLL_INTERVAL_MS = 10_000L
+
     // ---- Timeouts ----
 
     /**

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEInterface.kt
@@ -598,6 +598,24 @@ class BLEInterface(
         log("Peer disconnected: ${peerInterface.name} (remaining: ${peers.size})")
     }
 
+    /**
+     * A peer's data-path liveness probe found the link dead (connected but no real data
+     * crossing). Force a real driver-level disconnect so it re-establishes -- mirrors
+     * python ble-reticulum's `driver.disconnect(address)` from `_run_data_path_probes`.
+     * The driver's `connectionLost` flow then tears the peer down ([collectDisconnections]
+     * -> [tearDownPeer]) and the reconnect backoff re-dials. (Android's `disconnect`
+     * cancels both a central GATT connection and a peripheral-side central, so this works
+     * regardless of which role we hold.)
+     */
+    internal suspend fun onDataPathDead(address: String) {
+        log("data-path dead for ${address.takeLast(8)} -- forcing reconnect via driver.disconnect")
+        try {
+            driver.disconnect(address)
+        } catch (e: Exception) {
+            log("onDataPathDead disconnect failed: ${e.message}")
+        }
+    }
+
     // ---- Blacklist and Backoff ----
 
     private fun isBlacklisted(address: String): Boolean {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/ble/BLEPeerInterface.kt
@@ -62,6 +62,24 @@ class BLEPeerInterface(
     @Volatile
     var lastTrafficReceived: Long = System.currentTimeMillis()
 
+    /**
+     * Last time *real data* crossed the link — a data fragment or a data-path probe
+     * frame, but NOT a keepalive or handshake. Drives the data-path liveness probe.
+     * ([lastTrafficReceived] counts keepalives and so cannot distinguish an
+     * idle-but-healthy link from a keepalive-alive-but-data-dead one; this clock can.)
+     * Mirrors python ble-reticulum `_last_real_data` (BLEInterface.py).
+     */
+    @Volatile
+    private var lastRealData: Long = System.currentTimeMillis()
+
+    /**
+     * Set once a PING/PONG has been seen from this peer (the peer speaks the data-path
+     * probe). Only probe-capable peers are reconnected on a dead path, so peers that
+     * predate the probe are never falsely reaped. Mirrors python `_probe_capable`.
+     */
+    @Volatile
+    private var probeCapable: Boolean = false
+
     // RSSI at discovery time, used for scoring/eviction decisions
     @Volatile
     var discoveryRssi: Int = -100
@@ -75,6 +93,7 @@ class BLEPeerInterface(
     var currentRssi: Int = -100
 
     private var rssiJob: Job? = null
+    private var probeJob: Job? = null
 
     init {
         this.parentInterface = parentBleInterface
@@ -89,6 +108,7 @@ class BLEPeerInterface(
 
         receiveJob = scope.launch { receiveLoop() }
         keepaliveJob = scope.launch { keepaliveLoop() }
+        probeJob = scope.launch { dataPathProbeLoop() }
         startRssiPolling()
     }
 
@@ -159,10 +179,16 @@ class BLEPeerInterface(
                     return@collect
                 }
 
+                // Data-path liveness probe frames (2-byte PING/PONG)
+                if (handleProbeFrame(fragment)) return@collect
+
                 // Skip identity handshake data (16 bytes exactly, already consumed by BLEInterface)
                 if (fragment.size == BLEConstants.IDENTITY_SIZE) {
                     return@collect
                 }
+
+                // Real data crossed the link -- refresh the data-path liveness clock.
+                lastRealData = System.currentTimeMillis()
 
                 try {
                     val packet = reassembler.receiveFragment(fragment, connection.address)
@@ -246,16 +272,98 @@ class BLEPeerInterface(
         }
     }
 
+    // ---- Data-Path Liveness Probe ----
+
+    /**
+     * Handle an inbound data-path liveness frame (2-byte PING/PONG). Returns true if
+     * [fragment] was a probe frame (and is now consumed). Receiving any probe frame
+     * proves the inbound data path is alive and that the peer speaks the probe, so the
+     * peer is marked probe-capable; a PING is echoed as a PONG.
+     *
+     * Mirrors python ble-reticulum `_handle_probe_frame` (BLEInterface.py). The python
+     * version also normalizes a "dev:"-prefixed peripheral address to resolve the peer's
+     * identity; here the frame already arrives on this peer's own connection, so no
+     * address lookup is needed.
+     *
+     * Visible as `internal` (rather than private) so unit tests can exercise the
+     * PING->PONG echo directly without driving the full receive coroutine loop (same
+     * pattern as [pollAndApplyRssi]).
+     */
+    internal suspend fun handleProbeFrame(fragment: ByteArray): Boolean {
+        if (fragment.size != 2) return false
+        val type = fragment[0]
+        if (type != BLEConstants.PROBE_PING_BYTE && type != BLEConstants.PROBE_PONG_BYTE) return false
+
+        // Any probe frame proves the data path is alive and the peer speaks the probe.
+        lastRealData = System.currentTimeMillis()
+        probeCapable = true
+
+        if (type == BLEConstants.PROBE_PING_BYTE) {
+            sendProbe(BLEConstants.PROBE_PONG_BYTE, fragment[1])
+        }
+        return true
+    }
+
+    /** Send a 2-byte data-path probe frame (PING/PONG) over the real data path. */
+    private suspend fun sendProbe(type: Byte, nonce: Byte) {
+        try {
+            connection.sendFragment(byteArrayOf(type, nonce))
+        } catch (e: Exception) {
+            log("Probe send failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Periodic data-path liveness sweep for this peer.
+     *
+     * - If the link has had no real data for [BLEConstants.DATA_PATH_PROBE_INTERVAL_MS],
+     *   send a PING; a healthy peer echoes a PONG, which refreshes [lastRealData] -- so
+     *   the probe is itself the traffic that keeps a genuinely idle-but-healthy link
+     *   from ever looking dead, and idle links are never reaped.
+     * - If a probe-capable peer's data path has been silent past
+     *   [BLEConstants.DATA_PATH_TIMEOUT_MS], the link is "connected but data-dead":
+     *   force a real reconnect via the driver.
+     *
+     * Mirrors python ble-reticulum `_run_data_path_probes` (BLEInterface.py). Python runs
+     * one timer in the parent interface iterating all peers; this kotlin port runs the
+     * loop per-peer (alongside the existing keepalive/RSSI jobs) to fit the per-peer
+     * structure. Reconnect goes through the parent's `driver.disconnect` (python parity),
+     * not the per-peer `detach()`/`close()` -- the parent owns the driver, and on Android
+     * `disconnect` cancels both a central GATT connection and a peripheral-side central.
+     */
+    private suspend fun dataPathProbeLoop() {
+        try {
+            while (online.value && !detached.get()) {
+                delay(BLEConstants.DATA_PATH_PROBE_POLL_INTERVAL_MS)
+                if (!online.value || detached.get()) break
+
+                val idle = System.currentTimeMillis() - lastRealData
+                if (idle > BLEConstants.DATA_PATH_PROBE_INTERVAL_MS) {
+                    // Low byte of the clock is a fine nonce; Long.toByte() truncates to it.
+                    sendProbe(BLEConstants.PROBE_PING_BYTE, System.currentTimeMillis().toByte())
+                }
+                if (probeCapable && idle > BLEConstants.DATA_PATH_TIMEOUT_MS) {
+                    log("data-path dead (no real data ${idle}ms) -- reconnecting")
+                    probeCapable = false
+                    parentBleInterface.onDataPathDead(connection.address)
+                }
+            }
+        } catch (e: CancellationException) {
+            // Normal cancellation
+        }
+    }
+
     /**
      * Update the underlying BLE connection (for MAC rotation).
      * Called by [BLEInterface] when the same identity connects from a new address.
      * Cancels old receive/keepalive, swaps connection, restarts loops.
      */
     fun updateConnection(newConnection: BLEPeerConnection, newAddress: String) {
-        // Cancel old receive/keepalive/rssi jobs
+        // Cancel old receive/keepalive/rssi/probe jobs
         receiveJob?.cancel()
         keepaliveJob?.cancel()
         rssiJob?.cancel()
+        probeJob?.cancel()
 
         // Close old connection
         try { connection.close() } catch (_: Exception) {}
@@ -265,12 +373,15 @@ class BLEPeerInterface(
         fragmenter = BLEFragmenter(newConnection.mtu)
         reassembler = BLEReassembler()
 
-        // MAC rotation proves liveness -- reset zombie detection timer
+        // MAC rotation proves liveness -- reset zombie + data-path timers, re-negotiate probe
         lastTrafficReceived = System.currentTimeMillis()
+        lastRealData = System.currentTimeMillis()
+        probeCapable = false
 
-        // Restart receive, keepalive, and RSSI polling
+        // Restart receive, keepalive, probe, and RSSI polling
         receiveJob = scope.launch { receiveLoop() }
         keepaliveJob = scope.launch { keepaliveLoop() }
+        probeJob = scope.launch { dataPathProbeLoop() }
         startRssiPolling()
 
         log("Connection updated to ${newAddress.takeLast(8)}")
@@ -288,6 +399,7 @@ class BLEPeerInterface(
         receiveJob?.cancel()
         keepaliveJob?.cancel()
         rssiJob?.cancel()
+        probeJob?.cancel()
         scope.cancel()
 
         // Close BLE connection

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEPeerInterfaceProbeTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ble/BLEPeerInterfaceProbeTest.kt
@@ -1,0 +1,117 @@
+package network.reticulum.interfaces.ble
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the BLE data-path liveness probe frame handling (protocol v0.4.0).
+ *
+ * [BLEPeerInterface.handleProbeFrame] is the inbound half of the probe: a 2-byte
+ * PING(0x04)/PONG(0x05) over the real data path. Receiving a PING must be answered
+ * with a PONG echoing the same nonce byte; any probe frame marks the peer
+ * probe-capable. Non-probe fragments must pass through untouched (returns false) so
+ * normal reassembly still runs. Mirrors python ble-reticulum `_handle_probe_frame`.
+ */
+@DisplayName("BLEPeerInterface data-path probe")
+class BLEPeerInterfaceProbeTest {
+
+    private val liveInterfaces = mutableListOf<BLEPeerInterface>()
+
+    @AfterEach
+    fun cleanup() {
+        liveInterfaces.forEach { runCatching { it.detach() } }
+        liveInterfaces.clear()
+    }
+
+    @Test
+    fun `inbound PING is answered with a PONG echoing the nonce`() = runTest {
+        val conn = CapturingConn()
+        val peer = newPeerInterface(conn)
+
+        val consumed = peer.handleProbeFrame(byteArrayOf(BLEConstants.PROBE_PING_BYTE, 0x2A))
+
+        // The PING is consumed (not handed to the reassembler)...
+        consumed shouldBe true
+        // ...and answered with exactly one PONG that echoes the PING's nonce byte.
+        conn.sent.size shouldBe 1
+        conn.sent[0].toList() shouldBe listOf(BLEConstants.PROBE_PONG_BYTE, 0x2A.toByte())
+    }
+
+    @Test
+    fun `inbound PONG is consumed without a reply`() = runTest {
+        val conn = CapturingConn()
+        val peer = newPeerInterface(conn)
+
+        // A PONG (the echo we asked for) proves the data path but must NOT
+        // trigger another probe frame, or two peers would ping-pong forever.
+        peer.handleProbeFrame(byteArrayOf(BLEConstants.PROBE_PONG_BYTE, 0x07)) shouldBe true
+        conn.sent.size shouldBe 0
+    }
+
+    @Test
+    fun `non-probe fragments are not consumed`() = runTest {
+        val conn = CapturingConn()
+        val peer = newPeerInterface(conn)
+
+        // Wrong length (a real fragment carries the 5-byte header) and wrong
+        // first byte must both fall through to normal reassembly.
+        peer.handleProbeFrame(byteArrayOf(0x01, 0x00, 0x00, 0x00, 0x01)) shouldBe false
+        peer.handleProbeFrame(byteArrayOf(0x09, 0x00)) shouldBe false
+        conn.sent.size shouldBe 0
+    }
+
+    private fun newPeerInterface(connection: CapturingConn): BLEPeerInterface {
+        val parent =
+            BLEInterface(
+                name = "BLE-test",
+                driver = StubBLEDriver(),
+                transportIdentity = ByteArray(16),
+            )
+        val peer =
+            BLEPeerInterface(
+                name = "BLE|test",
+                connection = connection,
+                parentBleInterface = parent,
+                peerIdentity = ByteArray(16),
+            )
+        liveInterfaces += peer
+        return peer
+    }
+
+    /** [BLEPeerConnection] fake that records every fragment sent, for PONG assertions. */
+    private class CapturingConn : BLEPeerConnection {
+        val sent = mutableListOf<ByteArray>()
+        override val address: String = "00:11:22:33:44:55"
+        override val mtu: Int = 185
+        override val identity: ByteArray? = ByteArray(16)
+        override val receivedFragments: SharedFlow<ByteArray> = MutableSharedFlow()
+        override suspend fun sendFragment(data: ByteArray) { sent += data }
+        override suspend fun readIdentity(): ByteArray = ByteArray(16)
+        override suspend fun writeIdentity(identity: ByteArray) = Unit
+        override suspend fun readRemoteRssi(): Int = -70
+        override fun close() = Unit
+    }
+
+    /** Minimal [BLEDriver] stub sufficient to construct a [BLEInterface] parent. */
+    private class StubBLEDriver : BLEDriver {
+        override suspend fun startAdvertising() = Unit
+        override suspend fun stopAdvertising() = Unit
+        override suspend fun startScanning() = Unit
+        override suspend fun stopScanning() = Unit
+        override suspend fun connect(address: String): BLEPeerConnection =
+            error("unused in probe tests")
+
+        override suspend fun disconnect(address: String) = Unit
+        override fun shutdown() = Unit
+        override val discoveredPeers: SharedFlow<DiscoveredPeer> = MutableSharedFlow()
+        override val incomingConnections: SharedFlow<BLEPeerConnection> = MutableSharedFlow()
+        override val connectionLost: SharedFlow<String> = MutableSharedFlow()
+        override val localAddress: String? = null
+        override val isRunning: Boolean = false
+    }
+}


### PR DESCRIPTION
## Summary

Ports the **data-path liveness probe** to the reticulum-kt BLE stack (the kotlinBackend of the Columba app), mirroring the python ble-reticulum reference and the reticulum-swift port. Detects and recovers from "connected but data-dead" links — link layer up, keepalives passing, real data silently failing.

## How it works

- 2-byte `PING (0x04)` / `PONG (0x05)` round-trip over the real data path. Capability auto-negotiated on the first frame seen; the 2-byte frames are shorter than the 5-byte fragment header so peers predating the probe reject them harmlessly (backwards compatible).
- New `lastRealData` clock (real data + probe frames only, not keepalives/handshake) — the existing `lastTrafficReceived` counts keepalives and so cannot distinguish an idle-but-healthy link from a data-dead one; the new clock can.
- Per-peer `probeJob` (alongside the existing `keepaliveJob`/`rssiJob`): PINGs an idle link (the probe is itself the keep-fresh traffic, so idle links are never reaped) and, on a data-dead probe-capable peer, calls `BLEInterface.onDataPathDead` -> `driver.disconnect(address)` so the link re-establishes (python parity).
- On Android `driver.disconnect` cancels **both** a central GATT connection and a peripheral-side central, so — unlike the swift/iOS port — there is no peripheral-role recovery gap.

## Tests

`BLEPeerInterfaceProbeTest` covers the inbound PING -> PONG echo (nonce echoed), the PONG-no-reply case, and non-probe passthrough. Existing BLE tests unchanged + green.

Mirrors python `BLEInterface.py` (`_run_data_path_probes` / `_handle_probe_frame` / `_send_probe` / `_last_real_data` / `_probe_capable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
