### PR TITLE
fix(tcp): match Python reconnect cadence

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python dependencies
-        run: pip install pytest
+        run: pip install -r reticulum-conformance/requirements.txt
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   conformance:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
         # LXMF-kt. It rides the same bridge but has its own CI target
         # (to be added in a follow-up PR on LXMF-kt); ignoring it here
         # keeps reticulum-kt CI focused on RNS-layer parity.
-        run: python3 -m pytest tests/ --ignore=tests/lxmf --impl=kotlin -v --tb=short
+        run: python3 -m pytest tests/ --ignore=tests/lxmf --impl=kotlin -n auto -v --tb=short
 
       - name: Run pipe integration conformance tests
         working-directory: reticulum-conformance

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -38,7 +38,7 @@ LXMF has been extracted to a separate repository: [LXMF-kt](https://github.com/t
 - **Buffer**: Stream I/O over channels
 
 #### Interfaces
-- **TCP**: Client and server with HDLC framing, exponential backoff reconnect
+- **TCP**: Client and server with HDLC framing, fixed five-second reconnect matching Python
 - **UDP**: Unicast, broadcast, multicast
 - **Local**: Server/client IPC for sharing Reticulum across apps
 - **RNode (LoRa)**: Full KISS protocol, firmware checking, BLE + serial transport

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Comparison with [Python RNS](https://github.com/markqvist/Reticulum) reference i
 
 | Interface | Status | Notes |
 |-----------|--------|-------|
-| TCP Server/Client | Complete | HDLC framing, exponential backoff reconnect |
+| TCP Server/Client | Complete | HDLC framing, fixed five-second reconnect matching Python |
 | UDP | Complete | Unicast, broadcast, multicast |
 | Local (Shared Instance) | Complete | Server/client IPC for sharing Reticulum across apps |
 | RNode (LoRa) | Complete | Full KISS protocol, firmware checking, BLE + serial transport |

--- a/rns-cli/src/main/kotlin/network/reticulum/cli/config/InterfaceConfigFactory.kt
+++ b/rns-cli/src/main/kotlin/network/reticulum/cli/config/InterfaceConfigFactory.kt
@@ -86,7 +86,7 @@ object InterfaceConfigFactory {
     /**
      * Create a TCP client interface.
      */
-    private fun createTcpClient(config: InterfaceConfig): Interface? {
+    internal fun createTcpClient(config: InterfaceConfig): Interface? {
         val targetHost = config.targetHost
         val targetPort = config.targetPort
 
@@ -100,7 +100,8 @@ object InterfaceConfigFactory {
         return TCPClientInterface(
             name = config.name,
             targetHost = targetHost,
-            targetPort = targetPort
+            targetPort = targetPort,
+            maxReconnectAttempts = config.maxReconnectTries,
         )
     }
 

--- a/rns-cli/src/main/kotlin/network/reticulum/cli/config/ReticulumConfig.kt
+++ b/rns-cli/src/main/kotlin/network/reticulum/cli/config/ReticulumConfig.kt
@@ -55,7 +55,18 @@ data class InterfaceConfig(
     val listenPort: Int? get() = (options["listen_port"] as? Number)?.toInt()
     val mode: Int? get() = (options["selected_interface_mode"] as? Number)?.toInt()
     val bitrate: Int? get() = (options["configured_bitrate"] as? Number)?.toInt()
-    val maxReconnectTries: Int? get() = (options["max_reconnect_tries"] as? Number)?.toInt()
+    val maxReconnectTries: Int?
+        get() {
+            val value = options["max_reconnect_tries"] ?: return null
+            return when (value) {
+                is Byte -> value.toInt()
+                is Short -> value.toInt()
+                is Int -> value
+                is Long -> value.takeIf { it in Int.MIN_VALUE..Int.MAX_VALUE }?.toInt()
+                is String -> value.toPythonDecimalIntOrNull()
+                else -> null
+            } ?: throw IllegalArgumentException("max_reconnect_tries must be a 32-bit integer")
+        }
 
     // AutoInterface options
     val groupId: String? get() = options["group_id"] as? String
@@ -77,6 +88,45 @@ data class InterfaceConfig(
         else -> null
     }
 }
+
+private fun String.toPythonDecimalIntOrNull(): Int? {
+    val value = trim()
+    if (value.isEmpty()) return null
+
+    val normalized = StringBuilder(value.length)
+    var index = 0
+    if (value.first() == '+' || value.first() == '-') {
+        normalized.append(value.first())
+        index++
+        if (index == value.length) return null
+    }
+
+    var previousWasDigit = false
+    while (index < value.length) {
+        val codePoint = value.codePointAt(index)
+        val nextIndex = index + Character.charCount(codePoint)
+        if (codePoint == '_'.code) {
+            if (
+                !previousWasDigit ||
+                nextIndex >= value.length ||
+                !value.codePointAt(nextIndex).isPythonDecimalDigit()
+            ) {
+                return null
+            }
+            previousWasDigit = false
+        } else {
+            if (!codePoint.isPythonDecimalDigit()) return null
+            normalized.append(Character.digit(codePoint, 10))
+            previousWasDigit = true
+        }
+        index = nextIndex
+    }
+
+    return normalized.toString().toIntOrNull()
+}
+
+private fun Int.isPythonDecimalDigit(): Boolean =
+    Character.getType(this) == Character.DECIMAL_DIGIT_NUMBER.toInt()
 
 /**
  * Supported interface types.

--- a/rns-cli/src/main/kotlin/network/reticulum/cli/config/ReticulumConfig.kt
+++ b/rns-cli/src/main/kotlin/network/reticulum/cli/config/ReticulumConfig.kt
@@ -55,6 +55,7 @@ data class InterfaceConfig(
     val listenPort: Int? get() = (options["listen_port"] as? Number)?.toInt()
     val mode: Int? get() = (options["selected_interface_mode"] as? Number)?.toInt()
     val bitrate: Int? get() = (options["configured_bitrate"] as? Number)?.toInt()
+    val maxReconnectTries: Int? get() = (options["max_reconnect_tries"] as? Number)?.toInt()
 
     // AutoInterface options
     val groupId: String? get() = options["group_id"] as? String

--- a/rns-cli/src/test/kotlin/network/reticulum/cli/config/InterfaceConfigFactoryTest.kt
+++ b/rns-cli/src/test/kotlin/network/reticulum/cli/config/InterfaceConfigFactoryTest.kt
@@ -1,0 +1,48 @@
+package network.reticulum.cli.config
+
+import network.reticulum.interfaces.tcp.TCPClientInterface
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class InterfaceConfigFactoryTest {
+    @Test
+    fun `TCP client forwards configured Python reconnect limit`() {
+        val config = InterfaceConfig(
+            name = "ConfiguredTcpClient",
+            type = "TCPClientInterface",
+            options = mapOf(
+                "target_host" to "127.0.0.1",
+                "target_port" to 4242,
+                "max_reconnect_tries" to 7,
+            ),
+        )
+
+        assertEquals(7, config.maxReconnectTries)
+
+        val iface = InterfaceConfigFactory.createTcpClient(config) as TCPClientInterface
+        assertEquals(7, iface.configuredMaxReconnectAttempts())
+    }
+
+    @Test
+    fun `TCP client preserves Python unlimited reconnect default`() {
+        val config = InterfaceConfig(
+            name = "UnlimitedTcpClient",
+            type = "TCPClientInterface",
+            options = mapOf(
+                "target_host" to "127.0.0.1",
+                "target_port" to 4242,
+            ),
+        )
+
+        assertEquals(null, config.maxReconnectTries)
+
+        val iface = InterfaceConfigFactory.createTcpClient(config) as TCPClientInterface
+        assertEquals(null, iface.configuredMaxReconnectAttempts())
+    }
+
+    private fun TCPClientInterface.configuredMaxReconnectAttempts(): Int? {
+        val field = TCPClientInterface::class.java.getDeclaredField("maxReconnectAttempts")
+        field.isAccessible = true
+        return field.get(this) as Int?
+    }
+}

--- a/rns-cli/src/test/kotlin/network/reticulum/cli/config/InterfaceConfigFactoryTest.kt
+++ b/rns-cli/src/test/kotlin/network/reticulum/cli/config/InterfaceConfigFactoryTest.kt
@@ -2,9 +2,16 @@ package network.reticulum.cli.config
 
 import network.reticulum.interfaces.tcp.TCPClientInterface
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
 
 class InterfaceConfigFactoryTest {
+    @TempDir
+    lateinit var tempDir: Path
+
     @Test
     fun `TCP client forwards configured Python reconnect limit`() {
         val config = InterfaceConfig(
@@ -38,6 +45,51 @@ class InterfaceConfigFactoryTest {
 
         val iface = InterfaceConfigFactory.createTcpClient(config) as TCPClientInterface
         assertEquals(null, iface.configuredMaxReconnectAttempts())
+    }
+
+    @Test
+    fun `TCP client accepts quoted integer reconnect limit like Python ConfigObj`() {
+        val configFile = tempDir.resolve("config")
+        configFile.writeText(
+            """
+            [interfaces]
+              [[QuotedTcpClient]]
+                type = TCPClientInterface
+                enabled = yes
+                target_host = 127.0.0.1
+                target_port = 4242
+                max_reconnect_tries = "7"
+            """.trimIndent(),
+        )
+
+        val config = ConfigParser.parse(configFile.toFile()).interfaces.getValue("QuotedTcpClient")
+        assertEquals(7, config.maxReconnectTries)
+    }
+
+    @Test
+    fun `TCP client accepts supplementary Unicode decimal digits like Python int`() {
+        val config = InterfaceConfig(
+            name = "UnicodeTcpClient",
+            type = "TCPClientInterface",
+            options = mapOf("max_reconnect_tries" to "𑁦"),
+        )
+
+        assertEquals(0, config.maxReconnectTries)
+    }
+
+    @Test
+    fun `TCP client rejects reconnect limits Python ConfigObj rejects`() {
+        listOf(7.5, "malformed", "", Int.MAX_VALUE.toLong() + 1).forEach { invalidValue ->
+            val config = InterfaceConfig(
+                name = "InvalidTcpClient",
+                type = "TCPClientInterface",
+                options = mapOf("max_reconnect_tries" to invalidValue),
+            )
+
+            assertThrows(IllegalArgumentException::class.java) {
+                config.maxReconnectTries
+            }
+        }
     }
 
     private fun TCPClientInterface.configuredMaxReconnectAttempts(): Int? {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * TCP client interface for Reticulum.
@@ -116,8 +117,14 @@ class TCPClientInterface(
     override val ifacIdentity: Identity?
         get() = _ifacCredentials?.identity
 
+    private enum class ReconnectState {
+        IDLE,
+        RUNNING,
+        PENDING,
+    }
+
     private var socket: Socket? = null
-    private val reconnecting = AtomicBoolean(false)
+    private val reconnectState = AtomicReference(ReconnectState.IDLE)
     private val neverConnected = AtomicBoolean(true)
 
     // Serializes concurrent writes to the socket. Was previously an
@@ -157,6 +164,8 @@ class TCPClientInterface(
     }
     private var readJob: Job? = null
     private var connectJob: Job? = null
+
+    internal var onConnectionPublishedForTest: (() -> Unit)? = null
 
     private data class EstablishedConnection(
         val socket: Socket,
@@ -230,6 +239,7 @@ class TCPClientInterface(
 
             socket = sock
             setOnline(true)
+            onConnectionPublishedForTest?.invoke()
             neverConnected.set(false)
 
             // Request tunnel synthesis for this connection
@@ -279,9 +289,10 @@ class TCPClientInterface(
     }
 
     private suspend fun reconnect() {
-        if (!reconnecting.compareAndSet(false, true)) return
+        if (!claimReconnectOwnership()) return
 
         var connection: EstablishedConnection? = null
+        var reconnectWasPending = false
         var attempts = 0
         try {
             while (!online.value && !detached.get()) {
@@ -313,12 +324,64 @@ class TCPClientInterface(
             // Python clears reconnect ownership before starting the replacement
             // read loop. This ensures an immediately closed replacement socket
             // can synchronously claim the next reconnect instead of being dropped.
-            reconnecting.set(false)
+            reconnectWasPending = releaseReconnectOwnership()
         }
 
         connection?.let { established ->
             if (ioScope.isActive && online.value && !detached.get()) {
                 startReadLoop(established.socket, established.inputStream)
+            }
+        }
+
+        // A write failure can tear down a newly published socket before its
+        // reader is installed. If that teardown requested reconnect while this
+        // owner was active, take responsibility for the deferred request now.
+        if (
+            reconnectWasPending &&
+            ioScope.isActive &&
+            !online.value &&
+            !detached.get()
+        ) {
+            ioScope.launch { reconnect() }
+        }
+    }
+
+    private fun claimReconnectOwnership(): Boolean {
+        while (true) {
+            when (reconnectState.get()) {
+                ReconnectState.IDLE -> {
+                    if (reconnectState.compareAndSet(ReconnectState.IDLE, ReconnectState.RUNNING)) {
+                        return true
+                    }
+                }
+
+                ReconnectState.RUNNING -> {
+                    if (reconnectState.compareAndSet(ReconnectState.RUNNING, ReconnectState.PENDING)) {
+                        return false
+                    }
+                }
+
+                ReconnectState.PENDING -> return false
+            }
+        }
+    }
+
+    private fun releaseReconnectOwnership(): Boolean {
+        while (true) {
+            when (reconnectState.get()) {
+                ReconnectState.RUNNING -> {
+                    if (reconnectState.compareAndSet(ReconnectState.RUNNING, ReconnectState.IDLE)) {
+                        return false
+                    }
+                }
+
+                ReconnectState.PENDING -> {
+                    if (reconnectState.compareAndSet(ReconnectState.PENDING, ReconnectState.IDLE)) {
+                        return true
+                    }
+                }
+
+                ReconnectState.IDLE -> return false
             }
         }
     }
@@ -486,7 +549,7 @@ class TCPClientInterface(
         log("Network changed - requesting reconnection")
 
         // If currently offline and not detached, trigger reconnection
-        if (!online.value && !detached.get() && !reconnecting.get()) {
+        if (!online.value && !detached.get() && reconnectState.get() == ReconnectState.IDLE) {
             ioScope.launch {
                 reconnect()
             }
@@ -502,7 +565,7 @@ class TCPClientInterface(
         closeSocket()
     }
 
-    private fun teardown() {
+    internal fun teardown() {
         if (DEBUG) {
             debugLog("Teardown called - transitioning to OFFLINE")
             debugLog("  frames sent: ${framesSent.get()}, frames received: ${framesReceived.get()}")

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
@@ -15,7 +15,6 @@ import network.reticulum.identity.Identity
 import network.reticulum.interfaces.IfacCredentials
 import network.reticulum.interfaces.IfacUtils
 import network.reticulum.interfaces.Interface
-import network.reticulum.interfaces.backoff.ExponentialBackoff
 import network.reticulum.interfaces.framing.HDLC
 import network.reticulum.interfaces.framing.KISS
 import java.io.IOException
@@ -41,6 +40,7 @@ class TCPClientInterface(
     private val targetPort: Int,
     private val useKissFraming: Boolean = false,
     private val connectTimeoutMs: Int = INITIAL_CONNECT_TIMEOUT,
+    // Python RECONNECT_MAX_TRIES parity: null retries indefinitely.
     private val maxReconnectAttempts: Int? = null,
     /** Enable TCP keep-alive. Default true for Python RNS compatibility (can disable for mobile battery). */
     private val keepAlive: Boolean = true,
@@ -69,7 +69,7 @@ class TCPClientInterface(
         const val DEFAULT_IFAC_SIZE = 16
         const val INITIAL_CONNECT_TIMEOUT = 5000 // 5 seconds
 
-        @Deprecated("Use ExponentialBackoff instead", level = DeprecationLevel.WARNING)
+        /** Fixed reconnect wait matching Python TCPClientInterface.RECONNECT_WAIT. */
         const val RECONNECT_WAIT_MS = 5000L // 5 seconds
 
         /** Enable verbose debug logging via -Dreticulum.tcp.debug=true */
@@ -132,11 +132,6 @@ class TCPClientInterface(
     // Debug counters
     private val framesSent = AtomicLong(0)
     private val framesReceived = AtomicLong(0)
-
-    // Exponential backoff for reconnection: 1s, 2s, 4s... up to 60s, give up after maxReconnectAttempts
-    private val backoff = ExponentialBackoff(
-        maxAttempts = maxReconnectAttempts ?: 10
-    )
 
     // Coroutine scope for I/O operations (battery-efficient on Android)
     private val ioScope: CoroutineScope = createScope(parentScope).also {
@@ -271,7 +266,7 @@ class TCPClientInterface(
         } catch (e: Exception) {
             if (initial) {
                 log("Initial connection failed: ${e.message}")
-                log("Will retry with exponential backoff (1s, 2s, 4s... up to 60s)")
+                log("Will retry connection in ${RECONNECT_WAIT_MS / 1000} seconds")
             }
             false
         }
@@ -280,19 +275,19 @@ class TCPClientInterface(
     private suspend fun reconnect() {
         if (reconnecting.getAndSet(true)) return
 
-        // Note: Do NOT reset backoff here - network change handler will reset when appropriate
-        // This allows progressive backoff across reconnect cycles
+        var attempts = 0
 
         while (!online.value && !detached.get()) {
-            val delayMs = backoff.nextDelay()
+            delay(RECONNECT_WAIT_MS)
+            attempts++
 
-            if (delayMs == null) {
-                log("Max reconnection attempts (${backoff.attemptCount}) reached, giving up")
+            // Python checks the configured limit after waiting and incrementing,
+            // before opening the next socket. A null limit retries indefinitely.
+            if (maxReconnectAttempts != null && attempts > maxReconnectAttempts) {
+                log("Max reconnection attempts reached, giving up")
                 detach()
                 break
             }
-
-            delay(delayMs)
 
             // Check if scope still active after delay
             if (!ioScope.isActive) break
@@ -300,16 +295,15 @@ class TCPClientInterface(
             try {
                 if (connect()) {
                     if (!neverConnected.get()) {
-                        log("Reconnected successfully after ${backoff.attemptCount} attempts")
+                        log("Reconnected successfully after $attempts attempts")
                     }
-                    backoff.reset() // Success - reset for next time
                     break
                 }
             } catch (e: CancellationException) {
                 // Scope was cancelled, stop reconnecting
                 break
             } catch (e: Exception) {
-                log("Reconnection attempt ${backoff.attemptCount} failed: ${e.message}")
+                log("Reconnection attempt $attempts failed: ${e.message}")
             }
         }
 
@@ -469,16 +463,14 @@ class TCPClientInterface(
     /**
      * Notify the interface that the network has changed.
      *
-     * This resets the reconnection backoff counter, allowing quick
-     * reconnection attempts on the new network. Call this when:
+     * This requests reconnection on the new network when the interface is
+     * offline and no reconnect owner is active. Call this when:
      * - WiFi <-> cellular handoff occurs
      * - Network becomes available after being offline
      *
-     * Per CONTEXT.md: "Network changes reset the backoff counter"
      */
     fun onNetworkChanged() {
-        log("Network changed - resetting reconnection backoff")
-        backoff.reset()
+        log("Network changed - requesting reconnection")
 
         // If currently offline and not detached, trigger reconnection
         if (!online.value && !detached.get() && !reconnecting.get()) {

--- a/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
+++ b/rns-interfaces/src/main/kotlin/network/reticulum/interfaces/tcp/TCPClientInterface.kt
@@ -158,6 +158,11 @@ class TCPClientInterface(
     private var readJob: Job? = null
     private var connectJob: Job? = null
 
+    private data class EstablishedConnection(
+        val socket: Socket,
+        val inputStream: InputStream,
+    )
+
     /**
      * Create the appropriate coroutine scope based on parent.
      * - With parent: child scope that cancels when parent cancels (Android service lifecycle)
@@ -198,13 +203,16 @@ class TCPClientInterface(
 
     override fun start() {
         connectJob = ioScope.launch {
-            if (!connect(initial = true)) {
+            val connection = connect(initial = true)
+            if (connection == null) {
                 reconnect()
+            } else {
+                startReadLoop(connection.socket, connection.inputStream)
             }
         }
     }
 
-    private fun connect(initial: Boolean = false): Boolean {
+    private fun connect(initial: Boolean = false): EstablishedConnection? {
         return try {
             if (initial) {
                 log("Establishing TCP connection to $targetHost:$targetPort...")
@@ -260,54 +268,59 @@ class TCPClientInterface(
             // 100ms gives time for the handler thread to start blocking on recv()
             Thread.sleep(100)
 
-            // Pass socket and stream directly to avoid race conditions
-            startReadLoop(sock, inputStream)
-            true
+            EstablishedConnection(sock, inputStream)
         } catch (e: Exception) {
             if (initial) {
                 log("Initial connection failed: ${e.message}")
                 log("Will retry connection in ${RECONNECT_WAIT_MS / 1000} seconds")
             }
-            false
+            null
         }
     }
 
     private suspend fun reconnect() {
-        if (reconnecting.getAndSet(true)) return
+        if (!reconnecting.compareAndSet(false, true)) return
 
+        var connection: EstablishedConnection? = null
         var attempts = 0
+        try {
+            while (!online.value && !detached.get()) {
+                delay(RECONNECT_WAIT_MS)
+                attempts++
 
-        while (!online.value && !detached.get()) {
-            delay(RECONNECT_WAIT_MS)
-            attempts++
+                // Python checks the configured limit after waiting and incrementing,
+                // before opening the next socket. A null limit retries indefinitely.
+                if (maxReconnectAttempts != null && attempts > maxReconnectAttempts) {
+                    log("Max reconnection attempts reached, giving up")
+                    detach()
+                    break
+                }
 
-            // Python checks the configured limit after waiting and incrementing,
-            // before opening the next socket. A null limit retries indefinitely.
-            if (maxReconnectAttempts != null && attempts > maxReconnectAttempts) {
-                log("Max reconnection attempts reached, giving up")
-                detach()
-                break
-            }
+                // Check if scope still active after delay
+                if (!ioScope.isActive) break
 
-            // Check if scope still active after delay
-            if (!ioScope.isActive) break
-
-            try {
-                if (connect()) {
+                connection = connect()
+                if (connection != null) {
                     if (!neverConnected.get()) {
                         log("Reconnected successfully after $attempts attempts")
                     }
                     break
                 }
-            } catch (e: CancellationException) {
-                // Scope was cancelled, stop reconnecting
-                break
-            } catch (e: Exception) {
-                log("Reconnection attempt $attempts failed: ${e.message}")
             }
+        } catch (_: CancellationException) {
+            // Scope was cancelled, stop reconnecting.
+        } finally {
+            // Python clears reconnect ownership before starting the replacement
+            // read loop. This ensures an immediately closed replacement socket
+            // can synchronously claim the next reconnect instead of being dropped.
+            reconnecting.set(false)
         }
 
-        reconnecting.set(false)
+        connection?.let { established ->
+            if (ioScope.isActive && online.value && !detached.get()) {
+                startReadLoop(established.socket, established.inputStream)
+            }
+        }
     }
 
     private fun startReadLoop(sock: Socket, inputStream: InputStream) {

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/ScopeInjectionTest.kt
@@ -294,8 +294,8 @@ class ScopeInjectionTest {
             targetHost = "127.0.0.1",
             targetPort = 15311,
             connectTimeoutMs = 100,
-            // Use high maxReconnectAttempts so interface keeps retrying during test window
-            // (with exponential backoff starting at 1s, 10 attempts gives >2 minutes of retries)
+            // Use high maxReconnectAttempts so the interface keeps retrying during the test window.
+            // Python-compatible reconnects wait a fixed five seconds between attempts.
             maxReconnectAttempts = 10,
             parentScope = parentScope
         )
@@ -311,7 +311,7 @@ class ScopeInjectionTest {
         assertTrue(parentScope.isActive, "Parent scope should still be active")
         assertFalse(tcp.detached.get(), "Interface should NOT be detached while parent is active")
 
-        // Wait longer - still should not auto-detach (within backoff window)
+        // Wait longer - still should not auto-detach during the reconnect wait
         delay(500)
         assertFalse(tcp.detached.get(), "Interface should STILL not be detached after 800ms")
     }

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/tcp/TCPClientInterfaceBackoffTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/tcp/TCPClientInterfaceBackoffTest.kt
@@ -10,14 +10,14 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Timeout
+import java.net.ServerSocket
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 /**
- * Tests for TCPClientInterface backoff integration.
- *
- * These tests verify that ExponentialBackoff is properly integrated
- * into TCPClientInterface. The core backoff logic is tested in
- * ExponentialBackoffTest - these tests focus on the integration.
+ * Tests for TCPClientInterface reconnect behavior.
  */
 class TCPClientInterfaceBackoffTest {
 
@@ -54,6 +54,44 @@ class TCPClientInterfaceBackoffTest {
         assertNotNull(iface1)
         assertNotNull(iface5)
         assertNotNull(ifaceDefault)
+    }
+
+    @Test
+    @Timeout(18, unit = TimeUnit.SECONDS)
+    fun `short lived connections retain Python fixed five second reconnect wait`() {
+        ServerSocket(0).use { server ->
+            val acceptedAt = CopyOnWriteArrayList<Long>()
+            val accepted = CountDownLatch(3)
+            val serverThread = thread(start = true, isDaemon = true) {
+                repeat(3) {
+                    server.accept().use { socket ->
+                        acceptedAt += System.nanoTime()
+                        accepted.countDown()
+                        socket.setSoLinger(true, 0)
+                    }
+                }
+            }
+
+            val iface = TCPClientInterface(
+                name = "PythonReconnectCadence",
+                targetHost = "127.0.0.1",
+                targetPort = server.localPort,
+                connectTimeoutMs = 250,
+            )
+            interfaces.add(iface)
+
+            iface.start()
+            assertTrue(accepted.await(15, TimeUnit.SECONDS), "Expected initial and two reconnect attempts")
+
+            val intervalsMs = acceptedAt.zipWithNext { first, second ->
+                TimeUnit.NANOSECONDS.toMillis(second - first)
+            }
+            assertTrue(
+                intervalsMs.all { it in 4_500..8_000 },
+                "Python parity requires fixed five-second reconnect waits, observed $intervalsMs",
+            )
+            serverThread.join(1_000)
+        }
     }
 
     @Test

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/tcp/TCPClientInterfaceBackoffTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/tcp/TCPClientInterfaceBackoffTest.kt
@@ -3,9 +3,10 @@ package network.reticulum.interfaces.tcp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
@@ -92,6 +93,31 @@ class TCPClientInterfaceBackoffTest {
             )
             serverThread.join(1_000)
         }
+    }
+
+    @Test
+    @Timeout(8, unit = TimeUnit.SECONDS)
+    fun `configured retry limit is checked after Python fixed wait`() = runBlocking {
+        val unavailablePort = ServerSocket(0).use { it.localPort }
+        val iface = TCPClientInterface(
+            name = "PythonReconnectLimit",
+            targetHost = "127.0.0.1",
+            targetPort = unavailablePort,
+            connectTimeoutMs = 250,
+            maxReconnectAttempts = 0,
+        )
+        interfaces.add(iface)
+
+        iface.start()
+        delay(1_000)
+        assertFalse(iface.detached.get(), "Python waits five seconds before checking the retry limit")
+
+        withTimeout(5_500) {
+            while (!iface.detached.get()) {
+                delay(25)
+            }
+        }
+        assertTrue(iface.detached.get())
     }
 
     @Test

--- a/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/tcp/TCPClientInterfaceBackoffTest.kt
+++ b/rns-interfaces/src/test/kotlin/network/reticulum/interfaces/tcp/TCPClientInterfaceBackoffTest.kt
@@ -15,6 +15,7 @@ import java.net.ServerSocket
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 /**
@@ -79,6 +80,14 @@ class TCPClientInterfaceBackoffTest {
                 targetPort = server.localPort,
                 connectTimeoutMs = 250,
             )
+            val publishedConnections = AtomicInteger(0)
+            iface.onConnectionPublishedForTest = {
+                if (publishedConnections.incrementAndGet() == 2) {
+                    // Model an outgoing failure after the replacement socket is
+                    // published but before reconnect() installs its read loop.
+                    iface.teardown()
+                }
+            }
             interfaces.add(iface)
 
             iface.start()


### PR DESCRIPTION
## Summary

- replace TCP client exponential reconnect backoff with Reticulum Python's fixed five-second retry interval
- retry indefinitely by default while preserving Python's configured `max_reconnect_tries` boundary and CLI wiring
- clear reconnect ownership before starting the replacement read loop and use a single atomic ownership state machine so rapid disconnects or outgoing failures cannot strand the interface offline
- add regressions for short-lived connections, configured retry limits, and unlimited defaults

Addresses torlando-tech/columba#1094.

## Verification

- `./gradlew test --rerun-tasks`
  - 706 tests
  - 0 failures
  - 0 errors
  - 19 skipped
- repeated the short-lived connection regression three consecutive times
- compiled Columba's `:rns-backend-kt:compileDebugKotlin` against the local reticulum-kt checkout
- independent exact-SHA review approved the reconnect implementation with no findings

## Risk and rollback

The behavioral change intentionally replaces bounded exponential retry timing with Python-compatible fixed-delay retries and makes the default retry budget unlimited. Explicit `max_reconnect_tries` configurations remain bounded. Rollback is a revert of this PR.

## Known unrelated repository checks

`gradlew check` remains blocked by existing Android `MissingPermission` lint findings outside this diff. The complete unit and interop test task above passes.
