### PR TITLE
ci: pin audited conformance references

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   conformance:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The audited conformance suite runs serially because its real-time link,
+    # watchdog and resource tests can flake when JVM peers are CPU-starved by
+    # pytest-xdist. One serial implementation pass needs more than 30 minutes.
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -24,11 +27,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: markqvist/Reticulum
+          ref: "1.3.1"
           path: Reticulum
 
       - uses: actions/checkout@v4
         with:
           repository: markqvist/LXMF
+          ref: "0.9.9"
           path: LXMF
 
       - name: Set up JDK 21
@@ -89,7 +94,7 @@ jobs:
         # LXMF-kt. It rides the same bridge but has its own CI target
         # (to be added in a follow-up PR on LXMF-kt); ignoring it here
         # keeps reticulum-kt CI focused on RNS-layer parity.
-        run: python3 -m pytest tests/ --ignore=tests/lxmf --impl=kotlin -n auto -v --tb=short
+        run: python3 -m pytest tests/ --ignore=tests/lxmf --impl=kotlin -v --tb=short
 
       - name: Run pipe integration conformance tests
         working-directory: reticulum-conformance


### PR DESCRIPTION
## Summary

- pin Python Reticulum to the conformance suite's audited `1.3.1` reference
- pin Python LXMF to the suite's audited `0.9.9` companion release
- restore serial pytest execution to avoid documented JVM/timer flakes under xdist
- increase the job timeout from 30 to 60 minutes for the serial implementation pass

## Why

The conformance suite explicitly certifies RNS 1.3.1 behavior, but the consumer workflow floated Reticulum and LXMF from their default branches. The latest run therefore combined an RNS 1.3.1 oracle with RNS 1.4.2/LXMF 1.1.0 and produced reference-to-reference failures for behavior intentionally changed after 1.3.1.

The suite's authoritative workflow also documents that full-suite xdist execution can starve JVM bridge peers and cause real-time link/watchdog/resource assertions to flake. The two extra stale-link failures appeared only under the complete parallel run and passed serially.

## Verification

- workflow YAML parsed successfully
- `git diff --check` passed
- exact merged Kotlin head with audited RNS 1.3.1 reference: `1235 passed, 12 skipped, 66 xfailed, 4 xpassed`
- pipe integration: `1 passed`
- focused failure matrix changed from `16 failed, 54 passed, 6 xfailed` on RNS 1.4.2 to `70 passed, 6 xfailed` on RNS 1.3.1

## Risk and rollback

This intentionally limits the CI claim to the conformance suite's documented RNS 1.3.1/LXMF 0.9.9 matrix. RNS 1.4.2 parity remains separate follow-up work. Rollback is reverting this workflow-only commit.
