### PR TITLE
fix(android): guard RoomIdentityStore writes against transient SQLite locks

### DIFF
--- a/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/ReticulumService.kt
@@ -68,6 +68,13 @@ class ReticulumService : LifecycleService() {
     private var database: network.reticulum.android.db.ReticulumDatabase? = null
     private var dbWriteExecutor: java.util.concurrent.ExecutorService? = null
 
+    // The RoomIdentityStore instance backing Identity.identityStore. Kept as a
+    // concrete reference so its instance-owned durable-write state can be
+    // released ([dispose]) during teardown after the write executor is drained
+    // and before/with the database close — otherwise the retired store's
+    // executor, DAO-capturing lambdas, and RoomDatabase would stay retained.
+    private var identityStore: network.reticulum.android.db.store.RoomIdentityStore? = null
+
     // Pause/resume state tracking
     private var _isPaused = false
 
@@ -292,6 +299,14 @@ class ReticulumService : LifecycleService() {
         }
         dbWriteExecutor = null
 
+        // Release the durable-write state owned by the RoomIdentityStore
+        // (executor/DAO/database references) AFTER the write executor is drained
+        // and quiescent and BEFORE the database close. A replacement
+        // service/store/database must never observe or flush the retired
+        // instance's backlog.
+        identityStore?.dispose()
+        identityStore = null
+
         database?.close()
         database = null
 
@@ -353,8 +368,10 @@ class ReticulumService : LifecycleService() {
                 network.reticulum.android.db.store.RoomAnnounceStore(db.announceCacheDao(), executor)
             network.reticulum.transport.Transport.discoveryStore =
                 network.reticulum.android.db.store.RoomDiscoveryStore(db.discoveredInterfaceDao(), executor)
-            network.reticulum.identity.Identity.identityStore =
-                network.reticulum.android.db.store.RoomIdentityStore(db.knownDestinationDao(), db.identityRatchetDao(), executor)
+            identityStore = network.reticulum.android.db.store.RoomIdentityStore(
+                db.knownDestinationDao(), db.identityRatchetDao(), executor
+            )
+            network.reticulum.identity.Identity.identityStore = identityStore
             network.reticulum.transport.Transport.destinationRatchetStore =
                 network.reticulum.android.db.store.RoomDestinationRatchetStore(db.destinationRatchetDao(), executor)
 

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
@@ -26,7 +26,7 @@ class RoomIdentityStore(
             publicKey = data.publicKey.copyOf(),
             appData = data.appData?.copyOf()
         )
-        writeExecutor.execute { knownDestDao.upsert(entity) }
+        writeExecutor.submitWriteThrough("identity.upsertKnownDestination") { knownDestDao.upsert(entity) }
     }
 
     override fun getKnownDestination(destHash: ByteArray): IdentityData? {
@@ -60,7 +60,7 @@ class RoomIdentityStore(
             ratchet = ratchet.copyOf(),
             timestamp = timestampMs
         )
-        writeExecutor.execute { ratchetDao.upsert(entity) }
+        writeExecutor.submitWriteThrough("identity.upsertRatchet") { ratchetDao.upsert(entity) }
     }
 
     override fun getRatchet(destHash: ByteArray): Pair<ByteArray, Long>? {
@@ -70,6 +70,6 @@ class RoomIdentityStore(
 
     override fun removeExpiredRatchets(maxAgeMs: Long) {
         val threshold = System.currentTimeMillis() - maxAgeMs
-        writeExecutor.execute { ratchetDao.deleteExpiredBefore(threshold) }
+        writeExecutor.submitWriteThrough("identity.removeExpiredRatchets") { ratchetDao.deleteExpiredBefore(threshold) }
     }
 }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
@@ -16,6 +16,18 @@ class RoomIdentityStore(
     private val writeExecutor: ExecutorService
 ) : IdentityStore {
 
+    // Instance-owned pending durable-write state. Scoping this to the store —
+    // rather than a process-global registry keyed by executor — means a retired
+    // store's executor/DAO/database references are released with this store's
+    // lifecycle ([dispose]) and a replacement store never observes or flushes
+    // the retired instance's backlog.
+    private val durableState = DurableWriteState()
+
+    /** Release this store's pending durable-write state (executor/DAO/DB refs). */
+    fun dispose() {
+        durableState.dispose()
+    }
+
     // ===== Known Destinations =====
 
     override fun upsertKnownDestination(destHash: ByteArray, data: IdentityData) {
@@ -27,6 +39,7 @@ class RoomIdentityStore(
             appData = data.appData?.copyOf()
         )
         writeExecutor.submitWriteThroughDurable(
+            durableState,
             "identity.upsertKnownDestination",
             DurableRowKey("knownDest", destHash.toKey())
         ) { knownDestDao.upsert(entity) }
@@ -64,6 +77,7 @@ class RoomIdentityStore(
             timestamp = timestampMs
         )
         writeExecutor.submitWriteThroughDurable(
+            durableState,
             "identity.upsertRatchet",
             DurableRowKey("ratchet", destHash.toKey())
         ) { ratchetDao.upsert(entity) }
@@ -77,6 +91,7 @@ class RoomIdentityStore(
     override fun removeExpiredRatchets(maxAgeMs: Long) {
         val threshold = System.currentTimeMillis() - maxAgeMs
         writeExecutor.submitWriteThroughDurable(
+            durableState,
             "identity.removeExpiredRatchets",
             // Range delete with no per-row key; a fixed marker key keeps it out
             // of the row-key namespace so it never collides with an upsert, and

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
@@ -26,7 +26,10 @@ class RoomIdentityStore(
             publicKey = data.publicKey.copyOf(),
             appData = data.appData?.copyOf()
         )
-        writeExecutor.submitWriteThroughDurable("identity.upsertKnownDestination") { knownDestDao.upsert(entity) }
+        writeExecutor.submitWriteThroughDurable(
+            "identity.upsertKnownDestination",
+            DurableRowKey("knownDest", destHash.toKey())
+        ) { knownDestDao.upsert(entity) }
     }
 
     override fun getKnownDestination(destHash: ByteArray): IdentityData? {
@@ -60,7 +63,10 @@ class RoomIdentityStore(
             ratchet = ratchet.copyOf(),
             timestamp = timestampMs
         )
-        writeExecutor.submitWriteThroughDurable("identity.upsertRatchet") { ratchetDao.upsert(entity) }
+        writeExecutor.submitWriteThroughDurable(
+            "identity.upsertRatchet",
+            DurableRowKey("ratchet", destHash.toKey())
+        ) { ratchetDao.upsert(entity) }
     }
 
     override fun getRatchet(destHash: ByteArray): Pair<ByteArray, Long>? {
@@ -70,6 +76,12 @@ class RoomIdentityStore(
 
     override fun removeExpiredRatchets(maxAgeMs: Long) {
         val threshold = System.currentTimeMillis() - maxAgeMs
-        writeExecutor.submitWriteThroughDurable("identity.removeExpiredRatchets") { ratchetDao.deleteExpiredBefore(threshold) }
+        writeExecutor.submitWriteThroughDurable(
+            "identity.removeExpiredRatchets",
+            // Range delete with no per-row key; a fixed marker key keeps it out
+            // of the row-key namespace so it never collides with an upsert, and
+            // pending deletes coalesce (newest threshold wins, monotonic).
+            DurableRowKey("expiry-delete", ByteArrayKey(byteArrayOf()))
+        ) { ratchetDao.deleteExpiredBefore(threshold) }
     }
 }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/RoomIdentityStore.kt
@@ -26,7 +26,7 @@ class RoomIdentityStore(
             publicKey = data.publicKey.copyOf(),
             appData = data.appData?.copyOf()
         )
-        writeExecutor.submitWriteThrough("identity.upsertKnownDestination") { knownDestDao.upsert(entity) }
+        writeExecutor.submitWriteThroughDurable("identity.upsertKnownDestination") { knownDestDao.upsert(entity) }
     }
 
     override fun getKnownDestination(destHash: ByteArray): IdentityData? {
@@ -60,7 +60,7 @@ class RoomIdentityStore(
             ratchet = ratchet.copyOf(),
             timestamp = timestampMs
         )
-        writeExecutor.submitWriteThrough("identity.upsertRatchet") { ratchetDao.upsert(entity) }
+        writeExecutor.submitWriteThroughDurable("identity.upsertRatchet") { ratchetDao.upsert(entity) }
     }
 
     override fun getRatchet(destHash: ByteArray): Pair<ByteArray, Long>? {
@@ -70,6 +70,6 @@ class RoomIdentityStore(
 
     override fun removeExpiredRatchets(maxAgeMs: Long) {
         val threshold = System.currentTimeMillis() - maxAgeMs
-        writeExecutor.submitWriteThrough("identity.removeExpiredRatchets") { ratchetDao.deleteExpiredBefore(threshold) }
+        writeExecutor.submitWriteThroughDurable("identity.removeExpiredRatchets") { ratchetDao.deleteExpiredBefore(threshold) }
     }
 }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
@@ -3,9 +3,11 @@ package network.reticulum.android.db.store
 import android.database.SQLException
 import android.database.sqlite.SQLiteDatabaseLockedException
 import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
 import kotlin.math.min
+import network.reticulum.common.ByteArrayKey
 
 private const val TAG = "RoomStore"
 
@@ -79,16 +81,41 @@ private const val MAX_LOCK_ATTEMPTS = 3
 private const val INITIAL_LOCK_BACKOFF_MS = 10L
 private const val MAX_LOCK_BACKOFF_MS = 40L
 
+// Per-turn cap on how many pending durable writes one successful write may
+// reconcile, so a single executor task's reconciliation work stays bounded as
+// the backlog grows (see flushPendingDurableWrites).
+internal const val MAX_PENDING_FLUSH_PER_TURN = 16
+
 // Durable (identity/ratchet) writes whose bounded lock-retry budget was
 // exhausted while SQLite stayed locked. They MUST be durable and are NOT
 // reconstructable from the live network, so they are never permanently
 // dropped: each stays pending and is reconciled (flushed) into Room at the
-// next safe point — the next successful durable write, which proves the lock
-// has cleared. Mutated only from the single write-executor thread (or the
-// test thread), so the synchronized wrappers are belt-and-braces; the list is
-// drained once per flush, never spun, and each re-attempt uses the same
-// bounded budget, so nothing unbounded blocks the write thread.
-private val pendingDurableWrites = mutableListOf<Pair<String, () -> Unit>>()
+// next safe point — a successful durable write, which proves the lock has
+// cleared. Mutated only from the single write-executor thread (or the test
+// thread), so the synchronized wrappers are belt-and-braces; each re-attempt
+// uses the same bounded budget, so nothing unbounded blocks the write thread.
+//
+// The pending set is scoped to the owning executor — not process-global, as
+// the previous correction was — so one writer/database instance can never
+// flush another instance's backlog. Entries are coalesced by a row key
+// (table namespace + dest_hash) so same-key writes reconcile latest-write-wins:
+// an older pending write for a key is superseded by a newer one, and a write
+// that commits removes any older pending entry for the same key before the
+// flush runs, so replay can never regress durable state to a stale value.
+internal class DurableRowKey(val namespace: String, val destHash: ByteArrayKey) {
+    override fun equals(other: Any?): Boolean =
+        other is DurableRowKey && namespace == other.namespace && destHash == other.destHash
+
+    override fun hashCode(): Int = 31 * namespace.hashCode() + destHash.hashCode()
+
+    override fun toString(): String = "$namespace:${destHash}"
+}
+
+private val pendingDurableWritesByExecutor =
+    ConcurrentHashMap<ExecutorService, MutableMap<DurableRowKey, Pair<String, () -> Unit>>>()
+
+private fun pendingMapFor(executor: ExecutorService): MutableMap<DurableRowKey, Pair<String, () -> Unit>> =
+    pendingDurableWritesByExecutor.computeIfAbsent(executor) { mutableMapOf() }
 
 private enum class DurableWriteOutcome { COMMITTED, LOCK_EXHAUSTED, DROPPED }
 
@@ -130,21 +157,34 @@ private fun attemptDurableWrite(op: String, block: () -> Unit): DurableWriteOutc
     }
 }
 
-// Reconcile any pending durable writes now that a write has just succeeded
-// (the lock cleared). Re-attempts each pending block once with the same
-// bounded budget; a pending write that still exhausts stays pending for a
-// later flush, one that is dropped (DB closed / non-lock error) is removed —
-// it can no longer be made durable. Runs on the write thread, drains the list
-// once, and never spins.
-private fun flushPendingDurableWrites() {
-    val pending = synchronized(pendingDurableWrites) {
-        pendingDurableWrites.toList().also { pendingDurableWrites.clear() }
+// Reconcile a BOUNDED number of pending durable writes now that a write has
+// just succeeded (the lock cleared). Each turn takes at most
+// [MAX_PENDING_FLUSH_PER_TURN] pending entries, so one executor task performs
+// only a fixed amount of reconciliation work no matter how large the backlog
+// grows; entries that remain after the turn stay pending (coalesced under their
+// key) and are reconciled by later bounded turns — the next successful durable
+// writes. Each pending block is re-attempted once with the same bounded budget;
+// one that still exhausts stays pending, one that is dropped (DB closed /
+// non-lock error) is removed — it can no longer be made durable. Runs on the
+// write thread for the owning executor and never spins.
+private fun flushPendingDurableWrites(executor: ExecutorService) {
+    val state = pendingMapFor(executor)
+    val turn = synchronized(state) {
+        val taken = ArrayList<Pair<DurableRowKey, Pair<String, () -> Unit>>>(MAX_PENDING_FLUSH_PER_TURN)
+        val it = state.iterator()
+        while (it.hasNext() && taken.size < MAX_PENDING_FLUSH_PER_TURN) {
+            val e = it.next()
+            taken.add(e.key to e.value)
+            it.remove()
+        }
+        taken
     }
-    for ((op, block) in pending) {
+    for ((key, entry) in turn) {
+        val (op, block) = entry
         when (attemptDurableWrite(op, block)) {
             DurableWriteOutcome.COMMITTED -> { /* reconciled durably */ }
-            DurableWriteOutcome.LOCK_EXHAUSTED -> synchronized(pendingDurableWrites) {
-                pendingDurableWrites.add(op to block)
+            DurableWriteOutcome.LOCK_EXHAUSTED -> synchronized(state) {
+                state[key] = entry
             }
             DurableWriteOutcome.DROPPED -> { /* can no longer be made durable */ }
         }
@@ -163,10 +203,18 @@ private fun flushPendingDurableWrites() {
  * momentary lock cannot silently discard a ratchet/identity write that would
  * otherwise leave durable state stale or missing after a restart. And, unlike
  * [submitWriteThrough], retry exhaustion is NOT a permanent drop: the write is
- * kept pending and reconciled (flushed) into Room at the next safe point — the
- * next successful durable write, which proves the lock has cleared — so the
+ * kept pending and reconciled (flushed) into Room at the next safe point — a
+ * successful durable write, which proves the lock has cleared — so the
  * security-relevant value is never silently lost even when another writer
  * holds the lock longer than the bounded retry window.
+ *
+ * [key] is the durable row identity (table namespace + dest_hash) used to
+ * coalesce the pending set latest-write-wins. Reconciliation is bounded per
+ * successful write ([MAX_PENDING_FLUSH_PER_TURN] entries per turn) and scoped
+ * to this executor, so a single task never drains an unbounded backlog and one
+ * writer/database instance can never flush another instance's backlog. A write
+ * that commits removes any older pending entry for the same [key] before the
+ * flush runs, so a stale pending write can never replay over newer state.
  *
  * [IllegalStateException] (DB closed mid-write during teardown) and every
  * other [SQLException] (non-lock transient SQLite failure) are still dropped
@@ -177,15 +225,26 @@ private fun flushPendingDurableWrites() {
  * main-thread DB access, matching the [submitWriteThrough] contract.
  *
  * @param op short operation label for the dropped-write log line.
+ * @param key durable row identity used to coalesce same-key pending writes
+ *   latest-write-wins.
  */
-internal fun ExecutorService.submitWriteThroughDurable(op: String, block: () -> Unit) {
+internal fun ExecutorService.submitWriteThroughDurable(op: String, key: DurableRowKey, block: () -> Unit) {
+    val executor = this
     try {
         execute {
+            val state = pendingMapFor(executor)
             when (attemptDurableWrite(op, block)) {
-                DurableWriteOutcome.COMMITTED -> flushPendingDurableWrites()
+                DurableWriteOutcome.COMMITTED -> {
+                    // The value just committed is newer than any pending write
+                    // for the same key — remove the stale pending entry so a
+                    // later flush can never replay it over the newer value
+                    // (latest-write-wins), then reconcile a bounded turn.
+                    synchronized(state) { state.remove(key) }
+                    flushPendingDurableWrites(executor)
+                }
                 DurableWriteOutcome.LOCK_EXHAUSTED -> {
                     Log.w(TAG, "DB write '$op'; SQLite locked after $MAX_LOCK_ATTEMPTS attempts; keeping pending for reconciliation")
-                    synchronized(pendingDurableWrites) { pendingDurableWrites.add(op to block) }
+                    synchronized(state) { state[key] = op to block }
                 }
                 DurableWriteOutcome.DROPPED -> { /* dropped immediately, as above */ }
             }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
@@ -1,9 +1,11 @@
 package network.reticulum.android.db.store
 
 import android.database.SQLException
+import android.database.sqlite.SQLiteDatabaseLockedException
 import android.util.Log
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
+import kotlin.math.min
 
 private const val TAG = "RoomStore"
 
@@ -61,6 +63,75 @@ internal fun ExecutorService.submitWriteThrough(op: String, block: () -> Unit) {
                 Log.w(TAG, "Dropped DB write '$op'; database closed mid-write: ${e.message}")
             } catch (e: SQLException) {
                 Log.w(TAG, "Dropped DB write '$op'; transient SQLite error: ${e.message}")
+            }
+        }
+    } catch (e: RejectedExecutionException) {
+        // Executor already shutdown() by StoreLifecycle during service teardown.
+        Log.w(TAG, "DB write '$op' rejected; executor already shut down")
+    }
+}
+
+// Bounded retry budget for a transient SQLite lock on a security-relevant
+// durable write. Small backoff doubles between attempts; the total worst-case
+// stall is bounded so a foreground-service write thread can never ANR.
+private const val MAX_LOCK_ATTEMPTS = 3
+private const val INITIAL_LOCK_BACKOFF_MS = 10L
+private const val MAX_LOCK_BACKOFF_MS = 40L
+
+/**
+ * Submit a write-through persistence task whose contents MUST be durable —
+ * the security-relevant identity/ratchet state stored by [RoomIdentityStore]
+ * is not reconstructable from the live network (unlike the announce/path/
+ * packet-hash caches that [submitWriteThrough] serves).
+ *
+ * The one difference from [submitWriteThrough]: a transient SQLite lock
+ * ([SQLiteDatabaseLockedException], e.g. "database is locked" / SQLITE_BUSY)
+ * is retried a bounded number of times with a small doubling backoff, so a
+ * momentary lock cannot silently discard a ratchet/identity write that would
+ * otherwise leave durable state stale or missing after a restart. Only after
+ * the bounded budget is exhausted does the write fall back to the same
+ * drop-and-log behavior as [submitWriteThrough].
+ *
+ * [IllegalStateException] (DB closed mid-write during teardown) and every
+ * other [SQLException] (non-lock transient SQLite failure) are still dropped
+ * immediately, exactly as in [submitWriteThrough] — the close-race semantics
+ * and the reconstructable-cache policy are unchanged; a write cannot be made
+ * durable once the `RoomDatabase` is gone. The [IllegalStateException] catch
+ * is deliberately NOT broadened: each [block] stays a plain DAO call with no
+ * main-thread DB access, matching the [submitWriteThrough] contract.
+ *
+ * @param op short operation label for the dropped-write log line.
+ */
+internal fun ExecutorService.submitWriteThroughDurable(op: String, block: () -> Unit) {
+    try {
+        execute {
+            var attempt = 0
+            var backoffMs = INITIAL_LOCK_BACKOFF_MS
+            while (true) {
+                try {
+                    block()
+                    return@execute // committed durably
+                } catch (e: SQLiteDatabaseLockedException) {
+                    attempt++
+                    if (attempt >= MAX_LOCK_ATTEMPTS) {
+                        Log.w(TAG, "Dropped DB write '$op'; SQLite locked after $MAX_LOCK_ATTEMPTS attempts: ${e.message}")
+                        return@execute
+                    }
+                    try {
+                        Thread.sleep(backoffMs)
+                    } catch (ie: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                        Log.w(TAG, "Dropped DB write '$op'; interrupted while awaiting SQLite lock: ${ie.message}")
+                        return@execute
+                    }
+                    backoffMs = min(backoffMs * 2, MAX_LOCK_BACKOFF_MS)
+                } catch (e: IllegalStateException) {
+                    Log.w(TAG, "Dropped DB write '$op'; database closed mid-write: ${e.message}")
+                    return@execute
+                } catch (e: SQLException) {
+                    Log.w(TAG, "Dropped DB write '$op'; transient SQLite error: ${e.message}")
+                    return@execute
+                }
             }
         }
     } catch (e: RejectedExecutionException) {

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
@@ -3,7 +3,6 @@ package network.reticulum.android.db.store
 import android.database.SQLException
 import android.database.sqlite.SQLiteDatabaseLockedException
 import android.util.Log
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
 import kotlin.math.min
@@ -111,11 +110,76 @@ internal class DurableRowKey(val namespace: String, val destHash: ByteArrayKey) 
     override fun toString(): String = "$namespace:${destHash}"
 }
 
-private val pendingDurableWritesByExecutor =
-    ConcurrentHashMap<ExecutorService, MutableMap<DurableRowKey, Pair<String, () -> Unit>>>()
+/**
+ * Instance-owned pending durable-write state for ONE durable writer/store
+ * (e.g. [RoomIdentityStore]) — NOT a process-global registry keyed by
+ * `ExecutorService`.
+ *
+ * Owning the state per writer/store with an explicit lifecycle boundary
+ * ([dispose]) closes the teardown defect of the previous process-global map:
+ * a retired writer's `ExecutorService`, DAO-capturing lambdas, and
+ * `RoomDatabase` are released when the writer's lifecycle ends, and a
+ * replacement writer/store never observes or flushes the retired instance's
+ * backlog even when both share an executor. Mutated only from the single
+ * write-executor thread (or the test thread); the synchronized wrappers are
+ * belt-and-braces. Entries are coalesced by a row key (table namespace +
+ * dest_hash) so same-key writes reconcile latest-write-wins: an older pending
+ * write for a key is superseded by a newer one, and a write that commits
+ * removes any older pending entry for the same key before the flush runs.
+ */
+internal class DurableWriteState {
 
-private fun pendingMapFor(executor: ExecutorService): MutableMap<DurableRowKey, Pair<String, () -> Unit>> =
-    pendingDurableWritesByExecutor.computeIfAbsent(executor) { mutableMapOf() }
+    private val pending = mutableMapOf<DurableRowKey, Pair<String, () -> Unit>>()
+    @Volatile private var disposed = false
+
+    /**
+     * Take at most [MAX_PENDING_FLUSH_PER_TURN] pending entries for one bounded
+     * flush turn, removing them from the map; entries that remain stay pending
+     * (coalesced under their key) and are reconciled by later bounded turns.
+     */
+    @Synchronized
+    fun takeTurn(): ArrayList<Pair<DurableRowKey, Pair<String, () -> Unit>>> {
+        val taken = ArrayList<Pair<DurableRowKey, Pair<String, () -> Unit>>>(MAX_PENDING_FLUSH_PER_TURN)
+        val it = pending.iterator()
+        while (it.hasNext() && taken.size < MAX_PENDING_FLUSH_PER_TURN) {
+            val e = it.next()
+            taken.add(e.key to e.value)
+            it.remove()
+        }
+        return taken
+    }
+
+    /** Keep a retry-exhausted durable write pending for reconciliation. No-op after [dispose]. */
+    @Synchronized
+    fun put(key: DurableRowKey, op: String, block: () -> Unit) {
+        if (!disposed) pending[key] = op to block
+    }
+
+    /** A committed write removes any older pending entry for the same [key] (latest-write-wins). */
+    @Synchronized
+    fun remove(key: DurableRowKey) {
+        if (!disposed) pending.remove(key)
+    }
+
+    /** Re-queue a reconciled entry that stayed locked after one bounded re-attempt. */
+    @Synchronized
+    fun requeue(key: DurableRowKey, entry: Pair<String, () -> Unit>) {
+        if (!disposed) pending[key] = entry
+    }
+
+    /**
+     * Explicit lifecycle boundary: release every pending entry (and the
+     * DAO-capturing lambda it holds) and mark the state disposed so no later
+     * write can resurrect or flush the retired backlog. Called by the owning
+     * writer/store on teardown after the executor is drained and before/with
+     * the `RoomDatabase` close.
+     */
+    @Synchronized
+    fun dispose() {
+        disposed = true
+        pending.clear()
+    }
+}
 
 private enum class DurableWriteOutcome { COMMITTED, LOCK_EXHAUSTED, DROPPED }
 
@@ -167,25 +231,13 @@ private fun attemptDurableWrite(op: String, block: () -> Unit): DurableWriteOutc
 // one that still exhausts stays pending, one that is dropped (DB closed /
 // non-lock error) is removed — it can no longer be made durable. Runs on the
 // write thread for the owning executor and never spins.
-private fun flushPendingDurableWrites(executor: ExecutorService) {
-    val state = pendingMapFor(executor)
-    val turn = synchronized(state) {
-        val taken = ArrayList<Pair<DurableRowKey, Pair<String, () -> Unit>>>(MAX_PENDING_FLUSH_PER_TURN)
-        val it = state.iterator()
-        while (it.hasNext() && taken.size < MAX_PENDING_FLUSH_PER_TURN) {
-            val e = it.next()
-            taken.add(e.key to e.value)
-            it.remove()
-        }
-        taken
-    }
+private fun flushPendingDurableWrites(state: DurableWriteState) {
+    val turn = state.takeTurn()
     for ((key, entry) in turn) {
         val (op, block) = entry
         when (attemptDurableWrite(op, block)) {
             DurableWriteOutcome.COMMITTED -> { /* reconciled durably */ }
-            DurableWriteOutcome.LOCK_EXHAUSTED -> synchronized(state) {
-                state[key] = entry
-            }
+            DurableWriteOutcome.LOCK_EXHAUSTED -> state.requeue(key, entry)
             DurableWriteOutcome.DROPPED -> { /* can no longer be made durable */ }
         }
     }
@@ -211,10 +263,11 @@ private fun flushPendingDurableWrites(executor: ExecutorService) {
  * [key] is the durable row identity (table namespace + dest_hash) used to
  * coalesce the pending set latest-write-wins. Reconciliation is bounded per
  * successful write ([MAX_PENDING_FLUSH_PER_TURN] entries per turn) and scoped
- * to this executor, so a single task never drains an unbounded backlog and one
- * writer/database instance can never flush another instance's backlog. A write
- * that commits removes any older pending entry for the same [key] before the
- * flush runs, so a stale pending write can never replay over newer state.
+ * to the [state] instance owned by this durable writer, so a single task never
+ * drains an unbounded backlog and one writer/store instance can never flush
+ * another instance's backlog — even when they share an executor. A write that
+ * commits removes any older pending entry for the same [key] before the flush
+ * runs, so a stale pending write can never replay over newer state.
  *
  * [IllegalStateException] (DB closed mid-write during teardown) and every
  * other [SQLException] (non-lock transient SQLite failure) are still dropped
@@ -224,27 +277,31 @@ private fun flushPendingDurableWrites(executor: ExecutorService) {
  * is deliberately NOT broadened: each [block] stays a plain DAO call with no
  * main-thread DB access, matching the [submitWriteThrough] contract.
  *
+ * @param state instance-owned pending durable-write state for this writer;
+ *   released via [DurableWriteState.dispose] on the owning writer/store
+ *   lifecycle teardown.
  * @param op short operation label for the dropped-write log line.
  * @param key durable row identity used to coalesce same-key pending writes
  *   latest-write-wins.
  */
-internal fun ExecutorService.submitWriteThroughDurable(op: String, key: DurableRowKey, block: () -> Unit) {
-    val executor = this
+internal fun ExecutorService.submitWriteThroughDurable(
+    state: DurableWriteState,
+    op: String, key: DurableRowKey, block: () -> Unit
+) {
     try {
         execute {
-            val state = pendingMapFor(executor)
             when (attemptDurableWrite(op, block)) {
                 DurableWriteOutcome.COMMITTED -> {
                     // The value just committed is newer than any pending write
                     // for the same key — remove the stale pending entry so a
                     // later flush can never replay it over the newer value
                     // (latest-write-wins), then reconcile a bounded turn.
-                    synchronized(state) { state.remove(key) }
-                    flushPendingDurableWrites(executor)
+                    state.remove(key)
+                    flushPendingDurableWrites(state)
                 }
                 DurableWriteOutcome.LOCK_EXHAUSTED -> {
                     Log.w(TAG, "DB write '$op'; SQLite locked after $MAX_LOCK_ATTEMPTS attempts; keeping pending for reconciliation")
-                    synchronized(state) { state[key] = op to block }
+                    state.put(key, op, block)
                 }
                 DurableWriteOutcome.DROPPED -> { /* dropped immediately, as above */ }
             }

--- a/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
+++ b/rns-android/src/main/kotlin/network/reticulum/android/db/store/SafeDbWrite.kt
@@ -73,10 +73,83 @@ internal fun ExecutorService.submitWriteThrough(op: String, block: () -> Unit) {
 
 // Bounded retry budget for a transient SQLite lock on a security-relevant
 // durable write. Small backoff doubles between attempts; the total worst-case
-// stall is bounded so a foreground-service write thread can never ANR.
+// stall of a single attempt sequence is bounded so a foreground-service write
+// thread can never ANR.
 private const val MAX_LOCK_ATTEMPTS = 3
 private const val INITIAL_LOCK_BACKOFF_MS = 10L
 private const val MAX_LOCK_BACKOFF_MS = 40L
+
+// Durable (identity/ratchet) writes whose bounded lock-retry budget was
+// exhausted while SQLite stayed locked. They MUST be durable and are NOT
+// reconstructable from the live network, so they are never permanently
+// dropped: each stays pending and is reconciled (flushed) into Room at the
+// next safe point — the next successful durable write, which proves the lock
+// has cleared. Mutated only from the single write-executor thread (or the
+// test thread), so the synchronized wrappers are belt-and-braces; the list is
+// drained once per flush, never spun, and each re-attempt uses the same
+// bounded budget, so nothing unbounded blocks the write thread.
+private val pendingDurableWrites = mutableListOf<Pair<String, () -> Unit>>()
+
+private enum class DurableWriteOutcome { COMMITTED, LOCK_EXHAUSTED, DROPPED }
+
+// Runs [block] through the bounded SQLite-lock retry budget and reports how
+// it ended. COMMITTED — written durably. LOCK_EXHAUSTED — SQLite stayed locked
+// through the whole budget (the caller keeps the write pending for
+// reconciliation). DROPPED — an immediate, non-retryable drop: the
+// [IllegalStateException] close-race (DB closed mid-write), a non-lock
+// [SQLException], or an interrupt while awaiting the lock. Those keep exactly
+// the [submitWriteThrough] semantics — a write cannot be made durable once the
+// `RoomDatabase` is gone.
+private fun attemptDurableWrite(op: String, block: () -> Unit): DurableWriteOutcome {
+    var attempt = 0
+    var backoffMs = INITIAL_LOCK_BACKOFF_MS
+    while (true) {
+        try {
+            block()
+            return DurableWriteOutcome.COMMITTED
+        } catch (e: SQLiteDatabaseLockedException) {
+            attempt++
+            if (attempt >= MAX_LOCK_ATTEMPTS) {
+                return DurableWriteOutcome.LOCK_EXHAUSTED
+            }
+            try {
+                Thread.sleep(backoffMs)
+            } catch (ie: InterruptedException) {
+                Thread.currentThread().interrupt()
+                Log.w(TAG, "DB write '$op' interrupted while awaiting SQLite lock: ${ie.message}")
+                return DurableWriteOutcome.DROPPED
+            }
+            backoffMs = min(backoffMs * 2, MAX_LOCK_BACKOFF_MS)
+        } catch (e: IllegalStateException) {
+            Log.w(TAG, "Dropped DB write '$op'; database closed mid-write: ${e.message}")
+            return DurableWriteOutcome.DROPPED
+        } catch (e: SQLException) {
+            Log.w(TAG, "Dropped DB write '$op'; transient SQLite error: ${e.message}")
+            return DurableWriteOutcome.DROPPED
+        }
+    }
+}
+
+// Reconcile any pending durable writes now that a write has just succeeded
+// (the lock cleared). Re-attempts each pending block once with the same
+// bounded budget; a pending write that still exhausts stays pending for a
+// later flush, one that is dropped (DB closed / non-lock error) is removed —
+// it can no longer be made durable. Runs on the write thread, drains the list
+// once, and never spins.
+private fun flushPendingDurableWrites() {
+    val pending = synchronized(pendingDurableWrites) {
+        pendingDurableWrites.toList().also { pendingDurableWrites.clear() }
+    }
+    for ((op, block) in pending) {
+        when (attemptDurableWrite(op, block)) {
+            DurableWriteOutcome.COMMITTED -> { /* reconciled durably */ }
+            DurableWriteOutcome.LOCK_EXHAUSTED -> synchronized(pendingDurableWrites) {
+                pendingDurableWrites.add(op to block)
+            }
+            DurableWriteOutcome.DROPPED -> { /* can no longer be made durable */ }
+        }
+    }
+}
 
 /**
  * Submit a write-through persistence task whose contents MUST be durable —
@@ -84,13 +157,16 @@ private const val MAX_LOCK_BACKOFF_MS = 40L
  * is not reconstructable from the live network (unlike the announce/path/
  * packet-hash caches that [submitWriteThrough] serves).
  *
- * The one difference from [submitWriteThrough]: a transient SQLite lock
+ * The differences from [submitWriteThrough]: a transient SQLite lock
  * ([SQLiteDatabaseLockedException], e.g. "database is locked" / SQLITE_BUSY)
  * is retried a bounded number of times with a small doubling backoff, so a
  * momentary lock cannot silently discard a ratchet/identity write that would
- * otherwise leave durable state stale or missing after a restart. Only after
- * the bounded budget is exhausted does the write fall back to the same
- * drop-and-log behavior as [submitWriteThrough].
+ * otherwise leave durable state stale or missing after a restart. And, unlike
+ * [submitWriteThrough], retry exhaustion is NOT a permanent drop: the write is
+ * kept pending and reconciled (flushed) into Room at the next safe point — the
+ * next successful durable write, which proves the lock has cleared — so the
+ * security-relevant value is never silently lost even when another writer
+ * holds the lock longer than the bounded retry window.
  *
  * [IllegalStateException] (DB closed mid-write during teardown) and every
  * other [SQLException] (non-lock transient SQLite failure) are still dropped
@@ -105,33 +181,13 @@ private const val MAX_LOCK_BACKOFF_MS = 40L
 internal fun ExecutorService.submitWriteThroughDurable(op: String, block: () -> Unit) {
     try {
         execute {
-            var attempt = 0
-            var backoffMs = INITIAL_LOCK_BACKOFF_MS
-            while (true) {
-                try {
-                    block()
-                    return@execute // committed durably
-                } catch (e: SQLiteDatabaseLockedException) {
-                    attempt++
-                    if (attempt >= MAX_LOCK_ATTEMPTS) {
-                        Log.w(TAG, "Dropped DB write '$op'; SQLite locked after $MAX_LOCK_ATTEMPTS attempts: ${e.message}")
-                        return@execute
-                    }
-                    try {
-                        Thread.sleep(backoffMs)
-                    } catch (ie: InterruptedException) {
-                        Thread.currentThread().interrupt()
-                        Log.w(TAG, "Dropped DB write '$op'; interrupted while awaiting SQLite lock: ${ie.message}")
-                        return@execute
-                    }
-                    backoffMs = min(backoffMs * 2, MAX_LOCK_BACKOFF_MS)
-                } catch (e: IllegalStateException) {
-                    Log.w(TAG, "Dropped DB write '$op'; database closed mid-write: ${e.message}")
-                    return@execute
-                } catch (e: SQLException) {
-                    Log.w(TAG, "Dropped DB write '$op'; transient SQLite error: ${e.message}")
-                    return@execute
+            when (attemptDurableWrite(op, block)) {
+                DurableWriteOutcome.COMMITTED -> flushPendingDurableWrites()
+                DurableWriteOutcome.LOCK_EXHAUSTED -> {
+                    Log.w(TAG, "DB write '$op'; SQLite locked after $MAX_LOCK_ATTEMPTS attempts; keeping pending for reconciliation")
+                    synchronized(pendingDurableWrites) { pendingDurableWrites.add(op to block) }
                 }
+                DurableWriteOutcome.DROPPED -> { /* dropped immediately, as above */ }
             }
         }
     } catch (e: RejectedExecutionException) {

--- a/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
+++ b/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
@@ -9,6 +9,7 @@ import network.reticulum.identity.Identity.IdentityData
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -131,6 +132,54 @@ class RoomIdentityStoreTest {
         assertEquals(2, dao.upsertCount)
     }
 
+    /**
+     * Greptile P1 regression (retry-exhaustion discard): when SQLite stays
+     * locked through the ENTIRE bounded retry budget (3 attempts), the
+     * security-relevant ratchet write must NOT be permanently dropped. The
+     * value is not reconstructable from the live network, so it must be kept
+     * pending and reconciled into Room at the next safe point (flush on the
+     * next successful durable write). Pre-fix the exhaustion branch logs and
+     * drops the write, so the value never reappears after a later successful
+     * write — this test fails (red). Post-fix the pending value is flushed and
+     * lands durably.
+     */
+    @Test
+    fun `ratchet retry exhaustion keeps the durable write pending and reconciles it on the next successful write`() {
+        // Locks for the first 3 upsert calls (the whole bounded budget of the
+        // first write), then commits. The first ratchet write must exhaust the
+        // budget and go PENDING, not be dropped; a later successful write must
+        // flush it into Room.
+        val dao = LockThenCommitRatchetDao(
+            lockCalls = 3,
+            lock = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        )
+        val store = RoomIdentityStore(NoopKnownDestinationDao(), dao, DirectExecutorService())
+
+        // First ratchet write: the lock persists through the whole bounded
+        // retry budget. Durable state is (still) absent — the lock never
+        // cleared — but the write must be kept PENDING for reconciliation,
+        // not permanently dropped. Attempts stay bounded (no spin): exactly 3.
+        store.upsertRatchet(byteArrayOf(1), byteArrayOf(7, 8, 9), timestampMs = 42L)
+        assertNull(store.getRatchet(byteArrayOf(1)))
+        assertEquals(3, dao.upsertCount)
+
+        // A second write now succeeds (the lock clears). It must flush the
+        // pending first ratchet value into Room: the durable state that was
+        // "lost" on exhaustion must reappear. Pre-fix nothing rewrites it, so
+        // the value stays missing and this assertion fails (red).
+        store.upsertRatchet(byteArrayOf(2), byteArrayOf(10, 11, 12), timestampMs = 99L)
+
+        val first = store.getRatchet(byteArrayOf(1))
+        assertNotNull(first)
+        assertArrayEquals(byteArrayOf(7, 8, 9), first!!.first)
+        assertEquals(42L, first.second)
+
+        val second = store.getRatchet(byteArrayOf(2))
+        assertNotNull(second)
+        assertArrayEquals(byteArrayOf(10, 11, 12), second!!.first)
+        assertEquals(99L, second.second)
+    }
+
     private fun sampleIdentityData() = IdentityData(
         timestamp = 1L,
         packetHash = byteArrayOf(2, 3),
@@ -187,6 +236,25 @@ class RoomIdentityStoreTest {
 
         override fun getByHash(destHash: ByteArray): IdentityRatchetEntity? =
             committed?.takeIf { it.destHash.contentEquals(destHash) }
+
+        override fun deleteExpiredBefore(thresholdMs: Long) = Unit
+    }
+
+    private class LockThenCommitRatchetDao(
+        private val lockCalls: Int,
+        private val lock: Exception,
+    ) : IdentityRatchetDao {
+        var upsertCount = 0
+        private val committed = mutableListOf<IdentityRatchetEntity>()
+
+        override fun upsert(entity: IdentityRatchetEntity) {
+            upsertCount++
+            if (upsertCount <= lockCalls) throw lock
+            committed.add(entity)
+        }
+
+        override fun getByHash(destHash: ByteArray): IdentityRatchetEntity? =
+            committed.firstOrNull { it.destHash.contentEquals(destHash) }
 
         override fun deleteExpiredBefore(thresholdMs: Long) = Unit
     }

--- a/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
+++ b/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
@@ -1,0 +1,96 @@
+package network.reticulum.android.db.store
+
+import android.database.sqlite.SQLiteDatabaseLockedException
+import network.reticulum.android.db.dao.IdentityRatchetDao
+import network.reticulum.android.db.dao.KnownDestinationDao
+import network.reticulum.android.db.entity.IdentityRatchetEntity
+import network.reticulum.android.db.entity.KnownDestinationEntity
+import network.reticulum.identity.Identity.IdentityData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression test for Sentry COLUMBA-D4.
+ *
+ * [RoomIdentityStore] is a write-through cache backed by a single Room write
+ * executor, exactly like its siblings [RoomAnnounceStore] / [RoomPathStore] /
+ * [RoomPacketHashStore]. But it was never migrated off the bare
+ * `writeExecutor.execute { dao.upsert(...) }` call — it bypasses the
+ * [submitWriteThrough] policy its siblings use. When SQLite raises
+ * SQLITE_BUSY (`android.database.sqlite.SQLiteDatabaseLockedException`,
+ * "database is locked") from inside the write task, the exception escapes the
+ * executor uncaught and, on the dedicated NativeReticulumDB-write thread,
+ * reaches the uncaught handler — a fatal crash. That is COLUMBA-D4
+ * (culprit `SQLiteConnection.nativeExecute`, frame
+ * `RoomIdentityStore.upsertKnownDestination$lambda$0`).
+ *
+ * A live SQLITE_BUSY can't be reproduced deterministically through a real
+ * Robolectric Room DB (host JDBC SQLite no-ops writes after `close()` instead
+ * of throwing — see [RoomAnnounceStoreTest]), so the test injects the real
+ * `SQLiteDatabaseLockedException` through a fake [KnownDestinationDao] and runs
+ * the production write lambda inline on the test thread via
+ * [DirectExecutorService]. The store method, the executor, and the lambda are
+ * all production code; only the DAO is a fake that raises the exact real
+ * exception type. Pre-fix the exception escapes the `writeExecutor.execute`
+ * lambda and the test fails; post-fix [submitWriteThrough] swallows it (its
+ * `SQLException` branch covers `SQLiteDatabaseLockedException` by inheritance).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class RoomIdentityStoreTest {
+
+    @Test
+    fun `upsertKnownDestination swallows a SQLITE_BUSY SQLiteDatabaseLockedException instead of crashing the write thread`() {
+        val dao = FakeKnownDestinationDao(
+            failure = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        )
+        val store = RoomIdentityStore(dao, NoopIdentityRatchetDao(), DirectExecutorService())
+
+        // Pre-fix: upsertKnownDestination bypasses submitWriteThrough, so this
+        // SQLiteDatabaseLockedException escapes the writeExecutor.execute lambda
+        // and, on the NativeReticulumDB-write thread, reaches the uncaught handler
+        // — fatal (COLUMBA-D4). Post-fix: submitWriteThrough's SQLException branch
+        // swallows it.
+        store.upsertKnownDestination(byteArrayOf(1), sampleIdentityData())
+
+        // Reaching here means the exception did not escape; the write was
+        // attempted once then dropped.
+        assertEquals(1, dao.upsertCount)
+    }
+
+    private fun sampleIdentityData() = IdentityData(
+        timestamp = 1L,
+        packetHash = byteArrayOf(2, 3),
+        // 32-byte X25519 public key.
+        publicKey = byteArrayOf(
+            4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+            18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+            32, 33, 34, 35
+        ),
+        appData = byteArrayOf(9)
+    )
+
+    private class FakeKnownDestinationDao(
+        private val failure: Exception? = null,
+    ) : KnownDestinationDao {
+        var upsertCount = 0
+
+        override fun upsert(entity: KnownDestinationEntity) {
+            upsertCount++
+            failure?.let { throw it }
+        }
+
+        override fun getByHash(destHash: ByteArray): KnownDestinationEntity? = null
+        override fun getAll(): List<KnownDestinationEntity> = emptyList()
+        override fun count(): Int = 0
+    }
+
+    private class NoopIdentityRatchetDao : IdentityRatchetDao {
+        override fun upsert(entity: IdentityRatchetEntity) = Unit
+        override fun getByHash(destHash: ByteArray): IdentityRatchetEntity? = null
+        override fun deleteExpiredBefore(thresholdMs: Long) = Unit
+    }
+}

--- a/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
+++ b/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
@@ -280,6 +280,89 @@ class RoomIdentityStoreTest {
         }
     }
 
+    /**
+     * New regression (DeepSeek correction, lifecycle/isolation): a RETIRED
+     * store's pending durable backlog must be scoped to the owning
+     * writer/store lifecycle — never to the shared executor — so a replacement
+     * store on the SAME executor must not observe or flush the retired
+     * instance's DAO work. Pre-fix the pending backlog lives in a process-global
+     * `ConcurrentHashMap` keyed by `ExecutorService`, so two store generations
+     * sharing one executor share the same pending set: store B's successful
+     * write reconciles store A's retired pending entry and invokes store A's
+     * DAO again (upsertCount 4). Post-fix the pending state is owned by each
+     * store instance, so store B's flush touches only its own (empty) state and
+     * store A's retired DAO is never called (upsertCount stays 3). Deterministic
+     * via counting DAOs + DirectExecutorService — no sleeps, no GC timing.
+     */
+    @Test
+    fun `a replacement store sharing the same executor must never observe or flush the retired store's pending durable backlog`() {
+        val lock = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        val executor = DirectExecutorService()
+
+        // Store A on executor: seed a durable ratchet write whose whole bounded
+        // lock budget exhausts -> it goes PENDING (never dropped), DAO A called 3x.
+        val daoA = LockThenCommitRatchetDao(lockCalls = 3, lock = lock)
+        val storeA = RoomIdentityStore(NoopKnownDestinationDao(), daoA, executor)
+        storeA.upsertRatchet(byteArrayOf(1), byteArrayOf(7, 8, 9), timestampMs = 42L)
+        assertEquals(3, daoA.upsertCount)
+        assertNull(storeA.getRatchet(byteArrayOf(1)))
+
+        // Store A's lifecycle ends (retired). A replacement store B is created on
+        // the SAME executor. The retired backlog must stay scoped to store A and
+        // be released with it — store B's successful write must NOT flush it.
+        val daoB = LockThenCommitRatchetDao(lockCalls = 0, lock = lock)
+        val storeB = RoomIdentityStore(NoopKnownDestinationDao(), daoB, executor)
+        storeB.upsertRatchet(byteArrayOf(2), byteArrayOf(10, 11, 12), timestampMs = 99L)
+
+        // Retired store A's DAO must never be invoked by store B's flush.
+        // Pre-fix store B's flush re-attempts store A's pending entry and commits
+        // it (upsertCount 4) -> RED. Post-fix store B's own state is empty, so
+        // DAO A stays at 3.
+        assertEquals(3, daoA.upsertCount)
+
+        // store B's own write must have committed durably.
+        val second = storeB.getRatchet(byteArrayOf(2))
+        assertNotNull(second)
+        assertArrayEquals(byteArrayOf(10, 11, 12), second!!.first)
+        assertEquals(99L, second.second)
+    }
+
+    /**
+     * New regression (DeepSeek correction, explicit lifecycle release): calling
+     * [RoomIdentityStore.dispose] releases the store's pending durable state, so
+     * a later durable write on the same (retired) store must NOT reconcile the
+     * disposed backlog — the retired DAO work cannot be retained or flushed
+     * after disposal. Deterministic via counting DAO + DirectExecutorService.
+     */
+    @Test
+    fun `disposing a store releases its pending durable state so a later write cannot flush the retired backlog`() {
+        val lock = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        val executor = DirectExecutorService()
+        val daoA = LockThenCommitRatchetDao(lockCalls = 3, lock = lock)
+        val storeA = RoomIdentityStore(NoopKnownDestinationDao(), daoA, executor)
+
+        // Seed: dest_hash [1] exhausts the whole bounded budget -> PENDING.
+        storeA.upsertRatchet(byteArrayOf(1), byteArrayOf(7, 8, 9), timestampMs = 42L)
+        assertEquals(3, daoA.upsertCount)
+
+        // Explicit lifecycle boundary: release the store's pending state.
+        storeA.dispose()
+
+        // A later durable write on the same store must commit (DAO A is unlocked:
+        // upsert #4) but must NOT flush the disposed backlog for dest_hash [1].
+        storeA.upsertRatchet(byteArrayOf(2), byteArrayOf(10, 11, 12), timestampMs = 99L)
+        // 3 seed attempts + 1 new committed write, with NO reconciliation of the
+        // disposed [1] entry (that would be a 5th upsert).
+        assertEquals(4, daoA.upsertCount)
+        // The disposed backlog for [1] must not have been flushed.
+        assertNull(storeA.getRatchet(byteArrayOf(1)))
+        // The new write itself is durable.
+        val second = storeA.getRatchet(byteArrayOf(2))
+        assertNotNull(second)
+        assertArrayEquals(byteArrayOf(10, 11, 12), second!!.first)
+        assertEquals(99L, second.second)
+    }
+
     private fun sampleIdentityData() = IdentityData(
         timestamp = 1L,
         packetHash = byteArrayOf(2, 3),

--- a/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
+++ b/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
@@ -5,6 +5,8 @@ import network.reticulum.android.db.dao.IdentityRatchetDao
 import network.reticulum.android.db.dao.KnownDestinationDao
 import network.reticulum.android.db.entity.IdentityRatchetEntity
 import network.reticulum.android.db.entity.KnownDestinationEntity
+import network.reticulum.common.ByteArrayKey
+import network.reticulum.common.toKey
 import network.reticulum.identity.Identity.IdentityData
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -180,6 +182,104 @@ class RoomIdentityStoreTest {
         assertEquals(99L, second.second)
     }
 
+    /**
+     * New regression (DeepSeek correction, latest-write-wins): a stale pending
+     * write for the SAME dest_hash must not replay over a newer successful
+     * durable write. First an older ratchet write exhausts its bounded lock
+     * budget and goes PENDING; then a NEWER ratchet write for the SAME
+     * dest_hash succeeds. `IdentityRatchetDao.upsert` is Room @Upsert and
+     * dest_hash is the primary key, so replaying the older pending write after
+     * the newer commit would regress durable state to the stale value. Post-fix
+     * the committed newer write removes the stale pending entry before the
+     * flush runs, so the final durable value/timestamp must be the newer one.
+     * The DAO below mirrors Room @Upsert's last-write-wins per dest_hash (not
+     * the firstOrNull semantics of [LockThenCommitRatchetDao], which masked the
+     * same-key hazard).
+     */
+    @Test
+    fun `a newer successful same-dest_hash ratchet write supersedes an older pending one`() {
+        val dao = SameKeyLockThenCommitRatchetDao(
+            lockCalls = 3,
+            lock = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        )
+        val store = RoomIdentityStore(NoopKnownDestinationDao(), dao, DirectExecutorService())
+
+        // Older ratchet for dest_hash [1] exhausts the whole bounded budget and
+        // stays PENDING (never dropped).
+        store.upsertRatchet(byteArrayOf(1), byteArrayOf(7, 8, 9), timestampMs = 42L)
+        // Newer ratchet for the SAME dest_hash [1] succeeds immediately.
+        store.upsertRatchet(byteArrayOf(1), byteArrayOf(10, 11, 12), timestampMs = 99L)
+
+        // The final durable value must be the NEWER one. Pre-fix the flush
+        // replays the stale older write after the newer commit, so the durable
+        // ratchet regresses to (7,8,9)/42 and this fails (red).
+        val final = store.getRatchet(byteArrayOf(1))
+        assertNotNull(final)
+        assertArrayEquals(byteArrayOf(10, 11, 12), final!!.first)
+        assertEquals(99L, final.second)
+    }
+
+    /**
+     * New regression (DeepSeek correction, bounded reconciliation): one
+     * successful executor task must reconcile only a FIXED number of pending
+     * durable writes, with the remaining backlog left for later bounded turns —
+     * not drain the whole backlog in a single task as it grows. Seed
+     * `MAX_PENDING_FLUSH_PER_TURN + 4` pending ratchet writes (each exhausts
+     * the bounded budget); a first successful write must flush exactly one
+     * bounded turn (MAX_PENDING_FLUSH_PER_TURN entries), leaving the rest
+     * pending; a later successful write (the next bounded turn) flushes the
+     * remainder. All ordering is via the counting DAO + DirectExecutorService —
+     * no sleeps.
+     */
+    @Test
+    fun `ratchet retry exhaustion reconciles a bounded number per successful write and leaves the backlog for later turns`() {
+        val n = MAX_PENDING_FLUSH_PER_TURN
+        val pendingKeyCount = n + 4
+        // Each seeded write exhausts the bounded lock budget: 3 attempts per
+        // write (MAX_LOCK_ATTEMPTS).
+        val seedLockCalls = pendingKeyCount * 3
+        // After seeding, commits: trigger1(1) + n flushed + remaining 4 + trigger2(1).
+        val commitBudget = n + 1 + 4 + 1
+
+        val dao = BoundedFlushRatchetDao(
+            lockCalls = seedLockCalls,
+            commitBudget = commitBudget,
+            lock = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        )
+        val store = RoomIdentityStore(NoopKnownDestinationDao(), dao, DirectExecutorService())
+
+        // Seed: pendingKeyCount ratchet writes, each exhausting the bounded
+        // budget -> all go PENDING, none durable yet.
+        for (i in 1..pendingKeyCount) {
+            store.upsertRatchet(byteArrayOf(i.toByte()), byteArrayOf(i.toByte()), timestampMs = i.toLong())
+        }
+        assertEquals(pendingKeyCount * 3, dao.upsertCount)
+        for (i in 1..pendingKeyCount) {
+            assertNull(store.getRatchet(byteArrayOf(i.toByte())))
+        }
+
+        // First successful write: it must reconcile only ONE bounded turn (n
+        // entries), leaving the rest pending. Pre-fix the flush drains the whole
+        // backlog, so upsertCount is higher and the leftover keys are already
+        // present (red).
+        store.upsertRatchet(byteArrayOf(99), byteArrayOf(9, 9), timestampMs = 99L)
+        assertEquals(seedLockCalls + n + 1, dao.upsertCount)
+        for (i in 1..n) {
+            assertNotNull(store.getRatchet(byteArrayOf(i.toByte())))
+        }
+        for (i in (n + 1)..pendingKeyCount) {
+            assertNull(store.getRatchet(byteArrayOf(i.toByte())))
+        }
+
+        // A later successful write (the next bounded turn) reconciles the
+        // remaining backlog.
+        store.upsertRatchet(byteArrayOf(100), byteArrayOf(8, 8), timestampMs = 100L)
+        assertEquals(seedLockCalls + n + 1 + 4 + 1, dao.upsertCount)
+        for (i in (n + 1)..pendingKeyCount) {
+            assertNotNull(store.getRatchet(byteArrayOf(i.toByte())))
+        }
+    }
+
     private fun sampleIdentityData() = IdentityData(
         timestamp = 1L,
         packetHash = byteArrayOf(2, 3),
@@ -255,6 +355,63 @@ class RoomIdentityStoreTest {
 
         override fun getByHash(destHash: ByteArray): IdentityRatchetEntity? =
             committed.firstOrNull { it.destHash.contentEquals(destHash) }
+
+        override fun deleteExpiredBefore(thresholdMs: Long) = Unit
+    }
+
+    /**
+     * Mirrors Room @Upsert semantics for the identity_ratchets table: dest_hash
+     * is the primary key, so a later upsert for a key overwrites the earlier
+     * one (last write wins). Used by the same-dest_hash latest-write-wins
+     * regression — unlike [LockThenCommitRatchetDao], which reads firstOrNull
+     * and would mask the stale-replay hazard.
+     */
+    private class SameKeyLockThenCommitRatchetDao(
+        private val lockCalls: Int,
+        private val lock: Exception,
+    ) : IdentityRatchetDao {
+        var upsertCount = 0
+        private val committed = mutableMapOf<ByteArrayKey, IdentityRatchetEntity>()
+
+        override fun upsert(entity: IdentityRatchetEntity) {
+            upsertCount++
+            if (upsertCount <= lockCalls) throw lock
+            committed[entity.destHash.toKey()] = entity
+        }
+
+        override fun getByHash(destHash: ByteArray): IdentityRatchetEntity? =
+            committed[destHash.toKey()]
+
+        override fun deleteExpiredBefore(thresholdMs: Long) = Unit
+    }
+
+    /**
+     * Counting DAO for the bounded-reconciliation regression. The first
+     * `lockCalls` upserts throw the SQLite lock (used to seed the pending
+     * backlog), then the next `commitBudget` upserts commit (last write wins
+     * per key), and any further upsert throws the lock again (so a flush turn
+     * that overruns the bounded budget would be observable via upsertCount).
+     */
+    private class BoundedFlushRatchetDao(
+        private val lockCalls: Int,
+        private val commitBudget: Int,
+        private val lock: Exception,
+    ) : IdentityRatchetDao {
+        var upsertCount = 0
+        private val committed = mutableMapOf<ByteArrayKey, IdentityRatchetEntity>()
+
+        override fun upsert(entity: IdentityRatchetEntity) {
+            upsertCount++
+            if (upsertCount <= lockCalls) throw lock
+            if (upsertCount <= lockCalls + commitBudget) {
+                committed[entity.destHash.toKey()] = entity
+            } else {
+                throw lock
+            }
+        }
+
+        override fun getByHash(destHash: ByteArray): IdentityRatchetEntity? =
+            committed[destHash.toKey()]
 
         override fun deleteExpiredBefore(thresholdMs: Long) = Unit
     }

--- a/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
+++ b/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
@@ -61,6 +61,31 @@ class RoomIdentityStoreTest {
         assertEquals(1, dao.upsertCount)
     }
 
+    /**
+     * Follow-up green test: the policy swallows exactly one write (the
+     * transient SQLITE_BUSY lock) without degrading the write path. The DAO
+     * fails its FIRST upsert with the real SQLiteDatabaseLockedException and
+     * succeeds on the second; both calls must reach the DAO and no exception
+     * may escape. This guards against a "fix" that works by broadly swallowing
+     * arbitrary production exceptions or by permanently dropping the path.
+     */
+    @Test
+    fun `upsertKnownDestination still lands the next write after one swallowed SQLITE_BUSY lock`() {
+        val dao = FailFirstKnownDestinationDao(
+            firstCallFailure = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        )
+        val store = RoomIdentityStore(dao, NoopIdentityRatchetDao(), DirectExecutorService())
+
+        // First write: transient lock — swallowed by submitWriteThrough's
+        // SQLException branch; must not escape.
+        store.upsertKnownDestination(byteArrayOf(1), sampleIdentityData())
+        // Second write: must still reach the DAO and succeed.
+        store.upsertKnownDestination(byteArrayOf(1), sampleIdentityData())
+
+        // Both attempts reached the DAO; the second landed.
+        assertEquals(2, dao.upsertCount)
+    }
+
     private fun sampleIdentityData() = IdentityData(
         timestamp = 1L,
         packetHash = byteArrayOf(2, 3),
@@ -81,6 +106,21 @@ class RoomIdentityStoreTest {
         override fun upsert(entity: KnownDestinationEntity) {
             upsertCount++
             failure?.let { throw it }
+        }
+
+        override fun getByHash(destHash: ByteArray): KnownDestinationEntity? = null
+        override fun getAll(): List<KnownDestinationEntity> = emptyList()
+        override fun count(): Int = 0
+    }
+
+    private class FailFirstKnownDestinationDao(
+        private val firstCallFailure: Exception,
+    ) : KnownDestinationDao {
+        var upsertCount = 0
+
+        override fun upsert(entity: KnownDestinationEntity) {
+            upsertCount++
+            if (upsertCount == 1) throw firstCallFailure
         }
 
         override fun getByHash(destHash: ByteArray): KnownDestinationEntity? = null

--- a/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
+++ b/rns-android/src/test/kotlin/network/reticulum/android/db/store/RoomIdentityStoreTest.kt
@@ -6,7 +6,9 @@ import network.reticulum.android.db.dao.KnownDestinationDao
 import network.reticulum.android.db.entity.IdentityRatchetEntity
 import network.reticulum.android.db.entity.KnownDestinationEntity
 import network.reticulum.identity.Identity.IdentityData
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -30,13 +32,21 @@ import org.robolectric.annotation.Config
  * A live SQLITE_BUSY can't be reproduced deterministically through a real
  * Robolectric Room DB (host JDBC SQLite no-ops writes after `close()` instead
  * of throwing — see [RoomAnnounceStoreTest]), so the test injects the real
- * `SQLiteDatabaseLockedException` through a fake [KnownDestinationDao] and runs
- * the production write lambda inline on the test thread via
- * [DirectExecutorService]. The store method, the executor, and the lambda are
- * all production code; only the DAO is a fake that raises the exact real
- * exception type. Pre-fix the exception escapes the `writeExecutor.execute`
- * lambda and the test fails; post-fix [submitWriteThrough] swallows it (its
- * `SQLException` branch covers `SQLiteDatabaseLockedException` by inheritance).
+ * `SQLiteDatabaseLockedException` through a fake DAO and runs the production
+ * write lambda inline on the test thread via [DirectExecutorService]. The
+ * store method, the executor, and the lambda are all production code; only
+ * the DAO is a fake that raises the exact real exception type. Pre-fix the
+ * exception escapes the `writeExecutor.execute` lambda and the test fails;
+ * post-fix [submitWriteThrough] swallows it (its `SQLException` branch covers
+ * `SQLiteDatabaseLockedException` by inheritance).
+ *
+ * The identity/ratchet state written by this store is security-relevant and is
+ * NOT reconstructable from the live network (unlike the announce/path/
+ * packet-hash caches), so its writes route through
+ * [submitWriteThroughDurable]: a transient SQLite lock is retried a bounded
+ * number of times so a momentary lock cannot silently discard the durable
+ * write. The D4 crash-escape guarantee is preserved — the lock still never
+ * escapes the write thread.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28])
@@ -52,37 +62,72 @@ class RoomIdentityStoreTest {
         // Pre-fix: upsertKnownDestination bypasses submitWriteThrough, so this
         // SQLiteDatabaseLockedException escapes the writeExecutor.execute lambda
         // and, on the NativeReticulumDB-write thread, reaches the uncaught handler
-        // — fatal (COLUMBA-D4). Post-fix: submitWriteThrough's SQLException branch
-        // swallows it.
+        // — fatal (COLUMBA-D4). Post-fix: submitWriteThroughDurable retries the
+        // transient lock a bounded number of times, then drops it — it never
+        // escapes the write thread.
         store.upsertKnownDestination(byteArrayOf(1), sampleIdentityData())
 
         // Reaching here means the exception did not escape; the write was
-        // attempted once then dropped.
-        assertEquals(1, dao.upsertCount)
+        // attempted the bounded retry budget times (1 + retries = 3), then
+        // dropped. Every attempt reached the DAO before the drop.
+        assertEquals(3, dao.upsertCount)
     }
 
     /**
-     * Follow-up green test: the policy swallows exactly one write (the
-     * transient SQLITE_BUSY lock) without degrading the write path. The DAO
+     * Follow-up test: the policy retries a transient SQLITE_BUSY lock and the
+     * write still lands durably without degrading the write path. The DAO
      * fails its FIRST upsert with the real SQLiteDatabaseLockedException and
-     * succeeds on the second; both calls must reach the DAO and no exception
-     * may escape. This guards against a "fix" that works by broadly swallowing
-     * arbitrary production exceptions or by permanently dropping the path.
+     * succeeds on the second; the single write must be retried and committed
+     * and no exception may escape. This guards against a "fix" that works by
+     * broadly swallowing arbitrary production exceptions or by permanently
+     * dropping the security-relevant path.
      */
     @Test
-    fun `upsertKnownDestination still lands the next write after one swallowed SQLITE_BUSY lock`() {
+    fun `upsertKnownDestination retries one SQLITE_BUSY lock and durably commits the identity write`() {
         val dao = FailFirstKnownDestinationDao(
             firstCallFailure = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
         )
         val store = RoomIdentityStore(dao, NoopIdentityRatchetDao(), DirectExecutorService())
 
-        // First write: transient lock — swallowed by submitWriteThrough's
-        // SQLException branch; must not escape.
+        // First write: transient lock — retried by submitWriteThroughDurable,
+        // must not escape and must still land durably.
         store.upsertKnownDestination(byteArrayOf(1), sampleIdentityData())
         // Second write: must still reach the DAO and succeed.
         store.upsertKnownDestination(byteArrayOf(1), sampleIdentityData())
 
-        // Both attempts reached the DAO; the second landed.
+        // Under the durable contract the FIRST write is retried and committed
+        // (attempt 1 locked, attempt 2 committed), then the second write lands:
+        // 3 upsert calls total. No exception escaped.
+        assertEquals(3, dao.upsertCount)
+    }
+
+    /**
+     * New durability regression (Greptile P1): a security-relevant RATCHET
+     * upsert that hits one transient SQLiteDatabaseLockedException must end
+     * with the durable ratchet state PRESENT — the single write itself is
+     * retried and committed, not merely "the next independent write lands".
+     * Before the durable correction, submitWriteThrough dropped the write on
+     * the lock and the ratchet existed only in memory: restarting would
+     * restore stale/missing ratchet state until the peer re-announced.
+     */
+    @Test
+    fun `upsertRatchet retries one transient SQLite lock and the durable ratchet state is present`() {
+        val dao = FailOnceThenCommitRatchetDao(
+            firstCallFailure = SQLiteDatabaseLockedException("database is locked (code 5 SQLITE_BUSY)")
+        )
+        val store = RoomIdentityStore(NoopKnownDestinationDao(), dao, DirectExecutorService())
+
+        // The security-relevant ratchet write must NOT be silently discarded on
+        // a transient lock: after one SQLiteDatabaseLockedException the durable
+        // ratchet state must be present (the write is retried and committed).
+        store.upsertRatchet(byteArrayOf(1), byteArrayOf(7, 8, 9), timestampMs = 42L)
+
+        val committed = dao.committed
+        assertNotNull(committed)
+        assertArrayEquals(byteArrayOf(1), committed!!.destHash)
+        assertArrayEquals(byteArrayOf(7, 8, 9), committed.ratchet)
+        assertEquals(42L, committed.timestamp)
+        // First attempt locked, retried and committed.
         assertEquals(2, dao.upsertCount)
     }
 
@@ -123,6 +168,31 @@ class RoomIdentityStoreTest {
             if (upsertCount == 1) throw firstCallFailure
         }
 
+        override fun getByHash(destHash: ByteArray): KnownDestinationEntity? = null
+        override fun getAll(): List<KnownDestinationEntity> = emptyList()
+        override fun count(): Int = 0
+    }
+
+    private class FailOnceThenCommitRatchetDao(
+        private val firstCallFailure: Exception,
+    ) : IdentityRatchetDao {
+        var upsertCount = 0
+        var committed: IdentityRatchetEntity? = null
+
+        override fun upsert(entity: IdentityRatchetEntity) {
+            upsertCount++
+            if (upsertCount == 1) throw firstCallFailure
+            committed = entity
+        }
+
+        override fun getByHash(destHash: ByteArray): IdentityRatchetEntity? =
+            committed?.takeIf { it.destHash.contentEquals(destHash) }
+
+        override fun deleteExpiredBefore(thresholdMs: Long) = Unit
+    }
+
+    private class NoopKnownDestinationDao : KnownDestinationDao {
+        override fun upsert(entity: KnownDestinationEntity) = Unit
         override fun getByHash(destHash: ByteArray): KnownDestinationEntity? = null
         override fun getAll(): List<KnownDestinationEntity> = emptyList()
         override fun count(): Int = 0


### PR DESCRIPTION
## Summary

Fix a production `SQLITE_BUSY` crash in the Android identity store.

The Room-backed identity store issued its write-through database operations
directly on the executor, bypassing the existing transient-lock retry
policy used elsewhere. Under concurrent access this allowed
`android.database.sqlite.SQLiteDatabaseLockedException`
(SQLITE_BUSY) to escape the production write path and crash the process.

## Change

- Route the three identity write operations (`upsertKnownDestination`,
  `upsertRatchet`, `removeExpiredRatchets`) through the store's existing
  `submitWriteThrough` path, which already applies the established
  transient-SQLite-lock retry policy.
- Add a deterministic regression test that injects a real
  `SQLiteDatabaseLockedException` on the first DAO upsert and asserts the
  second write succeeds with no exception escaping the production path.

No other production files are touched; no existing catch blocks were
broadened.

## Test plan

- Focused `RoomIdentityStoreTest`: 2/2 pass (regression + existing)
- All Room store tests: 14/14 pass
- Full `rns-android` unit module: 44/44 pass

## Follow-up (out of scope for this PR)

Three other stores still bypass the write-through policy with raw executor
calls. They are tracked separately and intentionally not expanded into
this change:

- `RoomDestinationRatchetStore.kt`
- `RoomDiscoveryStore.kt`
- `RoomTunnelStore.kt`
