### PR TITLE
fix(resource): apply receive limits before requesting parts

### DIFF
--- a/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/link/Link.kt
@@ -2366,15 +2366,6 @@ class Link private constructor(
                         )
                     if (resource != null) {
                         registerIncomingResource(resource)
-                        callbacks.resourceStarted?.let { callback ->
-                            thread(isDaemon = true) {
-                                try {
-                                    callback(resource)
-                                } catch (e: Exception) {
-                                    log("Error in resource started callback: ${e.message}")
-                                }
-                            }
-                        }
                     }
                 }
                 ACCEPT_APP -> {
@@ -2397,15 +2388,6 @@ class Link private constructor(
                                     )
                                 if (resource != null) {
                                     registerIncomingResource(resource)
-                                    callbacks.resourceStarted?.let { startCallback ->
-                                        thread(isDaemon = true) {
-                                            try {
-                                                startCallback(resource)
-                                            } catch (e: Exception) {
-                                                log("Error in resource started callback: ${e.message}")
-                                            }
-                                        }
-                                    }
                                 }
                             } else {
                                 log("Rejecting resource ${advertisement.hash.toHexString()} (strategy: ACCEPT_APP, callback returned false)")
@@ -2793,6 +2775,23 @@ class Link private constructor(
         synchronized(incomingResources) {
             incomingResources.any { it.hash.contentEquals(advertisementHash) }
         }
+
+    /**
+     * Invoke the inbound Resource start callback synchronously.
+     *
+     * Python calls this callback inside `Resource.accept`, after registration
+     * and before requesting the first parts. Keep the same ordering so callback
+     * configuration is guaranteed to apply before any payload can assemble.
+     */
+    internal fun resourceStarted(resource: network.reticulum.resource.Resource) {
+        callbacks.resourceStarted?.let { callback ->
+            try {
+                callback(resource)
+            } catch (e: Exception) {
+                log("Error in resource started callback: ${e.message}")
+            }
+        }
+    }
 
     /**
      * Test-only: snapshot of the current incoming resource hashes.

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -1747,6 +1747,7 @@ class Resource private constructor(
     fun requestNextEmitCountForTest(): Int = requestNextEmitCount.get()
     fun hmuRequestsSentForTest(): Int = hmuRequestsSent.get()
     fun hashmapUpdatesReceivedForTest(): Int = hashmapUpdatesReceived.get()
+    fun watchdogActiveForTest(): Boolean = watchdogActive
 
     /** Drive the private assemble(). */
     fun assembleForTest() = assemble()

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -172,6 +172,14 @@ class Resource private constructor(
                 progressCallback?.let { resource.callbacks.progress = it }
 
                 resource.initializeFromAdvertisement(advertisement)
+                // Python invokes resource_started synchronously after the
+                // inbound Resource is registered and before hashmap_update()
+                // requests the first parts (Resource.py:223-234). This ordering
+                // is load-bearing: applications use the callback to configure
+                // per-transfer limits such as max_decompressed_size. Deferring
+                // it lets a small compressed Resource arrive and assemble with
+                // the default limit before the callback applies its bound.
+                link.resourceStarted(resource)
                 resource.requestNext()
 
                 resource

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -335,6 +335,7 @@ class Resource private constructor(
     // Watchdog
     private var watchdogThread: Thread? = null
     @Volatile private var watchdogActive = false
+    @Volatile private var cancelTransitionHookForTest: (() -> Unit)? = null
 
     // SDU for this resource — uses plain packet MDU (not link MDU) because
     // resource parts are already bulk-encrypted before splitting, and are sent
@@ -1462,6 +1463,7 @@ class Resource private constructor(
                 // thread could otherwise install a fresh watchdog on a canceled
                 // Resource.
                 status = ResourceConstants.FAILED
+                cancelTransitionHookForTest?.invoke()
                 stopWatchdog()
                 true
             }
@@ -1777,6 +1779,9 @@ class Resource private constructor(
     fun hashmapUpdatesReceivedForTest(): Int = hashmapUpdatesReceived.get()
     fun watchdogActiveForTest(): Boolean = watchdogActive
     fun startWatchdogForTest() = startWatchdog()
+    fun setCancelTransitionHookForTest(hook: (() -> Unit)?) {
+        cancelTransitionHookForTest = hook
+    }
 
     /** Drive the private assemble(). */
     fun assembleForTest() = assemble()

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -1607,6 +1607,7 @@ class Resource private constructor(
     /**
      * Start watchdog thread for timeout detection.
      */
+    @Synchronized
     private fun startWatchdog() {
         // Test-only suppression (see companion watchdogDisabledForTest): the
         // reference harness disables the watchdog around _build_resource_receiver
@@ -1614,11 +1615,18 @@ class Resource private constructor(
         // timeout-retry cancelling it.
         if (watchdogDisabledForTest) return
         if (watchdogActive) return
+        if (status >= ResourceConstants.ASSEMBLING) return
 
         watchdogActive = true
-        watchdogThread = thread(name = "resource-watchdog-${hash.toHexString().take(8)}") {
+        val newThread = thread(
+            start = false,
+            isDaemon = true,
+            name = "resource-watchdog-${hash.toHexString().take(8)}",
+        ) {
             watchdogJob()
         }
+        watchdogThread = newThread
+        newThread.start()
     }
 
     /**
@@ -1635,6 +1643,7 @@ class Resource private constructor(
      * rather than thread interruption (Resource.py:560-670), so the
      * equivalent self-targeting issue doesn't exist there.
      */
+    @Synchronized
     private fun stopWatchdog() {
         watchdogActive = false
         val thread = watchdogThread
@@ -1648,47 +1657,56 @@ class Resource private constructor(
      * Watchdog job for timeout handling.
      */
     private fun watchdogJob() {
-        while (watchdogActive) {
-            try {
-                Thread.sleep(ResourceConstants.WATCHDOG_MAX_SLEEP * 1000)
+        try {
+            while (watchdogActive && status < ResourceConstants.ASSEMBLING) {
+                try {
+                    Thread.sleep(ResourceConstants.WATCHDOG_MAX_SLEEP * 1000)
 
-                if (!watchdogActive) break
+                    if (!watchdogActive || status >= ResourceConstants.ASSEMBLING) break
 
-                val now = System.currentTimeMillis()
-                val idleTime = now - lastActivity
+                    val now = System.currentTimeMillis()
+                    val idleTime = now - lastActivity
 
-                // Check for timeout
-                val timeout = (link.rtt ?: 5000L) * ResourceConstants.PART_TIMEOUT_FACTOR
-                if (idleTime > timeout) {
-                    retries++
-                    if (retries > ResourceConstants.MAX_RETRIES) {
-                        // Mirrors python `Resource.py:578, 591, 628, 636, 648,
-                        // 667, 690` etc. — every retries-exhausted branch in
-                        // python's watchdog calls `self.cancel()`. Calling
-                        // cancel() (rather than the previous inline
-                        // `status = FAILED; callbacks.failed?.invoke`) ensures
-                        // `link.resourceConcluded(this)` runs, which removes
-                        // the resource from `incomingResources` so a future
-                        // RESOURCE_ADV with the same hash is no longer
-                        // dropped by the dedup guard inside
-                        // `Resource.accept`. Without this, a single
-                        // watchdog-fail leaves the hash registered for the
-                        // lifetime of the link, killing the recovery path.
-                        log("Resource ${hash.toHexString()} timed out after $retries retries")
-                        cancel()
-                        break
-                    } else {
-                        log("Resource timeout, retry $retries/${ResourceConstants.MAX_RETRIES}")
-                        if (!initiator) {
-                            requestNext()
+                    // Check for timeout
+                    val timeout = (link.rtt ?: 5000L) * ResourceConstants.PART_TIMEOUT_FACTOR
+                    if (idleTime > timeout) {
+                        retries++
+                        if (retries > ResourceConstants.MAX_RETRIES) {
+                            // Mirrors python `Resource.py:578, 591, 628, 636, 648,
+                            // 667, 690` etc. — every retries-exhausted branch in
+                            // python's watchdog calls `self.cancel()`. Calling
+                            // cancel() (rather than the previous inline
+                            // `status = FAILED; callbacks.failed?.invoke`) ensures
+                            // `link.resourceConcluded(this)` runs, which removes
+                            // the resource from `incomingResources` so a future
+                            // RESOURCE_ADV with the same hash is no longer
+                            // dropped by the dedup guard inside
+                            // `Resource.accept`. Without this, a single
+                            // watchdog-fail leaves the hash registered for the
+                            // lifetime of the link, killing the recovery path.
+                            log("Resource ${hash.toHexString()} timed out after $retries retries")
+                            cancel()
+                            break
+                        } else {
+                            log("Resource timeout, retry $retries/${ResourceConstants.MAX_RETRIES}")
+                            if (!initiator) {
+                                requestNext()
+                            }
                         }
                     }
-                }
 
-            } catch (e: InterruptedException) {
-                break
-            } catch (e: Exception) {
-                log("Watchdog error: ${e.message}")
+                } catch (e: InterruptedException) {
+                    break
+                } catch (e: Exception) {
+                    log("Watchdog error: ${e.message}")
+                }
+            }
+        } finally {
+            synchronized(this) {
+                if (watchdogThread === Thread.currentThread()) {
+                    watchdogActive = false
+                    watchdogThread = null
+                }
             }
         }
     }

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -181,6 +181,11 @@ class Resource private constructor(
                 // the default limit before the callback applies its bound.
                 link.resourceStarted(resource)
                 resource.requestNext()
+                // Python starts the watchdog only after resource_started and
+                // the initial hashmap request (Resource.py:223-234). Starting
+                // it during initialization allows a watchdog retry to bypass a
+                // slow callback and request parts before configuration finishes.
+                resource.startWatchdog()
 
                 resource
             } catch (e: Exception) {
@@ -532,7 +537,6 @@ class Resource private constructor(
         // Register with link
         link.registerIncomingResource(this)
 
-        startWatchdog()
         log("Resource ${hash.toHexString()} accepted: $size bytes in ${parts.size} parts")
     }
 

--- a/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
+++ b/rns-core/src/main/kotlin/network/reticulum/resource/Resource.kt
@@ -1452,11 +1452,21 @@ class Resource private constructor(
         // Necessary now that cancel() fires `callbacks.failed?.invoke`:
         // without this guard, a double-cancel from application code +
         // watchdog timeout would deliver the failed callback twice.
-        if (status >= ResourceConstants.COMPLETE) {
-            return
+        val transitionedToFailed = synchronized(this) {
+            if (status >= ResourceConstants.COMPLETE) {
+                false
+            } else {
+                // Publish the terminal status while holding the same monitor used
+                // by startWatchdog(). Python likewise sets FAILED before stopping
+                // its watchdog. This closes the stop-then-status gap where another
+                // thread could otherwise install a fresh watchdog on a canceled
+                // Resource.
+                status = ResourceConstants.FAILED
+                stopWatchdog()
+                true
+            }
         }
-        stopWatchdog()
-        status = ResourceConstants.FAILED
+        if (!transitionedToFailed) return
         // python Resource.py:1087-1094 — when the INITIATOR cancels a still-ACTIVE
         // transfer it sends a RESOURCE_ICL packet carrying the resource hash so the
         // receiver tears its inbound resource down too. Without this the receiver's
@@ -1766,6 +1776,7 @@ class Resource private constructor(
     fun hmuRequestsSentForTest(): Int = hmuRequestsSent.get()
     fun hashmapUpdatesReceivedForTest(): Int = hashmapUpdatesReceived.get()
     fun watchdogActiveForTest(): Boolean = watchdogActive
+    fun startWatchdogForTest() = startWatchdog()
 
     /** Drive the private assemble(). */
     fun assembleForTest() = assemble()

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -14,6 +14,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.msgpack.core.MessagePack
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -160,13 +164,18 @@ class LinkResourceDedupTest {
     @Timeout(5)
     fun `Resource accept invokes resource started before requesting parts`() {
         val link = freshLink()
+        link.setRttForTest(1)
         val advHash = ByteArray(16) { 0xAC.toByte() }
         val adv = ResourceAdvertisement.unpack(buildAdvertisementBytes(hash = advHash))
         assertNotNull(adv, "Test sanity: advertisement should unpack")
 
         var callbackCount = 0
+        val callbackEntered = CountDownLatch(1)
+        val releaseCallback = CountDownLatch(1)
+        val callbackResource = AtomicReference<Resource>()
         link.setResourceStartedCallback { resourceObj ->
             val resource = resourceObj as Resource
+            callbackResource.set(resource)
             callbackCount++
             assertTrue(
                 link.hasIncomingResource(resource.hash),
@@ -177,22 +186,53 @@ class LinkResourceDedupTest {
                 resource.requestNextEmitCountForTest(),
                 "No part request may be emitted before resource-started returns",
             )
+            callbackEntered.countDown()
+            assertTrue(
+                releaseCallback.await(3, TimeUnit.SECONDS),
+                "Test must release the blocked resource-started callback",
+            )
         }
 
         // Resource.accept must invoke the callback after registration and before
-        // requestNext(). This is where callers configure per-transfer limits.
-        val accepted = Resource.accept(advertisement = adv, link = link)
+        // both requestNext() and watchdog startup. A 1 ms RTT makes an incorrectly
+        // early watchdog retry on its first one-second tick while the callback is
+        // blocked, deterministically reproducing the CI race.
+        var accepted: Resource? = null
+        val acceptThread = thread(start = true, isDaemon = true) {
+            accepted = Resource.accept(advertisement = adv, link = link)
+        }
 
-        assertNotNull(accepted, "Synthetic advertisement should be accepted")
         assertTrue(
-            accepted.requestNextEmitCountForTest() > 0,
-            "Resource.accept should request parts only after resource-started returns",
+            callbackEntered.await(2, TimeUnit.SECONDS),
+            "resource-started callback should run during Resource.accept",
         )
-        assertEquals(
-            1,
-            callbackCount,
-            "resource-started must run synchronously before the first part request",
-        )
+        try {
+            Thread.sleep(1_200)
+            assertEquals(
+                0,
+                callbackResource.get().requestNextEmitCountForTest(),
+                "Neither initial nor watchdog part requests may run while resource-started is blocked",
+            )
+        } finally {
+            releaseCallback.countDown()
+            acceptThread.join(2_000)
+        }
+
+        assertFalse(acceptThread.isAlive, "Resource.accept should finish after callback release")
+        val acceptedResource = assertNotNull(accepted, "Synthetic advertisement should be accepted")
+        try {
+            assertTrue(
+                acceptedResource.requestNextEmitCountForTest() > 0,
+                "Resource.accept should request parts only after resource-started returns",
+            )
+            assertEquals(
+                1,
+                callbackCount,
+                "resource-started must run synchronously before the first part request",
+            )
+        } finally {
+            acceptedResource.cancel()
+        }
     }
 
     @Test

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.msgpack.core.MessagePack
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -234,10 +237,53 @@ class LinkResourceDedupTest {
         assertEquals(1, callbackCount, "resource-started must run exactly once")
         assertEquals(ResourceConstants.FAILED, accepted.status, "Callback cancellation must remain terminal")
         assertFalse(accepted.watchdogActiveForTest(), "A terminal Resource must not restart its watchdog")
+        accepted.startWatchdogForTest()
+        assertFalse(accepted.watchdogActiveForTest(), "Explicit restart must reject a terminal Resource")
         assertFalse(
             link.hasIncomingResource(advHash),
             "Callback cancellation must remove the Resource from inbound tracking",
         )
+    }
+
+    @Test
+    @DisplayName("Concurrent cancel and watchdog start leave Resource terminal and stopped")
+    @Timeout(5)
+    fun `Concurrent cancel and watchdog start leave Resource terminal and stopped`() {
+        val link = freshLink()
+        val advHash = ByteArray(16) { 0xAE.toByte() }
+        val adv = ResourceAdvertisement.unpack(buildAdvertisementBytes(hash = advHash))
+        assertNotNull(adv, "Test sanity: advertisement should unpack")
+        link.setResourceStartedCallback { }
+
+        val accepted = assertNotNull(Resource.accept(advertisement = adv, link = link))
+        assertTrue(accepted.watchdogActiveForTest(), "Test requires an initially active watchdog")
+
+        val ready = CountDownLatch(2)
+        val start = CountDownLatch(1)
+        val finished = CountDownLatch(2)
+        val cancelThread = thread(start = true, isDaemon = true) {
+            ready.countDown()
+            start.await()
+            accepted.cancel()
+            finished.countDown()
+        }
+        val restartThread = thread(start = true, isDaemon = true) {
+            ready.countDown()
+            start.await()
+            accepted.startWatchdogForTest()
+            finished.countDown()
+        }
+
+        assertTrue(ready.await(1, TimeUnit.SECONDS), "Both lifecycle operations must be ready")
+        start.countDown()
+        assertTrue(finished.await(2, TimeUnit.SECONDS), "Both lifecycle operations must finish")
+        cancelThread.join()
+        restartThread.join()
+
+        assertEquals(ResourceConstants.FAILED, accepted.status)
+        assertFalse(accepted.watchdogActiveForTest(), "Atomic terminal transition must win either ordering")
+        accepted.startWatchdogForTest()
+        assertFalse(accepted.watchdogActiveForTest(), "Terminal Resource must reject later watchdog starts")
     }
 
     @Test

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -6,6 +6,7 @@ import network.reticulum.destination.Destination
 import network.reticulum.identity.Identity
 import network.reticulum.resource.Resource
 import network.reticulum.resource.ResourceAdvertisement
+import network.reticulum.resource.ResourceConstants
 import network.reticulum.transport.Transport
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -208,6 +209,35 @@ class LinkResourceDedupTest {
         } finally {
             acceptedResource.cancel()
         }
+    }
+
+    @Test
+    @DisplayName("Resource.accept does not restart watchdog after resource-started cancels")
+    @Timeout(5)
+    fun `Resource accept does not restart watchdog after resource started cancels`() {
+        val link = freshLink()
+        val advHash = ByteArray(16) { 0xAD.toByte() }
+        val adv = ResourceAdvertisement.unpack(buildAdvertisementBytes(hash = advHash))
+        assertNotNull(adv, "Test sanity: advertisement should unpack")
+
+        var callbackCount = 0
+        link.setResourceStartedCallback { resourceObj ->
+            callbackCount++
+            (resourceObj as Resource).cancel()
+        }
+
+        val accepted = assertNotNull(
+            Resource.accept(advertisement = adv, link = link),
+            "Callback cancellation should conclude, not invalidate, the accepted Resource",
+        )
+
+        assertEquals(1, callbackCount, "resource-started must run exactly once")
+        assertEquals(ResourceConstants.FAILED, accepted.status, "Callback cancellation must remain terminal")
+        assertFalse(accepted.watchdogActiveForTest(), "A terminal Resource must not restart its watchdog")
+        assertFalse(
+            link.hasIncomingResource(advHash),
+            "Callback cancellation must remove the Resource from inbound tracking",
+        )
     }
 
     @Test

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -14,10 +14,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.msgpack.core.MessagePack
 import java.io.ByteArrayOutputStream
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -164,18 +160,13 @@ class LinkResourceDedupTest {
     @Timeout(5)
     fun `Resource accept invokes resource started before requesting parts`() {
         val link = freshLink()
-        link.setRttForTest(1)
         val advHash = ByteArray(16) { 0xAC.toByte() }
         val adv = ResourceAdvertisement.unpack(buildAdvertisementBytes(hash = advHash))
         assertNotNull(adv, "Test sanity: advertisement should unpack")
 
         var callbackCount = 0
-        val callbackEntered = CountDownLatch(1)
-        val releaseCallback = CountDownLatch(1)
-        val callbackResource = AtomicReference<Resource>()
         link.setResourceStartedCallback { resourceObj ->
             val resource = resourceObj as Resource
-            callbackResource.set(resource)
             callbackCount++
             assertTrue(
                 link.hasIncomingResource(resource.hash),
@@ -186,44 +177,28 @@ class LinkResourceDedupTest {
                 resource.requestNextEmitCountForTest(),
                 "No part request may be emitted before resource-started returns",
             )
-            callbackEntered.countDown()
-            assertTrue(
-                releaseCallback.await(3, TimeUnit.SECONDS),
-                "Test must release the blocked resource-started callback",
+            assertFalse(
+                resource.watchdogActiveForTest(),
+                "Watchdog must not start before resource-started returns",
             )
         }
 
         // Resource.accept must invoke the callback after registration and before
-        // both requestNext() and watchdog startup. A 1 ms RTT makes an incorrectly
-        // early watchdog retry on its first one-second tick while the callback is
-        // blocked, deterministically reproducing the CI race.
-        var accepted: Resource? = null
-        val acceptThread = thread(start = true, isDaemon = true) {
-            accepted = Resource.accept(advertisement = adv, link = link)
-        }
-
-        assertTrue(
-            callbackEntered.await(2, TimeUnit.SECONDS),
-            "resource-started callback should run during Resource.accept",
+        // both requestNext() and watchdog startup. The callback's direct state
+        // assertions make the race regression deterministic without wall-clock
+        // sleeps or scheduler assumptions.
+        val acceptedResource = assertNotNull(
+            Resource.accept(advertisement = adv, link = link),
+            "Synthetic advertisement should be accepted",
         )
-        try {
-            Thread.sleep(1_200)
-            assertEquals(
-                0,
-                callbackResource.get().requestNextEmitCountForTest(),
-                "Neither initial nor watchdog part requests may run while resource-started is blocked",
-            )
-        } finally {
-            releaseCallback.countDown()
-            acceptThread.join(2_000)
-        }
-
-        assertFalse(acceptThread.isAlive, "Resource.accept should finish after callback release")
-        val acceptedResource = assertNotNull(accepted, "Synthetic advertisement should be accepted")
         try {
             assertTrue(
                 acceptedResource.requestNextEmitCountForTest() > 0,
                 "Resource.accept should request parts only after resource-started returns",
+            )
+            assertTrue(
+                acceptedResource.watchdogActiveForTest(),
+                "Resource.accept should start the watchdog after the initial part request",
             )
             assertEquals(
                 1,

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -258,32 +258,43 @@ class LinkResourceDedupTest {
         val accepted = assertNotNull(Resource.accept(advertisement = adv, link = link))
         assertTrue(accepted.watchdogActiveForTest(), "Test requires an initially active watchdog")
 
-        val ready = CountDownLatch(2)
-        val start = CountDownLatch(1)
-        val finished = CountDownLatch(2)
-        val cancelThread = thread(start = true, isDaemon = true) {
-            ready.countDown()
-            start.await()
-            accepted.cancel()
-            finished.countDown()
-        }
-        val restartThread = thread(start = true, isDaemon = true) {
-            ready.countDown()
-            start.await()
-            accepted.startWatchdogForTest()
-            finished.countDown()
+        val terminalPublished = CountDownLatch(1)
+        val releaseCancel = CountDownLatch(1)
+        accepted.setCancelTransitionHookForTest {
+            terminalPublished.countDown()
+            assertTrue(releaseCancel.await(2, TimeUnit.SECONDS), "Test must release cancellation")
         }
 
-        assertTrue(ready.await(1, TimeUnit.SECONDS), "Both lifecycle operations must be ready")
-        start.countDown()
-        assertTrue(finished.await(2, TimeUnit.SECONDS), "Both lifecycle operations must finish")
-        cancelThread.join()
-        restartThread.join()
-
+        val cancelThread = thread(start = true, isDaemon = true) { accepted.cancel() }
+        assertTrue(
+            terminalPublished.await(1, TimeUnit.SECONDS),
+            "Cancellation must publish FAILED while holding the watchdog monitor",
+        )
         assertEquals(ResourceConstants.FAILED, accepted.status)
-        assertFalse(accepted.watchdogActiveForTest(), "Atomic terminal transition must win either ordering")
-        accepted.startWatchdogForTest()
-        assertFalse(accepted.watchdogActiveForTest(), "Terminal Resource must reject later watchdog starts")
+
+        val restartThread = thread(start = true, isDaemon = true) { accepted.startWatchdogForTest() }
+        val blockedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1)
+        while (restartThread.state != Thread.State.BLOCKED && restartThread.isAlive && System.nanoTime() < blockedDeadline) {
+            Thread.onSpinWait()
+        }
+
+        try {
+            assertEquals(
+                Thread.State.BLOCKED,
+                restartThread.state,
+                "Watchdog start must block on the atomic cancellation monitor",
+            )
+        } finally {
+            releaseCancel.countDown()
+            cancelThread.join(2_000)
+            restartThread.join(2_000)
+            accepted.setCancelTransitionHookForTest(null)
+        }
+
+        assertFalse(cancelThread.isAlive, "Cancellation must finish after test release")
+        assertFalse(restartThread.isAlive, "Watchdog restart must finish after cancellation")
+        assertEquals(ResourceConstants.FAILED, accepted.status)
+        assertFalse(accepted.watchdogActiveForTest(), "Atomic terminal transition must reject the waiting restart")
     }
 
     @Test

--- a/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
+++ b/rns-test/src/test/kotlin/network/reticulum/link/LinkResourceDedupTest.kt
@@ -156,6 +156,46 @@ class LinkResourceDedupTest {
     }
 
     @Test
+    @DisplayName("Resource.accept invokes resource-started synchronously before requesting parts")
+    @Timeout(5)
+    fun `Resource accept invokes resource started before requesting parts`() {
+        val link = freshLink()
+        val advHash = ByteArray(16) { 0xAC.toByte() }
+        val adv = ResourceAdvertisement.unpack(buildAdvertisementBytes(hash = advHash))
+        assertNotNull(adv, "Test sanity: advertisement should unpack")
+
+        var callbackCount = 0
+        link.setResourceStartedCallback { resourceObj ->
+            val resource = resourceObj as Resource
+            callbackCount++
+            assertTrue(
+                link.hasIncomingResource(resource.hash),
+                "The Resource must be registered before resource-started runs",
+            )
+            assertEquals(
+                0,
+                resource.requestNextEmitCountForTest(),
+                "No part request may be emitted before resource-started returns",
+            )
+        }
+
+        // Resource.accept must invoke the callback after registration and before
+        // requestNext(). This is where callers configure per-transfer limits.
+        val accepted = Resource.accept(advertisement = adv, link = link)
+
+        assertNotNull(accepted, "Synthetic advertisement should be accepted")
+        assertTrue(
+            accepted.requestNextEmitCountForTest() > 0,
+            "Resource.accept should request parts only after resource-started returns",
+        )
+        assertEquals(
+            1,
+            callbackCount,
+            "resource-started must run synchronously before the first part request",
+        )
+    }
+
+    @Test
     @DisplayName("Resource.accept returns null on duplicate-hash advertisement (covers all 4 call sites)")
     @Timeout(5)
     fun `Resource accept returns null on duplicate-hash advertisement`() {


### PR DESCRIPTION
## Summary

- invoke the inbound resource-started callback synchronously after registration and before requesting parts
- start the receiver watchdog only after callback configuration and the initial request
- prevent terminal resources from restarting watchdogs and make cancellation/watchdog transitions atomic
- add deterministic callback, watchdog, cancellation, and forced-interleaving regressions

This fixes the timing race exposed by the decompression-bomb conformance case after PR #82 was merged. The ordering matches Python Reticulum 1.3.1.

## Verification

- `./gradlew :rns-test:test --tests network.reticulum.link.LinkResourceDedupTest --rerun-tasks`
- forced cancel/watchdog interleaving regression: 10/10 repetitions
- `./gradlew test --rerun-tasks` with Reticulum 1.3.1 and LXMF 0.9.9
- exact four-arm bz2 decompression-bomb conformance case: 1 passed, 3 documented xfails
- `git diff --check`
- independent exact-head convergence review: approved
